### PR TITLE
Fix: Adjust version comparison logic to handle "v" prefix

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,9 +30,17 @@ jobs:
           echo "current: ${{ env.CURRENT_API_VERSION }}"
           echo "New: ${{ env.NEW_API_VERSION }}"
 
-          if [ "${{ env.NEW_API_VERSION }}" != "${{ env.CURRENT_API_VERSION }}" ] && [[ "${{ env.NEW_API_VERSION }}" = v* ]]; then
-            echo "generate new client"
-            echo "RESULT=true" >> $GITHUB_OUTPUT
+          if [[ "${{ env.NEW_API_VERSION }}" != "${{ env.CURRENT_API_VERSION }}" ]]; then
+            if [[ "${{ env.NEW_API_VERSION }}" = v* ]] && [[ "${{ env.CURRENT_API_VERSION }}" != v* ]]; then
+              echo "generate new client"
+              echo "RESULT=true" >> $GITHUB_OUTPUT
+            elif [[ "${{ env.NEW_API_VERSION }}" != v* ]] && [[ "${{ env.CURRENT_API_VERSION }}" = v* ]]; then
+              echo "generate new client"
+              echo "RESULT=true" >> $GITHUB_OUTPUT
+            else
+              echo "skip client generation"
+              echo "RESULT=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "skip client generation"
             echo "RESULT=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This commit modifies the version comparison logic in the GitHub Actions workflow to correctly handle cases where version numbers include or exclude the "v" prefix. The updated code ensures that when comparing versions like "v1.31.0" and "1.33.0", the check correctly detects version changes and triggers the generation of a new client.

This adjustment improves the reliability of the workflow and ensures consistency in version comparison.