### PR TITLE
GitHub Actions Fix URL and Version Prefix in Generate Client Workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -53,30 +53,24 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v3
-      - name: "URL Check"
-        id: url-check
+      - name: "Check Version Prefix"
+        id: version-prefix
         run: |
-          if [[ $(wget --spider --server-response "https://github.com/meraki/openapi/archive/refs/tags/${{ needs.check-for-updates.outputs.new }}.zip" 2>&1 | grep 'HTTP/1.1 200 OK') ]]; then
-            echo "URL Check: Passed"
-            echo "::set-output name=url_check::true"
+          if [[ "${{ needs.check-for-updates.outputs.new }}" != v* ]]; then
+            echo "NEW_VERSION=v${{ needs.check-for-updates.outputs.new }}" >> $GITHUB_ENV
           else
-            echo "URL Check: Failed"
-            echo "::set-output name=url_check::false"
+            echo "NEW_VERSION=${{ needs.check-for-updates.outputs.new }}" >> $GITHUB_ENV
           fi
-      - name: "Update Version"
-        if: steps.url-check.outputs.url_check == 'false' && startsWith(needs.check-for-updates.outputs.new, 'v') == false
-        run: |
-          echo "NEW_API_VERSION=v${{ needs.check-for-updates.outputs.new }}" >> $GITHUB_ENV
       - name: "Fetch Specification"
-        run: wget https://github.com/meraki/openapi/archive/refs/tags/${{ needs.check-for-updates.outputs.new }}.zip && unzip -j ${{ needs.check-for-updates.outputs.new }}.zip '*/spec2.json'
+        run: wget https://github.com/meraki/openapi/archive/refs/tags/${{ env.NEW_VERSION }}.zip && unzip -j ${{ env.NEW_VERSION }}.zip '*/spec2.json'
       - name: "Install JRE"
         run: sudo apt update && sudo apt install -y default-jre
       - name: "Install OpenAPI Generator"
         run: wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.0/openapi-generator-cli-5.3.0.jar -O .openapi/generator/openapi-generator-cli.jar
       - name: "Run OpenAPI Generator"
-        run: rm -rf client/; java -jar .openapi/generator/openapi-generator-cli.jar generate -i spec2.json -g go -o client -p enumClassPrefix=true -p structPrefix=true --package-name client -p packageVersion=${{ needs.check-for-updates.outputs.new }} -t .openapi/templates --git-user-id meraki --git-repo-id dashboard-api-go/client --git-host github.com
+        run: rm -rf client/; java -jar .openapi/generator/openapi-generator-cli.jar generate -i spec2.json -g go -o client -p enumClassPrefix=true -p structPrefix=true --package-name client -p packageVersion=${{ env.NEW_VERSION }} -t .openapi/templates --git-user-id meraki --git-repo-id dashboard-api-go/client --git-host github.com
       - name: "Cleanup"
-        run: rm .openapi/generator/openapi-generator-cli.jar; rm spec2.json; rm ${{ needs.check-for-updates.outputs.new }}.zip
+        run: rm .openapi/generator/openapi-generator-cli.jar; rm spec2.json; rm ${{ env.NEW_VERSION }}.zip
       - name: "Git Config"
         run: |
           git config user.name "GitHub Actions"
@@ -84,13 +78,13 @@ jobs:
       - name: "Git Commit"
         run: |
           git add -A
-          git commit -m "OpenAPI Client Generation ${{ needs.check-for-updates.outputs.new }}"
-          git tag ${{ needs.check-for-updates.outputs.new }}
+          git commit -m "OpenAPI Client Generation ${{ env.NEW_VERSION }}"
+          git tag ${{ env.NEW_VERSION }}
           git push origin main
-          git push origin ${{ needs.check-for-updates.outputs.new }}
+          git push origin ${{ env.NEW_VERSION }}
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ needs.check-for-updates.outputs.new }}
-          name: Release ${{ needs.check-for-updates.outputs.new }}
-          body: Meraki Golang Dashboard API ${{ needs.check-for-updates.outputs.new }}
+          tag: ${{ env.NEW_VERSION }}
+          name: Release ${{ env.NEW_VERSION }}
+          body: Meraki Golang Dashboard API ${{ env.NEW_VERSION }}


### PR DESCRIPTION
This commit addresses an issue in the Generate Client workflow where an incorrect resource URL was being requested. The workflow has been updated to ensure that the URL includes the correct version, taking into account the presence or absence of the "v" prefix. Additionally, a new step has been added to check the version prefix and update it if necessary, guaranteeing that the correct version is used throughout the workflow. 

These changes improve the reliability and accuracy of the client generation process.
