### PR TITLE
## [3.0.0] - 2024-04-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2024-04-16
+- dashboard-api-go supports now v1.44.1 of Meraki Dashboard API.
+- User-agent is now required. Format of string "ApplicationName VendorName".
+
 ## [2.0.9] - 2024-03-14
 - New main branch SDK doesn't use the intended user agent string format #21
 - Incorrect links to documentation in code #23 [Removed]
@@ -1338,4 +1342,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.0.7]: https://github.com/meraki/dashboard-api-go/compare/v2.0.6...2.0.7
 [2.0.8]: https://github.com/meraki/dashboard-api-go/compare/v2.0.7...2.0.8
 [2.0.9]: https://github.com/meraki/dashboard-api-go/compare/v2.0.8...2.0.9
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v2.0.9...main
+[3.0.0]: https://github.com/meraki/dashboard-api-go/compare/v2.0.9...3.0.0
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.0...main

--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ The client could be generated with the following parameters:
 - `baseURL`: The base URL, FQDN or IP, of the MERAKI instance.
 - `dashboardApiKey`: The meraki_key for access to API.
 - `debug`: Boolean to enable debugging
-- `sslVerify`: Boolean to enable or disable SSL certificate verification.
+- `userAgent`: String, set the User-Agent Format (AplicationName VendorName).
 
 ```go
 client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
-		"MERAKI_KEY",
-		"true")
+		"MerakiKey",
+		"true", "AplicationName VendorName")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 nResponse, _, err := client.Administered.GetAdministeredIDentitiesMe()
 	if err != nil {
 		fmt.Println(err)
@@ -48,7 +52,7 @@ The client can be configured with the following environment variables:
 - `MERAKI_BASE_URL`: The base URL, FQDN or IP, of the MERAKI instance.
 - `MERAKI_DASHBOARD_API_KEY`: The meraki_key for access to API.
 - `MERAKI_DEBUG`: Boolean to enable debugging
-- `MERAKI_SSL_VERIFY`: Boolean to enable or disable SSL certificate verification.
+- `MERAKI_USER_AGENT`: String, set the User-Agent Format (AplicationName VendorName).
 
 ```go
 Client, err = meraki.NewClient()
@@ -61,8 +65,8 @@ Here is an example of how we can generate a client, get a device count and then 
 
 ```go
 client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
-		"Meraki_key",
-		"true")
+		"MerakiKey",
+		"true", "AplicationName VendorName")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -89,6 +93,7 @@ client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 | SDK versions | MERAKI Dashboard version supported |
 |--------------|------------------------------------|
 | 2.y.z        |  1.33.0                            |
+| 3.y.z        |  1.44.1                            |
 
 
 ## Changelog

--- a/examples/administered/main.go
+++ b/examples/administered/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v2/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
 )
 
 // Client is DNA Center API client
@@ -14,7 +14,7 @@ func main() {
 	fmt.Println("Authenticating")
 	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true")
+		"true", "AplicationName VendorName")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -30,14 +30,5 @@ func main() {
 		return
 	}
 
-	nResponse2, _, err := client.Administered.GetAdministeredIDentitiesMe()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	if nResponse2 != nil {
-		fmt.Println(nResponse)
-		return
-	}
 	fmt.Println("There's no data on response")
 }

--- a/examples/networks/main.go
+++ b/examples/networks/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v2/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
 )
 
 var client *meraki.Client
@@ -13,7 +13,7 @@ func main() {
 	fmt.Println("Authenticating")
 	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true")
+		"true", "AplicationName VendorName")
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/organizations/main.go
+++ b/examples/organizations/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v2/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
 )
 
 var client *meraki.Client
@@ -13,13 +13,13 @@ func main() {
 	fmt.Println("Authenticating")
 	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true")
+		"true", "AplicationName VendorName")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	nResponse, _, err := client.Organizations.GetOrganizations()
+	nResponse, _, err := client.Organizations.GetOrganizations(nil)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/testPagination/main.go
+++ b/examples/testPagination/main.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	meraki "github.com/meraki/dashboard-api-go/v2/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
 )
 
 var client *meraki.Client
@@ -22,7 +22,7 @@ func main() {
 	fmt.Println("Authenticating")
 	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"false")
+		"true", "AplicationName VendorName")
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,19 @@
-module github.com/meraki/dashboard-api-go/v2
+module github.com/meraki/dashboard-api-go/v3
 
 go 1.21.5
 
 require (
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/google/go-querystring v1.1.0
+	github.com/juju/ratelimit v1.0.2
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/h2non/gock.v1 v1.1.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
-	github.com/juju/ratelimit v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	gopkg.in/h2non/gock.v1 v1.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
 github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -58,6 +59,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
 gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=

--- a/sdk/administered.go
+++ b/sdk/administered.go
@@ -2,6 +2,7 @@ package meraki
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -42,6 +43,7 @@ type ResponseAdministeredGetAdministeredIDentitiesMeAuthenticationTwoFactor stru
 func (s *AdministeredService) GetAdministeredIDentitiesMe() (*ResponseAdministeredGetAdministeredIDentitiesMe, *resty.Response, error) {
 	path := "/api/v1/administered/identities/me"
 	s.rateLimiterBucket.Wait(1)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
@@ -55,7 +57,10 @@ func (s *AdministeredService) GetAdministeredIDentitiesMe() (*ResponseAdminister
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation GetAdministeredIdentitiesMe")
+		if response.StatusCode() == http.StatusUnauthorized {
+			return s.GetAdministeredIDentitiesMe()
+		}
+		return nil, response, fmt.Errorf("error with operation GetApplications")
 	}
 
 	result := response.Result().(*ResponseAdministeredGetAdministeredIDentitiesMe)

--- a/sdk/api_client_test.go
+++ b/sdk/api_client_test.go
@@ -25,7 +25,7 @@ type result struct{}
 
 // testClient returns a new Client for testing.
 func testClient(t *testing.T) *Client {
-	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG)
+	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound")
 	assert.Equal(t, err, nil)
 	client, err := NewClient()
 	assert.Equal(t, err, nil)
@@ -37,7 +37,7 @@ func testClient(t *testing.T) *Client {
 
 // TestSetOptions tests the Client.SetOptions method.
 func TestSetOptions(t *testing.T) {
-	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG)
+	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, os.Getenv(MERAKI_BASE_URL), TEST_MERAKI_BASE_URL)
 	assert.Equal(t, os.Getenv(MERAKI_DASHBOARD_API_KEY), TEST_MERAKI_DASHBOARD_API_KEY)
@@ -46,7 +46,7 @@ func TestSetOptions(t *testing.T) {
 
 // TestSetOptions tests the Client.SetOptionsWithRequests method.
 func TestSetOptionsWithRequests(t *testing.T) {
-	err := SetOptionsWithRequests(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, TEST_MERAKI_REQUESTS_PER_SECOND)
+	err := SetOptionsWithRequests(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound", TEST_MERAKI_REQUESTS_PER_SECOND)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, os.Getenv(MERAKI_BASE_URL), TEST_MERAKI_BASE_URL)
 	assert.Equal(t, os.Getenv(MERAKI_DASHBOARD_API_KEY), TEST_MERAKI_DASHBOARD_API_KEY)
@@ -61,7 +61,6 @@ func TestNewClient(t *testing.T) {
 	debug, _ := strconv.ParseBool(TEST_MERAKI_DEBUG)
 	assert.Equal(t, client.common.client.Debug, debug)
 	assert.Equal(t, client.common.client.Header.Get("Authorization"), fmt.Sprintf("Bearer %s", TEST_MERAKI_DASHBOARD_API_KEY))
-	assert.Equal(t, client.common.client.Header.Get("User-Agent"), DEFAULT_USER_AGENT)
 }
 
 // TestNewClientWithOptions tests the Client.NewClientWithOptions method.
@@ -69,7 +68,7 @@ func TestNewClientWithOptions(t *testing.T) {
 	url := "url"
 	key := "key"
 	debug := false
-	client, err := NewClientWithOptions(url, key, strconv.FormatBool(debug))
+	client, err := NewClientWithOptions(url, key, strconv.FormatBool(debug), "Test Cloverhound")
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, client, nil)
 	assert.Equal(t, client.common.client.HostURL, url)
@@ -83,7 +82,7 @@ func TestNewClientWithOptionsAndRequests(t *testing.T) {
 	key := "key"
 	debug := false
 	requests := 6
-	client, err := NewClientWithOptionsAndRequests(url, key, strconv.FormatBool(debug), requests)
+	client, err := NewClientWithOptionsAndRequests(url, key, strconv.FormatBool(debug), "Test Cloverhound", requests)
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, client, nil)
 	assert.Equal(t, client.common.client.HostURL, url)
@@ -99,14 +98,6 @@ func TestSetAuthToken(t *testing.T) {
 	client := testClient(t)
 	client.SetAuthToken(newToken)
 	assert.Equal(t, client.common.client.Header.Get("Authorization"), fmt.Sprintf("Bearer %s", newToken))
-}
-
-// TestSetUserAgent tests the Client.SetUserAgent method.
-func TestSetUserAgent(t *testing.T) {
-	newUserAgent := "user2"
-	client := testClient(t)
-	client.SetUserAgent(newUserAgent)
-	assert.Equal(t, client.common.client.Header.Get("User-Agent"), newUserAgent)
 }
 
 // TestSetRequestsPerSecond tests the Client.SetRequestsPerSecond method.

--- a/sdk/appliance.go
+++ b/sdk/appliance.go
@@ -3,7 +3,6 @@ package meraki
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/go-resty/resty/v2"
@@ -45,6 +44,12 @@ type GetOrganizationApplianceSecurityEventsQueryParams struct {
 	EndingBefore  string  `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	SortOrder     string  `url:"sortOrder,omitempty"`     //Sorted order of security events based on event detection time. Order options are 'ascending' or 'descending'. Default is ascending order.
 }
+type GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 50.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter the results by network IDs
+}
 type GetOrganizationApplianceUplinkStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -52,6 +57,11 @@ type GetOrganizationApplianceUplinkStatusesQueryParams struct {
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //A list of network IDs. The returned devices will be filtered to only include these networks.
 	Serials       []string `url:"serials[],omitempty"`     //A list of serial numbers. The returned devices will be filtered to only include these serials.
 	Iccids        []string `url:"iccids[],omitempty"`      //A list of ICCIDs. The returned devices will be filtered to only include these ICCIDs.
+}
+type GetOrganizationApplianceUplinksUsageByNetworkQueryParams struct {
+	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data. The maximum lookback period is 365 days from today.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 14 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 14 days. The default is 1 day.
 }
 type GetOrganizationApplianceVpnStatsQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 300. Default is 300.
@@ -122,6 +132,36 @@ type ResponseItemApplianceGetDeviceAppliancePrefixesDelegatedVLANAssignmentsOrig
 type ResponseItemApplianceGetDeviceAppliancePrefixesDelegatedVLANAssignmentsVLAN struct {
 	ID   *int   `json:"id,omitempty"`   //
 	Name string `json:"name,omitempty"` //
+}
+type ResponseApplianceGetDeviceApplianceRadioSettings struct {
+	FiveGhzSettings    *ResponseApplianceGetDeviceApplianceRadioSettingsFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Manual radio settings for 5 GHz
+	RfProfileID        string                                                              `json:"rfProfileId,omitempty"`        // RF Profile ID
+	Serial             string                                                              `json:"serial,omitempty"`             // The device serial
+	TwoFourGhzSettings *ResponseApplianceGetDeviceApplianceRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Manual radio settings for 2.4 GHz
+}
+type ResponseApplianceGetDeviceApplianceRadioSettingsFiveGhzSettings struct {
+	Channel      *int `json:"channel,omitempty"`      // Manual channel for 5 GHz
+	ChannelWidth *int `json:"channelWidth,omitempty"` // Manual channel width for 5 GHz
+	TargetPower  *int `json:"targetPower,omitempty"`  // Manual target power for 5 GHz
+}
+type ResponseApplianceGetDeviceApplianceRadioSettingsTwoFourGhzSettings struct {
+	Channel     *int `json:"channel,omitempty"`     // Manual channel for 2.4 GHz
+	TargetPower *int `json:"targetPower,omitempty"` // Manual target power for 2.4 GHz
+}
+type ResponseApplianceUpdateDeviceApplianceRadioSettings struct {
+	FiveGhzSettings    *ResponseApplianceUpdateDeviceApplianceRadioSettingsFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Manual radio settings for 5 GHz
+	RfProfileID        string                                                                 `json:"rfProfileId,omitempty"`        // RF Profile ID
+	Serial             string                                                                 `json:"serial,omitempty"`             // The device serial
+	TwoFourGhzSettings *ResponseApplianceUpdateDeviceApplianceRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Manual radio settings for 2.4 GHz
+}
+type ResponseApplianceUpdateDeviceApplianceRadioSettingsFiveGhzSettings struct {
+	Channel      *int `json:"channel,omitempty"`      // Manual channel for 5 GHz
+	ChannelWidth *int `json:"channelWidth,omitempty"` // Manual channel width for 5 GHz
+	TargetPower  *int `json:"targetPower,omitempty"`  // Manual target power for 5 GHz
+}
+type ResponseApplianceUpdateDeviceApplianceRadioSettingsTwoFourGhzSettings struct {
+	Channel     *int `json:"channel,omitempty"`     // Manual channel for 2.4 GHz
+	TargetPower *int `json:"targetPower,omitempty"` // Manual target power for 2.4 GHz
 }
 type ResponseApplianceGetDeviceApplianceUplinksSettings struct {
 	Interfaces *ResponseApplianceGetDeviceApplianceUplinksSettingsInterfaces `json:"interfaces,omitempty"` // Interface settings.
@@ -363,16 +403,20 @@ type ResponseApplianceGetNetworkApplianceFirewallCellularFirewallRulesRules stru
 type ResponseApplianceUpdateNetworkApplianceFirewallCellularFirewallRules interface{}
 type ResponseApplianceGetNetworkApplianceFirewallFirewalledServices []ResponseItemApplianceGetNetworkApplianceFirewallFirewalledServices // Array of ResponseApplianceGetNetworkApplianceFirewallFirewalledServices
 type ResponseItemApplianceGetNetworkApplianceFirewallFirewalledServices struct {
-	Access     string   `json:"access,omitempty"`     //
-	AllowedIPs []string `json:"allowedIps,omitempty"` //
-	Service    string   `json:"service,omitempty"`    //
+	Access     string   `json:"access,omitempty"`     // A string indicating the rule for which IPs are allowed to use the specified service
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of allowed IPs that can access the service
+	Service    string   `json:"service,omitempty"`    // Appliance service name
 }
 type ResponseApplianceGetNetworkApplianceFirewallFirewalledService struct {
-	Access     string   `json:"access,omitempty"`     //
-	AllowedIPs []string `json:"allowedIps,omitempty"` //
-	Service    string   `json:"service,omitempty"`    //
+	Access     string   `json:"access,omitempty"`     // A string indicating the rule for which IPs are allowed to use the specified service
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of allowed IPs that can access the service
+	Service    string   `json:"service,omitempty"`    // Appliance service name
 }
-type ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService interface{}
+type ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService struct {
+	Access     string   `json:"access,omitempty"`     // A string indicating the rule for which IPs are allowed to use the specified service
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of allowed IPs that can access the service
+	Service    string   `json:"service,omitempty"`    // Appliance service name
+}
 type ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules []ResponseItemApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules // Array of ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules
 type ResponseItemApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules struct {
 	Comment       string `json:"comment,omitempty"`       //
@@ -387,20 +431,33 @@ type ResponseItemApplianceGetNetworkApplianceFirewallInboundCellularFirewallRule
 type ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules []ResponseItemApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules // Array of ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules
 type ResponseItemApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules interface{}
 type ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRules struct {
-	Rules             *[]ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRulesRules `json:"rules,omitempty"`             //
-	SyslogDefaultRule *bool                                                                    `json:"syslogDefaultRule,omitempty"` //
+	Rules             *[]ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRulesRules `json:"rules,omitempty"`             // An ordered array of the firewall rules (not including the default rule)
+	SyslogDefaultRule *bool                                                                    `json:"syslogDefaultRule,omitempty"` // Log the special default rule (boolean value - enable only if you've configured a syslog server) (optional)
 }
 type ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRulesRules struct {
-	Comment       string `json:"comment,omitempty"`       //
-	DestCidr      string `json:"destCidr,omitempty"`      //
-	DestPort      string `json:"destPort,omitempty"`      //
-	Policy        string `json:"policy,omitempty"`        //
-	Protocol      string `json:"protocol,omitempty"`      //
-	SrcCidr       string `json:"srcCidr,omitempty"`       //
-	SrcPort       string `json:"srcPort,omitempty"`       //
-	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` //
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
 }
-type ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRules interface{}
+type ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRules struct {
+	Rules             *[]ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRulesRules `json:"rules,omitempty"`             // An ordered array of the firewall rules (not including the default rule)
+	SyslogDefaultRule *bool                                                                       `json:"syslogDefaultRule,omitempty"` // Log the special default rule (boolean value - enable only if you've configured a syslog server) (optional)
+}
+type ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRulesRules struct {
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
+}
 type ResponseApplianceGetNetworkApplianceFirewallL3FirewallRules struct {
 	Rules *[]ResponseApplianceGetNetworkApplianceFirewallL3FirewallRulesRules `json:"rules,omitempty"` //
 }
@@ -462,16 +519,16 @@ func (r *ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesRules) Unmar
 
 type ResponseApplianceUpdateNetworkApplianceFirewallL7FirewallRules interface{}
 type ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategories struct {
-	ApplicationCategories *[]ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategories `json:"applicationCategories,omitempty"` //
+	ApplicationCategories *[]ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategories `json:"applicationCategories,omitempty"` //  The L7 firewall application categories and their associated applications for an MX network
 }
 type ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategories struct {
-	Applications *[]ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategoriesApplications `json:"applications,omitempty"` //
-	ID           string                                                                                                               `json:"id,omitempty"`           //
-	Name         string                                                                                                               `json:"name,omitempty"`         //
+	Applications *[]ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategoriesApplications `json:"applications,omitempty"` // Details of the associated applications
+	ID           string                                                                                                               `json:"id,omitempty"`           // The id of the category
+	Name         string                                                                                                               `json:"name,omitempty"`         // The name of the category
 }
 type ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategoriesApplicationCategoriesApplications struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The id of the application
+	Name string `json:"name,omitempty"` // The name of the application
 }
 type ResponseApplianceGetNetworkApplianceFirewallOneToManyNatRules struct {
 	Rules *[]ResponseApplianceGetNetworkApplianceFirewallOneToManyNatRulesRules `json:"rules,omitempty"` //
@@ -584,6 +641,161 @@ type ResponseApplianceGetNetworkAppliancePrefixesDelegatedStaticOrigin struct {
 	Type       string   `json:"type,omitempty"`       // Origin type
 }
 type ResponseApplianceUpdateNetworkAppliancePrefixesDelegatedStatic interface{}
+type ResponseApplianceGetNetworkApplianceRfProfiles struct {
+	Assigned *[]ResponseApplianceGetNetworkApplianceRfProfilesAssigned `json:"assigned,omitempty"` // RF Profiles
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssigned struct {
+	FiveGhzSettings    *ResponseApplianceGetNetworkApplianceRfProfilesAssignedFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band.
+	ID                 string                                                                    `json:"id,omitempty"`                 // ID of the RF Profile.
+	Name               string                                                                    `json:"name,omitempty"`               // The name of the profile.
+	NetworkID          string                                                                    `json:"networkId,omitempty"`          // ID of network this RF Profile belongs in.
+	PerSSIDSettings    *ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *ResponseApplianceGetNetworkApplianceRfProfilesAssignedTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Whether ax radio on 5Ghz band is on or off.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings struct {
+	Status1 *ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1.
+	Status2 *ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2.
+	Status3 *ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3.
+	Status4 *ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedPerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilesAssignedTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Whether ax radio on 2.4Ghz band is on or off.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfile struct {
+	FiveGhzSettings    *ResponseApplianceCreateNetworkApplianceRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band.
+	ID                 string                                                              `json:"id,omitempty"`                 // ID of the RF Profile.
+	Name               string                                                              `json:"name,omitempty"`               // The name of the profile.
+	NetworkID          string                                                              `json:"networkId,omitempty"`          // ID of network this RF Profile belongs in.
+	PerSSIDSettings    *ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *ResponseApplianceCreateNetworkApplianceRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfileFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Whether ax radio on 5Ghz band is on or off.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings struct {
+	Status1 *ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1.
+	Status2 *ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2.
+	Status3 *ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3.
+	Status4 *ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfilePerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceCreateNetworkApplianceRfProfileTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Whether ax radio on 2.4Ghz band is on or off.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceGetNetworkApplianceRfProfile struct {
+	FiveGhzSettings    *ResponseApplianceGetNetworkApplianceRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band.
+	ID                 string                                                           `json:"id,omitempty"`                 // ID of the RF Profile.
+	Name               string                                                           `json:"name,omitempty"`               // The name of the profile.
+	NetworkID          string                                                           `json:"networkId,omitempty"`          // ID of network this RF Profile belongs in.
+	PerSSIDSettings    *ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *ResponseApplianceGetNetworkApplianceRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band.
+}
+type ResponseApplianceGetNetworkApplianceRfProfileFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Whether ax radio on 5Ghz band is on or off.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings struct {
+	Status1 *ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1.
+	Status2 *ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2.
+	Status3 *ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3.
+	Status4 *ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfilePerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceGetNetworkApplianceRfProfileTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Whether ax radio on 2.4Ghz band is on or off.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfile struct {
+	FiveGhzSettings    *ResponseApplianceUpdateNetworkApplianceRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band.
+	ID                 string                                                              `json:"id,omitempty"`                 // ID of the RF Profile.
+	Name               string                                                              `json:"name,omitempty"`               // The name of the profile.
+	NetworkID          string                                                              `json:"networkId,omitempty"`          // ID of network this RF Profile belongs in.
+	PerSSIDSettings    *ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *ResponseApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfileFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Whether ax radio on 5Ghz band is on or off.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings struct {
+	Status1 *ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1.
+	Status2 *ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2.
+	Status3 *ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3.
+	Status4 *ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Band mode of this SSID
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Whether this SSID steers clients to the most open band between 2.4 GHz and 5 GHz.
+}
+type ResponseApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Whether ax radio on 2.4Ghz band is on or off.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
+}
 type ResponseApplianceGetNetworkApplianceSecurityEvents []ResponseItemApplianceGetNetworkApplianceSecurityEvents // Array of ResponseApplianceGetNetworkApplianceSecurityEvents
 type ResponseItemApplianceGetNetworkApplianceSecurityEvents struct {
 	Action          string `json:"action,omitempty"`          //
@@ -604,30 +816,51 @@ type ResponseItemApplianceGetNetworkApplianceSecurityEvents struct {
 	URI             string `json:"uri,omitempty"`             //
 }
 type ResponseApplianceGetNetworkApplianceSecurityIntrusion struct {
-	IDsRulesets       string                                                                  `json:"idsRulesets,omitempty"`       //
-	Mode              string                                                                  `json:"mode,omitempty"`              //
-	ProtectedNetworks *ResponseApplianceGetNetworkApplianceSecurityIntrusionProtectedNetworks `json:"protectedNetworks,omitempty"` //
+	IDsRulesets       string                                                                  `json:"idsRulesets,omitempty"`       // Intrusion detection ruleset
+	Mode              string                                                                  `json:"mode,omitempty"`              // Intrusion detection mode
+	ProtectedNetworks *ResponseApplianceGetNetworkApplianceSecurityIntrusionProtectedNetworks `json:"protectedNetworks,omitempty"` // Networks included in and excluded from the detection engine
 }
 type ResponseApplianceGetNetworkApplianceSecurityIntrusionProtectedNetworks struct {
-	ExcludedCidr []string `json:"excludedCidr,omitempty"` //
-	IncludedCidr []string `json:"includedCidr,omitempty"` //
-	UseDefault   *bool    `json:"useDefault,omitempty"`   //
+	ExcludedCidr []string `json:"excludedCidr,omitempty"` // List of IP addresses or subnets being excluded from protection
+	IncludedCidr []string `json:"includedCidr,omitempty"` // List of IP addresses or subnets being protected
+	UseDefault   *bool    `json:"useDefault,omitempty"`   // Whether special IPv4 addresses should be used (see: https://tools.ietf.org/html/rfc5735)
 }
-type ResponseApplianceUpdateNetworkApplianceSecurityIntrusion interface{}
+type ResponseApplianceUpdateNetworkApplianceSecurityIntrusion struct {
+	IDsRulesets       string                                                                     `json:"idsRulesets,omitempty"`       // Intrusion detection ruleset
+	Mode              string                                                                     `json:"mode,omitempty"`              // Intrusion detection mode
+	ProtectedNetworks *ResponseApplianceUpdateNetworkApplianceSecurityIntrusionProtectedNetworks `json:"protectedNetworks,omitempty"` // Networks included in and excluded from the detection engine
+}
+type ResponseApplianceUpdateNetworkApplianceSecurityIntrusionProtectedNetworks struct {
+	ExcludedCidr []string `json:"excludedCidr,omitempty"` // List of IP addresses or subnets being excluded from protection
+	IncludedCidr []string `json:"includedCidr,omitempty"` // List of IP addresses or subnets being protected
+	UseDefault   *bool    `json:"useDefault,omitempty"`   // Whether special IPv4 addresses should be used (see: https://tools.ietf.org/html/rfc5735)
+}
 type ResponseApplianceGetNetworkApplianceSecurityMalware struct {
-	AllowedFiles *[]ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedFiles `json:"allowedFiles,omitempty"` //
-	AllowedURLs  *[]ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedURLs  `json:"allowedUrls,omitempty"`  //
-	Mode         string                                                             `json:"mode,omitempty"`         //
+	AllowedFiles *[]ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedFiles `json:"allowedFiles,omitempty"` // Sha256 digests of files permitted by the malware detection engine
+	AllowedURLs  *[]ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedURLs  `json:"allowedUrls,omitempty"`  // URLs permitted by the malware detection engine
+	Mode         string                                                             `json:"mode,omitempty"`         // Current status of malware prevention
 }
 type ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedFiles struct {
-	Comment string `json:"comment,omitempty"` //
-	Sha256  string `json:"sha256,omitempty"`  //
+	Comment string `json:"comment,omitempty"` // Comment about the allowed file
+	Sha256  string `json:"sha256,omitempty"`  // The sha256 digest of allowed file
 }
 type ResponseApplianceGetNetworkApplianceSecurityMalwareAllowedURLs struct {
-	Comment string `json:"comment,omitempty"` //
-	URL     string `json:"url,omitempty"`     //
+	Comment string `json:"comment,omitempty"` // Comment about the allowed URL
+	URL     string `json:"url,omitempty"`     // The allowed URL
 }
-type ResponseApplianceUpdateNetworkApplianceSecurityMalware interface{}
+type ResponseApplianceUpdateNetworkApplianceSecurityMalware struct {
+	AllowedFiles *[]ResponseApplianceUpdateNetworkApplianceSecurityMalwareAllowedFiles `json:"allowedFiles,omitempty"` // Sha256 digests of files permitted by the malware detection engine
+	AllowedURLs  *[]ResponseApplianceUpdateNetworkApplianceSecurityMalwareAllowedURLs  `json:"allowedUrls,omitempty"`  // URLs permitted by the malware detection engine
+	Mode         string                                                                `json:"mode,omitempty"`         // Current status of malware prevention
+}
+type ResponseApplianceUpdateNetworkApplianceSecurityMalwareAllowedFiles struct {
+	Comment string `json:"comment,omitempty"` // Comment about the allowed file
+	Sha256  string `json:"sha256,omitempty"`  // The sha256 digest of allowed file
+}
+type ResponseApplianceUpdateNetworkApplianceSecurityMalwareAllowedURLs struct {
+	Comment string `json:"comment,omitempty"` // Comment about the allowed URL
+	URL     string `json:"url,omitempty"`     // The allowed URL
+}
 type ResponseApplianceGetNetworkApplianceSettings struct {
 	ClientTrackingMethod string                                                  `json:"clientTrackingMethod,omitempty"` // Client tracking method of a network
 	DeploymentMode       string                                                  `json:"deploymentMode,omitempty"`       // Deployment mode of a network
@@ -745,6 +978,7 @@ type ResponseItemApplianceGetNetworkApplianceStaticRoutes struct {
 	Enabled            *bool                                                                   `json:"enabled,omitempty"`            //
 	FixedIPAssignments *ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments `json:"fixedIpAssignments,omitempty"` //
 	GatewayIP          string                                                                  `json:"gatewayIp,omitempty"`          //
+	GatewayVLANID      *int                                                                    `json:"gatewayVlanId,omitempty"`      //
 	ID                 string                                                                  `json:"id,omitempty"`                 //
 	IPVersion          *int                                                                    `json:"ipVersion,omitempty"`          //
 	Name               string                                                                  `json:"name,omitempty"`               //
@@ -769,6 +1003,7 @@ type ResponseApplianceGetNetworkApplianceStaticRoute struct {
 	Enabled            *bool                                                              `json:"enabled,omitempty"`            //
 	FixedIPAssignments *ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` //
 	GatewayIP          string                                                             `json:"gatewayIp,omitempty"`          //
+	GatewayVLANID      *int                                                               `json:"gatewayVlanId,omitempty"`      //
 	ID                 string                                                             `json:"id,omitempty"`                 //
 	IPVersion          *int                                                               `json:"ipVersion,omitempty"`          //
 	Name               string                                                             `json:"name,omitempty"`               //
@@ -799,21 +1034,33 @@ type ResponseApplianceGetNetworkApplianceTrafficShapingGlobalBandwidthLimits str
 type ResponseApplianceUpdateNetworkApplianceTrafficShaping interface{}
 type ResponseApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClasses []ResponseItemApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClasses // Array of ResponseApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClasses
 type ResponseItemApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClasses struct {
-	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` //
-	MaxJitter                *int   `json:"maxJitter,omitempty"`                //
-	MaxLatency               *int   `json:"maxLatency,omitempty"`               //
-	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        //
-	Name                     string `json:"name,omitempty"`                     //
+	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` // ID of the custom performance class
+	MaxJitter                *int   `json:"maxJitter,omitempty"`                // Maximum jitter in milliseconds
+	MaxLatency               *int   `json:"maxLatency,omitempty"`               // Maximum latency in milliseconds
+	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        // Maximum percentage of packet loss
+	Name                     string `json:"name,omitempty"`                     // Name of the custom performance class
 }
-type ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass interface{}
+type ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass struct {
+	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` // ID of the custom performance class
+	MaxJitter                *int   `json:"maxJitter,omitempty"`                // Maximum jitter in milliseconds
+	MaxLatency               *int   `json:"maxLatency,omitempty"`               // Maximum latency in milliseconds
+	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        // Maximum percentage of packet loss
+	Name                     string `json:"name,omitempty"`                     // Name of the custom performance class
+}
 type ResponseApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClass struct {
-	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` //
-	MaxJitter                *int   `json:"maxJitter,omitempty"`                //
-	MaxLatency               *int   `json:"maxLatency,omitempty"`               //
-	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        //
-	Name                     string `json:"name,omitempty"`                     //
+	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` // ID of the custom performance class
+	MaxJitter                *int   `json:"maxJitter,omitempty"`                // Maximum jitter in milliseconds
+	MaxLatency               *int   `json:"maxLatency,omitempty"`               // Maximum latency in milliseconds
+	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        // Maximum percentage of packet loss
+	Name                     string `json:"name,omitempty"`                     // Name of the custom performance class
 }
-type ResponseApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass interface{}
+type ResponseApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass struct {
+	CustomPerformanceClassID string `json:"customPerformanceClassId,omitempty"` // ID of the custom performance class
+	MaxJitter                *int   `json:"maxJitter,omitempty"`                // Maximum jitter in milliseconds
+	MaxLatency               *int   `json:"maxLatency,omitempty"`               // Maximum latency in milliseconds
+	MaxLossPercentage        *int   `json:"maxLossPercentage,omitempty"`        // Maximum percentage of packet loss
+	Name                     string `json:"name,omitempty"`                     // Name of the custom performance class
+}
 type ResponseApplianceGetNetworkApplianceTrafficShapingRules struct {
 	DefaultRulesEnabled *bool                                                           `json:"defaultRulesEnabled,omitempty"` //
 	Rules               *[]ResponseApplianceGetNetworkApplianceTrafficShapingRulesRules `json:"rules,omitempty"`               //
@@ -1004,6 +1251,21 @@ type ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTraf
 	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
 	VLAN *int   `json:"vlan,omitempty"` // VLAN ID of the configured VLAN in the Meraki network. Cannot be used in combination with the "cidr" property and is currently only available under a template network.
 }
+type ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions struct {
+	Custom            *[]ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsCustom            `json:"custom,omitempty"`            // Custom VPN exclusion rules.
+	MajorApplications *[]ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsMajorApplications `json:"majorApplications,omitempty"` // Major Application based VPN exclusion rules.
+	NetworkID         string                                                                                 `json:"networkId,omitempty"`         // ID of the network whose VPN exclusion rules are returned.
+	NetworkName       string                                                                                 `json:"networkName,omitempty"`       // Name of the network whose VPN exclusion rules are returned.
+}
+type ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsCustom struct {
+	Destination string `json:"destination,omitempty"` // Destination address; hostname required for DNS, IPv4 otherwise.
+	Port        string `json:"port,omitempty"`        // Destination port.
+	Protocol    string `json:"protocol,omitempty"`    // Protocol.
+}
+type ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsMajorApplications struct {
+	ID   string `json:"id,omitempty"`   // Application's Meraki ID.
+	Name string `json:"name,omitempty"` // Application's name.
+}
 type ResponseApplianceGetNetworkApplianceUplinksUsageHistory []ResponseItemApplianceGetNetworkApplianceUplinksUsageHistory // Array of ResponseApplianceGetNetworkApplianceUplinksUsageHistory
 type ResponseItemApplianceGetNetworkApplianceUplinksUsageHistory struct {
 	ByInterface *[]ResponseItemApplianceGetNetworkApplianceUplinksUsageHistoryByInterface `json:"byInterface,omitempty"` //
@@ -1099,9 +1361,11 @@ type ResponseApplianceCreateNetworkApplianceVLANMandatoryDhcp struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enable Mandatory DHCP on VLAN.
 }
 type ResponseApplianceGetNetworkApplianceVLANsSettings struct {
-	VLANsEnabled *bool `json:"vlansEnabled,omitempty"` //
+	VLANsEnabled *bool `json:"vlansEnabled,omitempty"` // Boolean indicating whether VLANs are enabled (true) or disabled (false) for the network
 }
-type ResponseApplianceUpdateNetworkApplianceVLANsSettings interface{}
+type ResponseApplianceUpdateNetworkApplianceVLANsSettings struct {
+	VLANsEnabled *bool `json:"vlansEnabled,omitempty"` // Boolean indicating whether VLANs are enabled (true) or disabled (false) for the network
+}
 type ResponseApplianceGetNetworkApplianceVLAN struct {
 	ApplianceIP            string                                                      `json:"applianceIp,omitempty"`            // The local IP of the appliance on the VLAN
 	Cidr                   string                                                      `json:"cidr,omitempty"`                   // CIDR of the pool of subnets. Applicable only for template network. Each network bound to the template will automatically pick a subnet from this pool to build its own VLAN.
@@ -1292,28 +1556,71 @@ type ResponseApplianceGetOrganizationApplianceSecurityIntrusionAllowedRules stru
 	RuleID  string `json:"ruleId,omitempty"`  //
 }
 type ResponseApplianceUpdateOrganizationApplianceSecurityIntrusion interface{}
+type ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork struct {
+	Items *[]ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItems `json:"items,omitempty"` // VPN exclusion rules by network
+}
+type ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItems struct {
+	Custom            *[]ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItemsCustom            `json:"custom,omitempty"`            // Custom VPN exclusion rules.
+	MajorApplications *[]ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItemsMajorApplications `json:"majorApplications,omitempty"` // Major Application based VPN exclusion rules.
+	NetworkID         string                                                                                                 `json:"networkId,omitempty"`         // ID of the network whose VPN exclusion rules are returned.
+	NetworkName       string                                                                                                 `json:"networkName,omitempty"`       // Name of the network whose VPN exclusion rules are returned.
+}
+type ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItemsCustom struct {
+	Destination string `json:"destination,omitempty"` // Destination address; hostname required for DNS, IPv4 otherwise.
+	Port        string `json:"port,omitempty"`        // Destination port.
+	Protocol    string `json:"protocol,omitempty"`    // Protocol.
+}
+type ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkItemsMajorApplications struct {
+	ID   string `json:"id,omitempty"`   // Application's Meraki ID.
+	Name string `json:"name,omitempty"` // Application's name.
+}
 type ResponseApplianceGetOrganizationApplianceUplinkStatuses []ResponseItemApplianceGetOrganizationApplianceUplinkStatuses // Array of ResponseApplianceGetOrganizationApplianceUplinkStatuses
 type ResponseItemApplianceGetOrganizationApplianceUplinkStatuses struct {
-	HighAvailability *ResponseItemApplianceGetOrganizationApplianceUplinkStatusesHighAvailability `json:"highAvailability,omitempty"` //
-	LastReportedAt   string                                                                       `json:"lastReportedAt,omitempty"`   //
-	Model            string                                                                       `json:"model,omitempty"`            //
-	NetworkID        string                                                                       `json:"networkId,omitempty"`        //
-	Serial           string                                                                       `json:"serial,omitempty"`           //
-	Uplinks          *[]ResponseItemApplianceGetOrganizationApplianceUplinkStatusesUplinks        `json:"uplinks,omitempty"`          //
+	HighAvailability *ResponseItemApplianceGetOrganizationApplianceUplinkStatusesHighAvailability `json:"highAvailability,omitempty"` // Device High Availability Capabilities
+	LastReportedAt   string                                                                       `json:"lastReportedAt,omitempty"`   // Last reported time for the device
+	Model            string                                                                       `json:"model,omitempty"`            // The uplink model
+	NetworkID        string                                                                       `json:"networkId,omitempty"`        // Network identifier
+	Serial           string                                                                       `json:"serial,omitempty"`           // The uplink serial
+	Uplinks          *[]ResponseItemApplianceGetOrganizationApplianceUplinkStatusesUplinks        `json:"uplinks,omitempty"`          // Uplinks
 }
 type ResponseItemApplianceGetOrganizationApplianceUplinkStatusesHighAvailability struct {
-	Enabled *bool  `json:"enabled,omitempty"` //
-	Role    string `json:"role,omitempty"`    //
+	Enabled *bool  `json:"enabled,omitempty"` // Indicates whether High Availability is enabled for the device. For devices that do not support HA, this will be 'false'
+	Role    string `json:"role,omitempty"`    // The HA role of the device on the network. For devices that do not support HA, this will be 'primary'
 }
 type ResponseItemApplianceGetOrganizationApplianceUplinkStatusesUplinks struct {
-	Gateway      string `json:"gateway,omitempty"`      //
-	Interface    string `json:"interface,omitempty"`    //
-	IP           string `json:"ip,omitempty"`           //
-	IPAssignedBy string `json:"ipAssignedBy,omitempty"` //
-	PrimaryDNS   string `json:"primaryDns,omitempty"`   //
-	PublicIP     string `json:"publicIp,omitempty"`     //
-	SecondaryDNS string `json:"secondaryDns,omitempty"` //
-	Status       string `json:"status,omitempty"`       //
+	Gateway      string `json:"gateway,omitempty"`      // Gateway IP
+	Interface    string `json:"interface,omitempty"`    // Uplink interface
+	IP           string `json:"ip,omitempty"`           // Uplink IP
+	IPAssignedBy string `json:"ipAssignedBy,omitempty"` // The way in which the IP is assigned
+	PrimaryDNS   string `json:"primaryDns,omitempty"`   // Primary DNS IP
+	PublicIP     string `json:"publicIp,omitempty"`     // Public IP
+	SecondaryDNS string `json:"secondaryDns,omitempty"` // Secondary DNS IP
+	Status       string `json:"status,omitempty"`       // Uplink status
+}
+type ResponseApplianceGetOrganizationApplianceUplinksStatusesOverview struct {
+	Counts *ResponseApplianceGetOrganizationApplianceUplinksStatusesOverviewCounts `json:"counts,omitempty"` // counts
+}
+type ResponseApplianceGetOrganizationApplianceUplinksStatusesOverviewCounts struct {
+	ByStatus *ResponseApplianceGetOrganizationApplianceUplinksStatusesOverviewCountsByStatus `json:"byStatus,omitempty"` // byStatus
+}
+type ResponseApplianceGetOrganizationApplianceUplinksStatusesOverviewCountsByStatus struct {
+	Active       *int `json:"active,omitempty"`       // number of uplinks that are active and working
+	Connecting   *int `json:"connecting,omitempty"`   // number of uplinks currently connecting
+	Failed       *int `json:"failed,omitempty"`       // number of uplinks that were working but have failed
+	NotConnected *int `json:"notConnected,omitempty"` // number of uplinks currently where nothing is plugged in
+	Ready        *int `json:"ready,omitempty"`        // number of uplinks that are working but on standby
+}
+type ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork []ResponseItemApplianceGetOrganizationApplianceUplinksUsageByNetwork // Array of ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork
+type ResponseItemApplianceGetOrganizationApplianceUplinksUsageByNetwork struct {
+	ByUplink  *[]ResponseItemApplianceGetOrganizationApplianceUplinksUsageByNetworkByUplink `json:"byUplink,omitempty"`  // Uplink usage
+	Name      string                                                                        `json:"name,omitempty"`      // Network name
+	NetworkID string                                                                        `json:"networkId,omitempty"` // Network identifier
+}
+type ResponseItemApplianceGetOrganizationApplianceUplinksUsageByNetworkByUplink struct {
+	Interface string `json:"interface,omitempty"` // Uplink name
+	Received  *int   `json:"received,omitempty"`  // Bytes received
+	Sent      *int   `json:"sent,omitempty"`      // Bytes sent
+	Serial    string `json:"serial,omitempty"`    // Uplink serial
 }
 type ResponseApplianceGetOrganizationApplianceVpnStats []ResponseItemApplianceGetOrganizationApplianceVpnStats // Array of ResponseApplianceGetOrganizationApplianceVpnStats
 type ResponseItemApplianceGetOrganizationApplianceVpnStats struct {
@@ -1354,7 +1661,7 @@ type ResponseItemApplianceGetOrganizationApplianceVpnStatsMerakiVpnpeersLossPerc
 type ResponseItemApplianceGetOrganizationApplianceVpnStatsMerakiVpnpeersMosSummaries struct {
 	AvgMos         *float64 `json:"avgMos,omitempty"`         //
 	MaxMos         *float64 `json:"maxMos,omitempty"`         //
-	MinMos         *int     `json:"minMos,omitempty"`         //
+	MinMos         *float64 `json:"minMos,omitempty"`         //
 	ReceiverUplink string   `json:"receiverUplink,omitempty"` //
 	SenderUplink   string   `json:"senderUplink,omitempty"`   //
 }
@@ -1445,30 +1752,44 @@ type ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeersPeersIPsec
 	IkePrfAlgo            []string `json:"ikePrfAlgo,omitempty"`            // [optional] This is the pseudo-random function to be used in IKE_SA. The value should be an array with one of the following algorithms: 'prfsha256', 'prfsha1', 'prfmd5', 'default'. The 'default' option can be used to default to the Authentication algorithm.
 }
 type ResponseApplianceGetOrganizationApplianceVpnVpnFirewallRules struct {
-	Rules *[]ResponseApplianceGetOrganizationApplianceVpnVpnFirewallRulesRules `json:"rules,omitempty"` //
+	Rules *[]ResponseApplianceGetOrganizationApplianceVpnVpnFirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules (not including the default rule)
 }
 type ResponseApplianceGetOrganizationApplianceVpnVpnFirewallRulesRules struct {
-	Comment       string `json:"comment,omitempty"`       //
-	DestCidr      string `json:"destCidr,omitempty"`      //
-	DestPort      string `json:"destPort,omitempty"`      //
-	Policy        string `json:"policy,omitempty"`        //
-	Protocol      string `json:"protocol,omitempty"`      //
-	SrcCidr       string `json:"srcCidr,omitempty"`       //
-	SrcPort       string `json:"srcPort,omitempty"`       //
-	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` //
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
 }
 type ResponseApplianceUpdateOrganizationApplianceVpnVpnFirewallRules struct {
-	Rules *[]ResponseApplianceUpdateOrganizationApplianceVpnVpnFirewallRulesRules `json:"rules,omitempty"` // List of firewall rules
+	Rules *[]ResponseApplianceUpdateOrganizationApplianceVpnVpnFirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules (not including the default rule)
 }
 type ResponseApplianceUpdateOrganizationApplianceVpnVpnFirewallRulesRules struct {
-	Comment       string `json:"comment,omitempty"`       // Description of the rule
-	DestCidr      string `json:"destCidr,omitempty"`      // List of destination IP addresses
-	DestPort      string `json:"destPort,omitempty"`      // List of destination ports
-	Policy        string `json:"policy,omitempty"`        // 'Deny' traffic specified by this rule
-	Protocol      string `json:"protocol,omitempty"`      // The type of protocol
-	SrcCidr       string `json:"srcCidr,omitempty"`       // List of source IP addresses
-	SrcPort       string `json:"srcPort,omitempty"`       // List of source ports
-	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Flag indicating whether the rule should be logged to syslog
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
+}
+type RequestApplianceUpdateDeviceApplianceRadioSettings struct {
+	FiveGhzSettings    *RequestApplianceUpdateDeviceApplianceRadioSettingsFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Manual radio settings for 5 GHz.
+	RfProfileID        string                                                                `json:"rfProfileId,omitempty"`        // The ID of an RF profile to assign to the device. If the value of this parameter is null, the appropriate basic RF profile (indoor or outdoor) will be assigned to the device. Assigning an RF profile will clear ALL manually configured overrides on the device (channel width, channel, power).
+	TwoFourGhzSettings *RequestApplianceUpdateDeviceApplianceRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Manual radio settings for 2.4 GHz.
+}
+type RequestApplianceUpdateDeviceApplianceRadioSettingsFiveGhzSettings struct {
+	Channel      *int `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
+	ChannelWidth *int `json:"channelWidth,omitempty"` // Sets a manual channel width for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
+	TargetPower  *int `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz. Can be between '8' or '30' or null for using auto power range.
+}
+type RequestApplianceUpdateDeviceApplianceRadioSettingsTwoFourGhzSettings struct {
+	Channel     *int `json:"channel,omitempty"`     // Sets a manual channel for 2.4 GHz. Can be '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13' or '14' or null for using auto channel.
+	TargetPower *int `json:"targetPower,omitempty"` // Set a manual target power for 2.4 GHz. Can be between '5' or '30' or null for using auto power range.
 }
 type RequestApplianceUpdateDeviceApplianceUplinksSettings struct {
 	Interfaces *RequestApplianceUpdateDeviceApplianceUplinksSettingsInterfaces `json:"interfaces,omitempty"` // Interface settings.
@@ -1721,6 +2042,78 @@ type RequestApplianceUpdateNetworkAppliancePrefixesDelegatedStaticOrigin struct 
 	Interfaces []string `json:"interfaces,omitempty"` // Interfaces associated with the prefix
 	Type       string   `json:"type,omitempty"`       // Type of the origin
 }
+type RequestApplianceCreateNetworkApplianceRfProfile struct {
+	FiveGhzSettings    *RequestApplianceCreateNetworkApplianceRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band
+	Name               string                                                             `json:"name,omitempty"`               // The name of the new profile. Must be unique. This param is required on creation.
+	PerSSIDSettings    *RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *RequestApplianceCreateNetworkApplianceRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band
+}
+type RequestApplianceCreateNetworkApplianceRfProfileFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Determines whether ax radio on 5Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering. Defaults to true.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Sets min bitrate (Mbps) of 5Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+}
+type RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings struct {
+	Status1 *RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1
+	Status2 *RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2
+	Status3 *RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3
+	Status4 *RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4
+}
+type RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceCreateNetworkApplianceRfProfilePerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceCreateNetworkApplianceRfProfileTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering. Defaults to true.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Sets min bitrate (Mbps) of 2.4Ghz band. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'. Defaults to 11.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfile struct {
+	FiveGhzSettings    *RequestApplianceUpdateNetworkApplianceRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Settings related to 5Ghz band
+	Name               string                                                             `json:"name,omitempty"`               // The name of the new profile. Must be unique.
+	PerSSIDSettings    *RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`    // Per-SSID radio settings by number.
+	TwoFourGhzSettings *RequestApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Settings related to 2.4Ghz band
+}
+type RequestApplianceUpdateNetworkApplianceRfProfileFiveGhzSettings struct {
+	AxEnabled  *bool `json:"axEnabled,omitempty"`  // Determines whether ax radio on 5Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering.
+	MinBitrate *int  `json:"minBitrate,omitempty"` // Sets min bitrate (Mbps) of 5Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings struct {
+	Status1 *RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings1 `json:"1,omitempty"` // Settings for SSID 1
+	Status2 *RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings2 `json:"2,omitempty"` // Settings for SSID 2
+	Status3 *RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings3 `json:"3,omitempty"` // Settings for SSID 3
+	Status4 *RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings4 `json:"4,omitempty"` // Settings for SSID 4
+}
+type RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings1 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings2 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings3 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfilePerSSIDSettings4 struct {
+	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+}
+type RequestApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings struct {
+	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering.
+	MinBitrate *float64 `json:"minBitrate,omitempty"` // Sets min bitrate (Mbps) of 2.4Ghz band. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
 type RequestApplianceUpdateNetworkApplianceSecurityIntrusion struct {
 	IDsRulesets       string                                                                    `json:"idsRulesets,omitempty"`       // Set the detection ruleset 'connectivity'/'balanced'/'security' (optional - omitting will leave current config unchanged). Default value is 'balanced' if none currently saved
 	Mode              string                                                                    `json:"mode,omitempty"`              // Set mode to 'disabled'/'detection'/'prevention' (optional - omitting will leave current config unchanged)
@@ -1780,6 +2173,7 @@ type RequestApplianceUpdateNetworkApplianceSSID struct {
 	AuthMode                     string                                                                  `json:"authMode,omitempty"`                     // The association control method for the SSID ('open', 'psk', '8021x-meraki' or '8021x-radius').
 	DefaultVLANID                *int                                                                    `json:"defaultVlanId,omitempty"`                // The VLAN ID of the VLAN associated to this SSID. This parameter is only valid if the network is in routed mode.
 	DhcpEnforcedDeauthentication *RequestApplianceUpdateNetworkApplianceSSIDDhcpEnforcedDeauthentication `json:"dhcpEnforcedDeauthentication,omitempty"` // DHCP Enforced Deauthentication enables the disassociation of wireless clients in addition to Mandatory DHCP. This param is only valid on firmware versions >= MX 17.0 where the associated LAN has Mandatory DHCP Enabled
+	Dot11W                       *RequestApplianceUpdateNetworkApplianceSSIDDot11W                       `json:"dot11w,omitempty"`                       // The current setting for Protected Management Frames (802.11w).
 	Enabled                      *bool                                                                   `json:"enabled,omitempty"`                      // Whether or not the SSID is enabled.
 	EncryptionMode               string                                                                  `json:"encryptionMode,omitempty"`               // The psk encryption mode for the SSID ('wep' or 'wpa'). This param is only valid if the authMode is 'psk'.
 	Name                         string                                                                  `json:"name,omitempty"`                         // The name of the SSID.
@@ -1790,6 +2184,10 @@ type RequestApplianceUpdateNetworkApplianceSSID struct {
 }
 type RequestApplianceUpdateNetworkApplianceSSIDDhcpEnforcedDeauthentication struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enable DCHP Enforced Deauthentication on the SSID.
+}
+type RequestApplianceUpdateNetworkApplianceSSIDDot11W struct {
+	Enabled  *bool `json:"enabled,omitempty"`  // Whether 802.11w is enabled or not.
+	Required *bool `json:"required,omitempty"` // (Optional) Whether 802.11w is required or not.
 }
 type RequestApplianceUpdateNetworkApplianceSSIDRadiusServers struct {
 	Host   string `json:"host,omitempty"`   // The IP address of your RADIUS server.
@@ -1951,6 +2349,19 @@ type RequestApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTraff
 	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
 	VLAN *int   `json:"vlan,omitempty"` // VLAN ID of the configured VLAN in the Meraki network. Currently only available under a template network.
 }
+type RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions struct {
+	Custom            *[]RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsCustom            `json:"custom,omitempty"`            // Custom VPN exclusion rules. Pass an empty array to clear existing rules.
+	MajorApplications *[]RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsMajorApplications `json:"majorApplications,omitempty"` // Major Application based VPN exclusion rules. Pass an empty array to clear existing rules.
+}
+type RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsCustom struct {
+	Destination string `json:"destination,omitempty"` // Destination address; hostname required for DNS, IPv4 otherwise.
+	Port        string `json:"port,omitempty"`        // Destination port.
+	Protocol    string `json:"protocol,omitempty"`    // Protocol.
+}
+type RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsMajorApplications struct {
+	ID   string `json:"id,omitempty"`   // Application's Meraki ID.
+	Name string `json:"name,omitempty"` // Application's name.
+}
 type RequestApplianceCreateNetworkApplianceVLAN struct {
 	ApplianceIP      string                                                   `json:"applianceIp,omitempty"`      // The local IP of the appliance on the VLAN
 	Cidr             string                                                   `json:"cidr,omitempty"`             // CIDR of the pool of subnets. Applicable only for template network. Each network bound to the template will automatically pick a subnet from this pool to build its own VLAN.
@@ -2036,20 +2447,20 @@ type RequestApplianceUpdateNetworkApplianceVLANReservedIPRanges struct {
 type RequestApplianceUpdateNetworkApplianceVpnBgp struct {
 	AsNumber      *int                                                     `json:"asNumber,omitempty"`      // An Autonomous System Number (ASN) is required if you are to run BGP and peer with another BGP Speaker outside of the Auto VPN domain. This ASN will be applied to the entire Auto VPN domain. The entire 4-byte ASN range is supported. So, the ASN must be an integer between 1 and 4294967295. When absent, this field is not updated. If no value exists then it defaults to 64512.
 	Enabled       *bool                                                    `json:"enabled,omitempty"`       // Boolean value to enable or disable the BGP configuration. When BGP is enabled, the asNumber (ASN) will be autopopulated with the preconfigured ASN at other Hubs or a default value if there is no ASN configured.
-	IbgpHoldTimer *int                                                     `json:"ibgpHoldTimer,omitempty"` // The IBGP holdtimer in seconds. The IBGP holdtimer must be an integer between 12 and 240. When absent, this field is not updated. If no value exists then it defaults to 240.
+	IbgpHoldTimer *int                                                     `json:"ibgpHoldTimer,omitempty"` // The iBGP holdtimer in seconds. The iBGP holdtimer must be an integer between 12 and 240. When absent, this field is not updated. If no value exists then it defaults to 240.
 	Neighbors     *[]RequestApplianceUpdateNetworkApplianceVpnBgpNeighbors `json:"neighbors,omitempty"`     // List of BGP neighbors. This list replaces the existing set of neighbors. When absent, this field is not updated.
 }
 type RequestApplianceUpdateNetworkApplianceVpnBgpNeighbors struct {
 	AllowTransit    *bool                                                                `json:"allowTransit,omitempty"`    // When this feature is on, the Meraki device will advertise routes learned from other Autonomous Systems, thereby allowing traffic between Autonomous Systems to transit this AS. When absent, it defaults to false.
 	Authentication  *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsAuthentication `json:"authentication,omitempty"`  // Authentication settings between BGP peers.
-	EbgpHoldTimer   *int                                                                 `json:"ebgpHoldTimer,omitempty"`   // The EBGP hold timer in seconds for each neighbor. The EBGP hold timer must be an integer between 12 and 240.
-	EbgpMultihop    *int                                                                 `json:"ebgpMultihop,omitempty"`    // Configure this if the neighbor is not adjacent. The EBGP multi-hop must be an integer between 1 and 255.
+	EbgpHoldTimer   *int                                                                 `json:"ebgpHoldTimer,omitempty"`   // The eBGP hold timer in seconds for each neighbor. The eBGP hold timer must be an integer between 12 and 240.
+	EbgpMultihop    *int                                                                 `json:"ebgpMultihop,omitempty"`    // Configure this if the neighbor is not adjacent. The eBGP multi-hop must be an integer between 1 and 255.
 	IP              string                                                               `json:"ip,omitempty"`              // The IPv4 address of the neighbor
-	IPv6            *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsIPv6           `json:"ipv6,omitempty"`            // Information regarding IPv6 address of the neighbor, Required if *ip* is not present.
+	IPv6            *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsIPv6           `json:"ipv6,omitempty"`            // Information regarding IPv6 address of the neighbor, Required if `ip` is not present.
 	NextHopIP       string                                                               `json:"nextHopIp,omitempty"`       // The IPv4 address of the remote BGP peer that will establish a TCP session with the local MX.
 	ReceiveLimit    *int                                                                 `json:"receiveLimit,omitempty"`    // The receive limit is the maximum number of routes that can be received from any BGP peer. The receive limit must be an integer between 0 and 4294967295. When absent, it defaults to 0.
 	RemoteAsNumber  *int                                                                 `json:"remoteAsNumber,omitempty"`  // Remote ASN of the neighbor. The remote ASN must be an integer between 1 and 4294967295.
-	SourceInterface string                                                               `json:"sourceInterface,omitempty"` // The output interface for peering with the remote BGP peer. Valid values are: 'wired0', 'wired1' or 'vlan{VLAN ID}'(e.g. 'vlan123').
+	SourceInterface string                                                               `json:"sourceInterface,omitempty"` // The output interface for peering with the remote BGP peer. Valid values are: 'wan1', 'wan2' or 'vlan{VLAN ID}'(e.g. 'vlan123').
 	TtlSecurity     *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsTtlSecurity    `json:"ttlSecurity,omitempty"`     // Settings for BGP TTL security to protect BGP peering sessions from forged IP attacks.
 }
 type RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsAuthentication struct {
@@ -2257,6 +2668,39 @@ func (s *ApplianceService) GetDeviceAppliancePrefixesDelegatedVLANAssignments(se
 	}
 
 	result := response.Result().(*ResponseApplianceGetDeviceAppliancePrefixesDelegatedVLANAssignments)
+	return result, response, err
+
+}
+
+//GetDeviceApplianceRadioSettings Return the radio settings of an appliance
+/* Return the radio settings of an appliance
+
+@param serial serial path parameter.
+
+
+*/
+func (s *ApplianceService) GetDeviceApplianceRadioSettings(serial string) (*ResponseApplianceGetDeviceApplianceRadioSettings, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/appliance/radio/settings"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseApplianceGetDeviceApplianceRadioSettings{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceApplianceRadioSettings")
+	}
+
+	result := response.Result().(*ResponseApplianceGetDeviceApplianceRadioSettings)
 	return result, response, err
 
 }
@@ -2965,6 +3409,74 @@ func (s *ApplianceService) GetNetworkAppliancePrefixesDelegatedStatic(networkID 
 
 }
 
+//GetNetworkApplianceRfProfiles List the RF profiles for this network
+/* List the RF profiles for this network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+func (s *ApplianceService) GetNetworkApplianceRfProfiles(networkID string) (*ResponseApplianceGetNetworkApplianceRfProfiles, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/rfProfiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseApplianceGetNetworkApplianceRfProfiles{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkApplianceRfProfiles")
+	}
+
+	result := response.Result().(*ResponseApplianceGetNetworkApplianceRfProfiles)
+	return result, response, err
+
+}
+
+//GetNetworkApplianceRfProfile Return a RF profile
+/* Return a RF profile
+
+@param networkID networkId path parameter. Network ID
+@param rfProfileID rfProfileId path parameter. Rf profile ID
+
+
+*/
+func (s *ApplianceService) GetNetworkApplianceRfProfile(networkID string, rfProfileID string) (*ResponseApplianceGetNetworkApplianceRfProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/rfProfiles/{rfProfileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{rfProfileId}", fmt.Sprintf("%v", rfProfileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseApplianceGetNetworkApplianceRfProfile{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkApplianceRfProfile")
+	}
+
+	result := response.Result().(*ResponseApplianceGetNetworkApplianceRfProfile)
+	return result, response, err
+
+}
+
 //GetNetworkApplianceSecurityEvents List the security events for a network
 /* List the security events for a network
 
@@ -3524,8 +4036,6 @@ func (s *ApplianceService) GetNetworkApplianceVLANs(networkID string) (*Response
 		SetError(&Error).
 		Get(path)
 
-	// log.Printf("[DEBUG] Response: %v", response)
-	log.Printf("[DEBUG] Error: %v", err)
 	if err != nil {
 		return nil, nil, err
 
@@ -3535,9 +4045,7 @@ func (s *ApplianceService) GetNetworkApplianceVLANs(networkID string) (*Response
 		return nil, response, fmt.Errorf("error with operation GetNetworkApplianceVlans")
 	}
 
-	log.Printf("[DEBUG] Selected method: GetDeviceCameraAnalyticsLive")
 	result := response.Result().(*ResponseApplianceGetNetworkApplianceVLANs)
-	log.Println("Result: ", result)
 	return result, response, err
 
 }
@@ -3778,6 +4286,42 @@ func (s *ApplianceService) GetOrganizationApplianceSecurityIntrusion(organizatio
 
 }
 
+//GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork Display VPN exclusion rules for MX networks.
+/* Display VPN exclusion rules for MX networks.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams Filtering parameter
+
+
+*/
+func (s *ApplianceService) GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork(organizationID string, getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams *GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams) (*ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/appliance/trafficShaping/vpnExclusions/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork")
+	}
+
+	result := response.Result().(*ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork)
+	return result, response, err
+
+}
+
 //GetOrganizationApplianceUplinkStatuses List the uplink status of every Meraki MX and Z series appliances in the organization
 /* List the uplink status of every Meraki MX and Z series appliances in the organization
 
@@ -3810,6 +4354,75 @@ func (s *ApplianceService) GetOrganizationApplianceUplinkStatuses(organizationID
 	}
 
 	result := response.Result().(*ResponseApplianceGetOrganizationApplianceUplinkStatuses)
+	return result, response, err
+
+}
+
+//GetOrganizationApplianceUplinksStatusesOverview Returns an overview of uplink statuses
+/* Returns an overview of uplink statuses
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+func (s *ApplianceService) GetOrganizationApplianceUplinksStatusesOverview(organizationID string) (*ResponseApplianceGetOrganizationApplianceUplinksStatusesOverview, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/appliance/uplinks/statuses/overview"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseApplianceGetOrganizationApplianceUplinksStatusesOverview{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationApplianceUplinksStatusesOverview")
+	}
+
+	result := response.Result().(*ResponseApplianceGetOrganizationApplianceUplinksStatusesOverview)
+	return result, response, err
+
+}
+
+//GetOrganizationApplianceUplinksUsageByNetwork Get the sent and received bytes for each uplink of all MX and Z networks within an organization
+/* Get the sent and received bytes for each uplink of all MX and Z networks within an organization. If more than one device was active during the specified timespan, then the sent and received bytes will be aggregated by interface.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationApplianceUplinksUsageByNetworkQueryParams Filtering parameter
+
+
+*/
+func (s *ApplianceService) GetOrganizationApplianceUplinksUsageByNetwork(organizationID string, getOrganizationApplianceUplinksUsageByNetworkQueryParams *GetOrganizationApplianceUplinksUsageByNetworkQueryParams) (*ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/appliance/uplinks/usage/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationApplianceUplinksUsageByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationApplianceUplinksUsageByNetwork")
+	}
+
+	result := response.Result().(*ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork)
 	return result, response, err
 
 }
@@ -4020,6 +4633,41 @@ func (s *ApplianceService) CreateNetworkAppliancePrefixesDelegatedStatic(network
 
 }
 
+//CreateNetworkApplianceRfProfile Creates new RF profile for this network
+/* Creates new RF profile for this network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *ApplianceService) CreateNetworkApplianceRfProfile(networkID string, requestApplianceCreateNetworkApplianceRfProfile *RequestApplianceCreateNetworkApplianceRfProfile) (*ResponseApplianceCreateNetworkApplianceRfProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/rfProfiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceCreateNetworkApplianceRfProfile).
+		SetResult(&ResponseApplianceCreateNetworkApplianceRfProfile{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateNetworkApplianceRfProfile")
+	}
+
+	result := response.Result().(*ResponseApplianceCreateNetworkApplianceRfProfile)
+	return result, response, err
+
+}
+
 //CreateNetworkApplianceStaticRoute Add a static route for an MX or teleworker network
 /* Add a static route for an MX or teleworker network
 
@@ -4154,6 +4802,38 @@ func (s *ApplianceService) SwapNetworkApplianceWarmSpare(networkID string) (*res
 	}
 
 	return response, err
+
+}
+
+//UpdateDeviceApplianceRadioSettings Update the radio settings of an appliance
+/* Update the radio settings of an appliance
+
+@param serial serial path parameter.
+*/
+func (s *ApplianceService) UpdateDeviceApplianceRadioSettings(serial string, requestApplianceUpdateDeviceApplianceRadioSettings *RequestApplianceUpdateDeviceApplianceRadioSettings) (*ResponseApplianceUpdateDeviceApplianceRadioSettings, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/appliance/radio/settings"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceUpdateDeviceApplianceRadioSettings).
+		SetResult(&ResponseApplianceUpdateDeviceApplianceRadioSettings{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceApplianceRadioSettings")
+	}
+
+	result := response.Result().(*ResponseApplianceUpdateDeviceApplianceRadioSettings)
+	return result, response, err
 
 }
 
@@ -4348,7 +5028,7 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallInboundCellularFirewall
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceFirewallInboundFirewallRules(networkID string, requestApplianceUpdateNetworkApplianceFirewallInboundFirewallRules *RequestApplianceUpdateNetworkApplianceFirewallInboundFirewallRules) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceFirewallInboundFirewallRules(networkID string, requestApplianceUpdateNetworkApplianceFirewallInboundFirewallRules *RequestApplianceUpdateNetworkApplianceFirewallInboundFirewallRules) (*ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/inboundFirewallRules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4357,19 +5037,21 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallInboundFirewallRules(ne
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceFirewallInboundFirewallRules).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallInboundFirewallRules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallInboundFirewallRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceFirewallInboundFirewallRules)
+	return result, response, err
 
 }
 
@@ -4619,12 +5301,46 @@ func (s *ApplianceService) UpdateNetworkAppliancePrefixesDelegatedStatic(network
 
 }
 
+//UpdateNetworkApplianceRfProfile Updates specified RF profile for this network
+/* Updates specified RF profile for this network
+
+@param networkID networkId path parameter. Network ID
+@param rfProfileID rfProfileId path parameter. Rf profile ID
+*/
+func (s *ApplianceService) UpdateNetworkApplianceRfProfile(networkID string, rfProfileID string, requestApplianceUpdateNetworkApplianceRfProfile *RequestApplianceUpdateNetworkApplianceRfProfile) (*ResponseApplianceUpdateNetworkApplianceRfProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/rfProfiles/{rfProfileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{rfProfileId}", fmt.Sprintf("%v", rfProfileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceUpdateNetworkApplianceRfProfile).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceRfProfile{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceRfProfile")
+	}
+
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceRfProfile)
+	return result, response, err
+
+}
+
 //UpdateNetworkApplianceSecurityIntrusion Set the supported intrusion settings for an MX network
 /* Set the supported intrusion settings for an MX network
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceSecurityIntrusion(networkID string, requestApplianceUpdateNetworkApplianceSecurityIntrusion *RequestApplianceUpdateNetworkApplianceSecurityIntrusion) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceSecurityIntrusion(networkID string, requestApplianceUpdateNetworkApplianceSecurityIntrusion *RequestApplianceUpdateNetworkApplianceSecurityIntrusion) (*ResponseApplianceUpdateNetworkApplianceSecurityIntrusion, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/security/intrusion"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4633,19 +5349,21 @@ func (s *ApplianceService) UpdateNetworkApplianceSecurityIntrusion(networkID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceSecurityIntrusion).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceSecurityIntrusion{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceSecurityIntrusion")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceSecurityIntrusion")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceSecurityIntrusion)
+	return result, response, err
 
 }
 
@@ -4654,7 +5372,7 @@ func (s *ApplianceService) UpdateNetworkApplianceSecurityIntrusion(networkID str
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceSecurityMalware(networkID string, requestApplianceUpdateNetworkApplianceSecurityMalware *RequestApplianceUpdateNetworkApplianceSecurityMalware) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceSecurityMalware(networkID string, requestApplianceUpdateNetworkApplianceSecurityMalware *RequestApplianceUpdateNetworkApplianceSecurityMalware) (*ResponseApplianceUpdateNetworkApplianceSecurityMalware, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/security/malware"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4663,19 +5381,21 @@ func (s *ApplianceService) UpdateNetworkApplianceSecurityMalware(networkID strin
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceSecurityMalware).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceSecurityMalware{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceSecurityMalware")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceSecurityMalware")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceSecurityMalware)
+	return result, response, err
 
 }
 
@@ -4845,7 +5565,7 @@ func (s *ApplianceService) UpdateNetworkApplianceTrafficShaping(networkID string
 @param networkID networkId path parameter. Network ID
 @param customPerformanceClassID customPerformanceClassId path parameter. Custom performance class ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceTrafficShapingCustomPerformanceClass(networkID string, customPerformanceClassID string, requestApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass *RequestApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceTrafficShapingCustomPerformanceClass(networkID string, customPerformanceClassID string, requestApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass *RequestApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass) (*ResponseApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses/{customPerformanceClassId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4855,19 +5575,21 @@ func (s *ApplianceService) UpdateNetworkApplianceTrafficShapingCustomPerformance
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceTrafficShapingCustomPerformanceClass")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceTrafficShapingCustomPerformanceClass")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceTrafficShapingCustomPerformanceClass)
+	return result, response, err
 
 }
 
@@ -4963,12 +5685,44 @@ func (s *ApplianceService) UpdateNetworkApplianceTrafficShapingUplinkSelection(n
 
 }
 
+//UpdateNetworkApplianceTrafficShapingVpnExclusions Update VPN exclusion rules for an MX network.
+/* Update VPN exclusion rules for an MX network.
+
+@param networkID networkId path parameter. Network ID
+*/
+func (s *ApplianceService) UpdateNetworkApplianceTrafficShapingVpnExclusions(networkID string, requestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions *RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions) (*ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/vpnExclusions"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceTrafficShapingVpnExclusions")
+	}
+
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceTrafficShapingVpnExclusions)
+	return result, response, err
+
+}
+
 //UpdateNetworkApplianceVLANsSettings Enable/Disable VLANs for the given network
 /* Enable/Disable VLANs for the given network
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceVLANsSettings(networkID string, requestApplianceUpdateNetworkApplianceVlansSettings *RequestApplianceUpdateNetworkApplianceVLANsSettings) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceVLANsSettings(networkID string, requestApplianceUpdateNetworkApplianceVlansSettings *RequestApplianceUpdateNetworkApplianceVLANsSettings) (*ResponseApplianceUpdateNetworkApplianceVLANsSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vlans/settings"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4977,19 +5731,21 @@ func (s *ApplianceService) UpdateNetworkApplianceVLANsSettings(networkID string,
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceVlansSettings).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceVLANsSettings{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceVlansSettings")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceVlansSettings")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceVLANsSettings)
+	return result, response, err
 
 }
 
@@ -5154,7 +5910,7 @@ func (s *ApplianceService) UpdateOrganizationApplianceSecurityIntrusion(organiza
 
 @param organizationID organizationId path parameter. Organization ID
 */
-func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string, requestApplianceUpdateOrganizationApplianceVpnThirdPartyVPNPeers *RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers) (*ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers, *resty.Response, error) {
+func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/thirdPartyVPNPeers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5162,22 +5918,19 @@ func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(orga
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBody(requestApplianceUpdateOrganizationApplianceVpnThirdPartyVPNPeers).
-		SetResult(&ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation UpdateOrganizationApplianceVpnThirdPartyVpnpeers")
+		return response, fmt.Errorf("error with operation UpdateOrganizationApplianceVpnThirdPartyVpnpeers")
 	}
 
-	result := response.Result().(*ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers)
-	return result, response, err
+	return response, err
 
 }
 
@@ -5241,6 +5994,40 @@ func (s *ApplianceService) DeleteNetworkAppliancePrefixesDelegatedStatic(network
 
 	if response.IsError() {
 		return response, fmt.Errorf("error with operation DeleteNetworkAppliancePrefixesDelegatedStatic")
+	}
+
+	return response, err
+
+}
+
+//DeleteNetworkApplianceRfProfile Delete a RF Profile
+/* Delete a RF Profile
+
+@param networkID networkId path parameter. Network ID
+@param rfProfileID rfProfileId path parameter. Rf profile ID
+
+
+*/
+func (s *ApplianceService) DeleteNetworkApplianceRfProfile(networkID string, rfProfileID string) (*resty.Response, error) {
+	//networkID string,rfProfileID string
+	path := "/api/v1/networks/{networkId}/appliance/rfProfiles/{rfProfileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{rfProfileId}", fmt.Sprintf("%v", rfProfileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteNetworkApplianceRfProfile")
 	}
 
 	return response, err

--- a/sdk/camera.go
+++ b/sdk/camera.go
@@ -29,6 +29,19 @@ type GetDeviceCameraAnalyticsZoneHistoryQueryParams struct {
 type GetDeviceCameraVideoLinkQueryParams struct {
 	Timestamp string `url:"timestamp,omitempty"` //[optional] The video link will start at this time. The timestamp should be a string in ISO8601 format. If no timestamp is specified, we will assume current time.
 }
+type GetOrganizationCameraBoundariesAreasByDeviceQueryParams struct {
+	Serials []string `url:"serials[],omitempty"` //A list of serial numbers. The returned cameras will be filtered to only include these serials.
+}
+type GetOrganizationCameraBoundariesLinesByDeviceQueryParams struct {
+	Serials []string `url:"serials[],omitempty"` //A list of serial numbers. The returned cameras will be filtered to only include these serials.
+}
+type GetOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams struct {
+	BoundaryIDs   []string `url:"boundaryIds[],omitempty"`   //A list of boundary ids. The returned cameras will be filtered to only include these ids.
+	Ranges        []string `url:"ranges[],omitempty"`        //A list of time ranges with intervals
+	Duration      int      `url:"duration,omitempty"`        //The minimum time, in seconds, that the person or car remains in the area to be counted. Defaults to boundary configuration or 60.
+	PerPage       int      `url:"perPage,omitempty"`         //The number of entries per page returned. Acceptable range is 1 - 1000. Defaults to 1000.
+	BoundaryTypes []string `url:"boundaryTypes[],omitempty"` //The detection types. Defaults to 'person'.
+}
 type GetOrganizationCameraOnboardingStatusesQueryParams struct {
 	Serials    []string `url:"serials[],omitempty"`    //A list of serial numbers. The returned cameras will be filtered to only include these serials.
 	NetworkIDs []string `url:"networkIds[],omitempty"` //A list of network IDs. The returned cameras will be filtered to only include these networks.
@@ -81,15 +94,23 @@ type ResponseItemCameraGetDeviceCameraAnalyticsZoneHistory struct {
 	StartTs      string   `json:"startTs,omitempty"`      //
 }
 type ResponseCameraGetDeviceCameraCustomAnalytics struct {
-	ArtifactID string                                                    `json:"artifactId,omitempty"` //
-	Enabled    *bool                                                     `json:"enabled,omitempty"`    //
-	Parameters *[]ResponseCameraGetDeviceCameraCustomAnalyticsParameters `json:"parameters,omitempty"` //
+	ArtifactID string                                                    `json:"artifactId,omitempty"` // Custom analytics artifact ID
+	Enabled    *bool                                                     `json:"enabled,omitempty"`    // Whether custom analytics is enabled
+	Parameters *[]ResponseCameraGetDeviceCameraCustomAnalyticsParameters `json:"parameters,omitempty"` // Parameters for the custom analytics workload
 }
 type ResponseCameraGetDeviceCameraCustomAnalyticsParameters struct {
-	Name  string   `json:"name,omitempty"`  //
-	Value *float64 `json:"value,omitempty"` //
+	Name  string   `json:"name,omitempty"`  // Name of the parameter
+	Value *float64 `json:"value,omitempty"` // Value of the parameter
 }
-type ResponseCameraUpdateDeviceCameraCustomAnalytics interface{}
+type ResponseCameraUpdateDeviceCameraCustomAnalytics struct {
+	ArtifactID string                                                       `json:"artifactId,omitempty"` // Custom analytics artifact ID
+	Enabled    *bool                                                        `json:"enabled,omitempty"`    // Whether custom analytics is enabled
+	Parameters *[]ResponseCameraUpdateDeviceCameraCustomAnalyticsParameters `json:"parameters,omitempty"` // Parameters for the custom analytics workload
+}
+type ResponseCameraUpdateDeviceCameraCustomAnalyticsParameters struct {
+	Name  string   `json:"name,omitempty"`  // Name of the parameter
+	Value *float64 `json:"value,omitempty"` // Value of the parameter
+}
 type ResponseCameraGenerateDeviceCameraSnapshot interface{}
 type ResponseCameraGetDeviceCameraQualityAndRetention struct {
 	AudioRecordingEnabled          *bool  `json:"audioRecordingEnabled,omitempty"`          //
@@ -117,12 +138,16 @@ type ResponseItemCameraGetDeviceCameraSenseObjectDetectionModels struct {
 	ID          string `json:"id,omitempty"`          //
 }
 type ResponseCameraGetDeviceCameraVideoSettings struct {
-	ExternalRtspEnabled *bool  `json:"externalRtspEnabled,omitempty"` //
-	RtspURL             string `json:"rtspUrl,omitempty"`             //
+	ExternalRtspEnabled *bool  `json:"externalRtspEnabled,omitempty"` // Boolean indicating if external rtsp stream is exposed
+	RtspURL             string `json:"rtspUrl,omitempty"`             // External rstp url. Will only be returned if external rtsp stream is exposed
 }
-type ResponseCameraUpdateDeviceCameraVideoSettings interface{}
+type ResponseCameraUpdateDeviceCameraVideoSettings struct {
+	ExternalRtspEnabled *bool  `json:"externalRtspEnabled,omitempty"` // Boolean indicating if external rtsp stream is exposed
+	RtspURL             string `json:"rtspUrl,omitempty"`             // External rstp url. Will only be returned if external rtsp stream is exposed
+}
 type ResponseCameraGetDeviceCameraVideoLink struct {
-	URL string `json:"url,omitempty"` //
+	URL       string `json:"url,omitempty"`       //
+	VisionURL string `json:"visionUrl,omitempty"` //
 }
 type ResponseCameraGetDeviceCameraWirelessProfiles struct {
 	IDs *ResponseCameraGetDeviceCameraWirelessProfilesIDs `json:"ids,omitempty"` //
@@ -144,6 +169,7 @@ type ResponseItemCameraGetNetworkCameraQualityRetentionProfiles struct {
 	Name                           string                                                                   `json:"name,omitempty"`                           //
 	NetworkID                      string                                                                   `json:"networkId,omitempty"`                      //
 	RestrictedBandwidthModeEnabled *bool                                                                    `json:"restrictedBandwidthModeEnabled,omitempty"` //
+	ScheduleID                     string                                                                   `json:"scheduleId,omitempty"`                     //
 	VideoSettings                  *ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettings `json:"videoSettings,omitempty"`                  //
 }
 type ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettings struct {
@@ -179,6 +205,7 @@ type ResponseCameraGetNetworkCameraQualityRetentionProfile struct {
 	Name                           string                                                              `json:"name,omitempty"`                           //
 	NetworkID                      string                                                              `json:"networkId,omitempty"`                      //
 	RestrictedBandwidthModeEnabled *bool                                                               `json:"restrictedBandwidthModeEnabled,omitempty"` //
+	ScheduleID                     string                                                              `json:"scheduleId,omitempty"`                     //
 	VideoSettings                  *ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettings `json:"videoSettings,omitempty"`                  //
 }
 type ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettings struct {
@@ -206,8 +233,8 @@ type ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettingsMV32 stru
 type ResponseCameraUpdateNetworkCameraQualityRetentionProfile interface{}
 type ResponseCameraGetNetworkCameraSchedules []ResponseItemCameraGetNetworkCameraSchedules // Array of ResponseCameraGetNetworkCameraSchedules
 type ResponseItemCameraGetNetworkCameraSchedules struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // Schedule id
+	Name string `json:"name,omitempty"` // Schedule name
 }
 type ResponseCameraGetNetworkCameraWirelessProfiles []ResponseItemCameraGetNetworkCameraWirelessProfiles // Array of ResponseCameraGetNetworkCameraWirelessProfiles
 type ResponseItemCameraGetNetworkCameraWirelessProfiles struct {
@@ -244,25 +271,89 @@ type ResponseCameraGetNetworkCameraWirelessProfileSSID struct {
 	Name           string `json:"name,omitempty"`           //
 }
 type ResponseCameraUpdateNetworkCameraWirelessProfile interface{}
+type ResponseCameraGetOrganizationCameraBoundariesAreasByDevice []ResponseItemCameraGetOrganizationCameraBoundariesAreasByDevice // Array of ResponseCameraGetOrganizationCameraBoundariesAreasByDevice
+type ResponseItemCameraGetOrganizationCameraBoundariesAreasByDevice struct {
+	Boundaries *ResponseItemCameraGetOrganizationCameraBoundariesAreasByDeviceBoundaries `json:"boundaries,omitempty"` // Configured area boundaries of the camera
+	NetworkID  string                                                                    `json:"networkId,omitempty"`  // The network id of the camera
+	Serial     string                                                                    `json:"serial,omitempty"`     // The serial number of the camera
+}
+type ResponseItemCameraGetOrganizationCameraBoundariesAreasByDeviceBoundaries struct {
+	ID       string                                                                              `json:"id,omitempty"`       // The area boundary id
+	Name     string                                                                              `json:"name,omitempty"`     // The area boundary name
+	Type     string                                                                              `json:"type,omitempty"`     // The area boundary type
+	Vertices *[]ResponseItemCameraGetOrganizationCameraBoundariesAreasByDeviceBoundariesVertices `json:"vertices,omitempty"` // The area boundary vertices
+}
+type ResponseItemCameraGetOrganizationCameraBoundariesAreasByDeviceBoundariesVertices struct {
+	X *float64 `json:"x,omitempty"` // The vertex x coordinate
+	Y *float64 `json:"y,omitempty"` // The vertex y coordinate
+}
+type ResponseCameraGetOrganizationCameraBoundariesLinesByDevice []ResponseItemCameraGetOrganizationCameraBoundariesLinesByDevice // Array of ResponseCameraGetOrganizationCameraBoundariesLinesByDevice
+type ResponseItemCameraGetOrganizationCameraBoundariesLinesByDevice struct {
+	Boundaries *ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundaries `json:"boundaries,omitempty"` // Configured line boundaries of the camera
+	NetworkID  string                                                                    `json:"networkId,omitempty"`  // The network id of the camera
+	Serial     string                                                                    `json:"serial,omitempty"`     // The serial number of the camera
+}
+type ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundaries struct {
+	DirectionVertex *ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundariesDirectionVertex `json:"directionVertex,omitempty"` // The line boundary crossing direction vertex
+	ID              string                                                                                   `json:"id,omitempty"`              // The line boundary id
+	Name            string                                                                                   `json:"name,omitempty"`            // The line boundary name
+	Type            string                                                                                   `json:"type,omitempty"`            // The line boundary type
+	Vertices        *[]ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundariesVertices      `json:"vertices,omitempty"`        // The line boundary vertices
+}
+type ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundariesDirectionVertex struct {
+	X *float64 `json:"x,omitempty"` // The vertex x coordinate
+	Y *float64 `json:"y,omitempty"` // The vertex y coordinate
+}
+type ResponseItemCameraGetOrganizationCameraBoundariesLinesByDeviceBoundariesVertices struct {
+	X *float64 `json:"x,omitempty"` // The vertex x coordinate
+	Y *float64 `json:"y,omitempty"` // The vertex y coordinate
+}
 type ResponseCameraGetOrganizationCameraCustomAnalyticsArtifacts []ResponseItemCameraGetOrganizationCameraCustomAnalyticsArtifacts // Array of ResponseCameraGetOrganizationCameraCustomAnalyticsArtifacts
 type ResponseItemCameraGetOrganizationCameraCustomAnalyticsArtifacts struct {
-	ArtifactID     string                                                                 `json:"artifactId,omitempty"`     //
-	Name           string                                                                 `json:"name,omitempty"`           //
-	OrganizationID string                                                                 `json:"organizationId,omitempty"` //
-	Status         *ResponseItemCameraGetOrganizationCameraCustomAnalyticsArtifactsStatus `json:"status,omitempty"`         //
+	ArtifactID     string                                                                 `json:"artifactId,omitempty"`     // Custom analytics artifact ID
+	Name           string                                                                 `json:"name,omitempty"`           // Custom analytics artifact name
+	OrganizationID string                                                                 `json:"organizationId,omitempty"` // Organization ID
+	Status         *ResponseItemCameraGetOrganizationCameraCustomAnalyticsArtifactsStatus `json:"status,omitempty"`         // Custom analytics artifact status
 }
 type ResponseItemCameraGetOrganizationCameraCustomAnalyticsArtifactsStatus struct {
-	Type string `json:"type,omitempty"` //
+	Message string `json:"message,omitempty"` // Status message
+	Type    string `json:"type,omitempty"`    // Status type
 }
-type ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact interface{}
+type ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact struct {
+	ArtifactID      string                                                               `json:"artifactId,omitempty"`      // Custom analytics artifact ID
+	Name            string                                                               `json:"name,omitempty"`            // Custom analytics artifact name
+	OrganizationID  string                                                               `json:"organizationId,omitempty"`  // Organization ID
+	Status          *ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifactStatus `json:"status,omitempty"`          // Custom analytics artifact status
+	UploadID        string                                                               `json:"uploadId,omitempty"`        // Upload ID
+	UploadURL       string                                                               `json:"uploadUrl,omitempty"`       // Upload URL
+	UploadURLExpiry string                                                               `json:"uploadUrlExpiry,omitempty"` // Upload URL expiry time
+}
+type ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifactStatus struct {
+	Message string `json:"message,omitempty"` // Status message
+	Type    string `json:"type,omitempty"`    // Status type
+}
 type ResponseCameraGetOrganizationCameraCustomAnalyticsArtifact struct {
-	ArtifactID     string                                                            `json:"artifactId,omitempty"`     //
-	Name           string                                                            `json:"name,omitempty"`           //
-	OrganizationID string                                                            `json:"organizationId,omitempty"` //
-	Status         *ResponseCameraGetOrganizationCameraCustomAnalyticsArtifactStatus `json:"status,omitempty"`         //
+	ArtifactID     string                                                            `json:"artifactId,omitempty"`     // Custom analytics artifact ID
+	Name           string                                                            `json:"name,omitempty"`           // Custom analytics artifact name
+	OrganizationID string                                                            `json:"organizationId,omitempty"` // Organization ID
+	Status         *ResponseCameraGetOrganizationCameraCustomAnalyticsArtifactStatus `json:"status,omitempty"`         // Custom analytics artifact status
 }
 type ResponseCameraGetOrganizationCameraCustomAnalyticsArtifactStatus struct {
-	Type string `json:"type,omitempty"` //
+	Message string `json:"message,omitempty"` // Status message
+	Type    string `json:"type,omitempty"`    // Status type
+}
+type ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval []ResponseItemCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval // Array of ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval
+type ResponseItemCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval struct {
+	BoundaryID string                                                                               `json:"boundaryId,omitempty"` // The boundary id
+	Results    *ResponseItemCameraGetOrganizationCameraDetectionsHistoryByBoundaryByIntervalResults `json:"results,omitempty"`    // The analytics data
+	Type       string                                                                               `json:"type,omitempty"`       // The boundary type
+}
+type ResponseItemCameraGetOrganizationCameraDetectionsHistoryByBoundaryByIntervalResults struct {
+	EndTime    string `json:"endTime,omitempty"`    // The period end time
+	In         *int   `json:"in,omitempty"`         // The number of detections entered
+	ObjectType string `json:"objectType,omitempty"` // The detection type
+	Out        *int   `json:"out,omitempty"`        // The number of detections exited
+	StartTime  string `json:"startTime,omitempty"`  // The period start time
 }
 type ResponseCameraGetOrganizationCameraOnboardingStatuses []ResponseItemCameraGetOrganizationCameraOnboardingStatuses // Array of ResponseCameraGetOrganizationCameraOnboardingStatuses
 type ResponseItemCameraGetOrganizationCameraOnboardingStatuses struct {
@@ -272,6 +363,72 @@ type ResponseItemCameraGetOrganizationCameraOnboardingStatuses struct {
 	UpdatedAt string `json:"updatedAt,omitempty"` //
 }
 type ResponseCameraUpdateOrganizationCameraOnboardingStatuses interface{}
+type ResponseCameraGetOrganizationCameraPermissions []ResponseItemCameraGetOrganizationCameraPermissions // Array of ResponseCameraGetOrganizationCameraPermissions
+type ResponseItemCameraGetOrganizationCameraPermissions struct {
+	ID    string `json:"id,omitempty"`    // Permission scope id
+	Level string `json:"level,omitempty"` // Permission scope level
+	Name  string `json:"name,omitempty"`  // Name of permission scope
+}
+type ResponseCameraGetOrganizationCameraPermission struct {
+	ID    string `json:"id,omitempty"`    // Permission scope id
+	Level string `json:"level,omitempty"` // Permission scope level
+	Name  string `json:"name,omitempty"`  // Name of permission scope
+}
+type ResponseCameraGetOrganizationCameraRoles []ResponseItemCameraGetOrganizationCameraRoles // Array of ResponseCameraGetOrganizationCameraRoles
+type ResponseItemCameraGetOrganizationCameraRoles struct {
+	AppliedOnDevices  *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOnDevices  `json:"appliedOnDevices,omitempty"`  //
+	AppliedOnNetworks *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` //
+	AppliedOrgWide    *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    //
+	Name              string                                                           `json:"name,omitempty"`              //
+}
+type ResponseItemCameraGetOrganizationCameraRolesAppliedOnDevices struct {
+	ID                string `json:"id,omitempty"`                //
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseItemCameraGetOrganizationCameraRolesAppliedOnNetworks struct {
+	ID                string `json:"id,omitempty"`                //
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseItemCameraGetOrganizationCameraRolesAppliedOrgWide struct {
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseCameraCreateOrganizationCameraRole interface{}
+type ResponseCameraGetOrganizationCameraRole struct {
+	AppliedOnDevices  *[]ResponseCameraGetOrganizationCameraRoleAppliedOnDevices  `json:"appliedOnDevices,omitempty"`  //
+	AppliedOnNetworks *[]ResponseCameraGetOrganizationCameraRoleAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` //
+	AppliedOrgWide    *[]ResponseCameraGetOrganizationCameraRoleAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    //
+	Name              string                                                      `json:"name,omitempty"`              //
+}
+type ResponseCameraGetOrganizationCameraRoleAppliedOnDevices struct {
+	ID                string `json:"id,omitempty"`                //
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseCameraGetOrganizationCameraRoleAppliedOnNetworks struct {
+	ID                string `json:"id,omitempty"`                //
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseCameraGetOrganizationCameraRoleAppliedOrgWide struct {
+	PermissionLevel   string `json:"permissionLevel,omitempty"`   //
+	PermissionScope   string `json:"permissionScope,omitempty"`   //
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` //
+	Tag               string `json:"tag,omitempty"`               //
+}
+type ResponseCameraUpdateOrganizationCameraRole interface{}
 type RequestCameraUpdateDeviceCameraCustomAnalytics struct {
 	ArtifactID string                                                      `json:"artifactId,omitempty"` // The ID of the custom analytics artifact
 	Enabled    *bool                                                       `json:"enabled,omitempty"`    // Enable custom analytics
@@ -291,7 +448,7 @@ type RequestCameraUpdateDeviceCameraQualityAndRetention struct {
 	MotionDetectorVersion          *int   `json:"motionDetectorVersion,omitempty"`          // The version of the motion detector that will be used by the camera. Only applies to Gen 2 cameras. Defaults to v2.
 	ProfileID                      string `json:"profileId,omitempty"`                      // The ID of a quality and retention profile to assign to the camera. The profile's settings will override all of the per-camera quality and retention settings. If the value of this parameter is null, any existing profile will be unassigned from the camera.
 	Quality                        string `json:"quality,omitempty"`                        // Quality of the camera. Can be one of 'Standard', 'High' or 'Enhanced'. Not all qualities are supported by every camera model.
-	Resolution                     string `json:"resolution,omitempty"`                     // Resolution of the camera. Can be one of '1280x720', '1920x1080', '1080x1080', '2058x2058', '2112x2112', '2880x2880', '2688x1512' or '3840x2160'.Not all resolutions are supported by every camera model.
+	Resolution                     string `json:"resolution,omitempty"`                     // Resolution of the camera. Can be one of '1280x720', '1920x1080', '1080x1080', '2112x2112', '2880x2880', '2688x1512' or '3840x2160'.Not all resolutions are supported by every camera model.
 	RestrictedBandwidthModeEnabled *bool  `json:"restrictedBandwidthModeEnabled,omitempty"` // Boolean indicating if restricted bandwidth is enabled(true) or disabled(false) on the camera. This setting does not apply to MV2 cameras.
 }
 type RequestCameraUpdateDeviceCameraSense struct {
@@ -349,7 +506,7 @@ type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV12WE 
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV13 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2688x1512'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -361,11 +518,11 @@ type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV32 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2058x2058'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV33 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV52 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -422,7 +579,7 @@ type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV12WE 
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV13 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2688x1512'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -434,11 +591,11 @@ type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV32 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2058x2058'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV33 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV52 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -496,6 +653,48 @@ type RequestCameraCreateOrganizationCameraCustomAnalyticsArtifact struct {
 type RequestCameraUpdateOrganizationCameraOnboardingStatuses struct {
 	Serial                  string `json:"serial,omitempty"`                  // Serial of camera
 	WirelessCredentialsSent *bool  `json:"wirelessCredentialsSent,omitempty"` // Note whether credentials were sent successfully
+}
+type RequestCameraCreateOrganizationCameraRole struct {
+	AppliedOnDevices  *[]RequestCameraCreateOrganizationCameraRoleAppliedOnDevices  `json:"appliedOnDevices,omitempty"`  // Device tag on which this specified permission is applied.
+	AppliedOnNetworks *[]RequestCameraCreateOrganizationCameraRoleAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` // Network tag on which this specified permission is applied.
+	AppliedOrgWide    *[]RequestCameraCreateOrganizationCameraRoleAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    // Permissions to be applied org wide.
+	Name              string                                                        `json:"name,omitempty"`              // The name of the new role. Must be unique. This parameter is required.
+}
+type RequestCameraCreateOrganizationCameraRoleAppliedOnDevices struct {
+	ID                string `json:"id,omitempty"`                // Device id.
+	InNetworksWithID  string `json:"inNetworksWithId,omitempty"`  // Network id scope
+	InNetworksWithTag string `json:"inNetworksWithTag,omitempty"` // Network tag scope
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
+	Tag               string `json:"tag,omitempty"`               // Device tag.
+}
+type RequestCameraCreateOrganizationCameraRoleAppliedOnNetworks struct {
+	ID                string `json:"id,omitempty"`                // Network id.
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
+	Tag               string `json:"tag,omitempty"`               // Network tag
+}
+type RequestCameraCreateOrganizationCameraRoleAppliedOrgWide struct {
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
+}
+type RequestCameraUpdateOrganizationCameraRole struct {
+	AppliedOnDevices  *[]RequestCameraUpdateOrganizationCameraRoleAppliedOnDevices  `json:"appliedOnDevices,omitempty"`  // Device tag on which this specified permission is applied.
+	AppliedOnNetworks *[]RequestCameraUpdateOrganizationCameraRoleAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` // Network tag on which this specified permission is applied.
+	AppliedOrgWide    *[]RequestCameraUpdateOrganizationCameraRoleAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    // Permissions to be applied org wide.
+	Name              string                                                        `json:"name,omitempty"`              // The name of the new role. Must be unique.
+}
+type RequestCameraUpdateOrganizationCameraRoleAppliedOnDevices struct {
+	ID                string `json:"id,omitempty"`                // Device id.
+	InNetworksWithID  string `json:"inNetworksWithId,omitempty"`  // Network id scope
+	InNetworksWithTag string `json:"inNetworksWithTag,omitempty"` // Network tag scope
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
+	Tag               string `json:"tag,omitempty"`               // Device tag.
+}
+type RequestCameraUpdateOrganizationCameraRoleAppliedOnNetworks struct {
+	ID                string `json:"id,omitempty"`                // Network id
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
+	Tag               string `json:"tag,omitempty"`               // Network tag
+}
+type RequestCameraUpdateOrganizationCameraRoleAppliedOrgWide struct {
+	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
 }
 
 //GetDeviceCameraAnalyticsLive Returns live state from camera of analytics zones
@@ -1077,6 +1276,78 @@ func (s *CameraService) GetNetworkCameraWirelessProfile(networkID string, wirele
 
 }
 
+//GetOrganizationCameraBoundariesAreasByDevice Returns all configured area boundaries of cameras
+/* Returns all configured area boundaries of cameras
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCameraBoundariesAreasByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *CameraService) GetOrganizationCameraBoundariesAreasByDevice(organizationID string, getOrganizationCameraBoundariesAreasByDeviceQueryParams *GetOrganizationCameraBoundariesAreasByDeviceQueryParams) (*ResponseCameraGetOrganizationCameraBoundariesAreasByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/boundaries/areas/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCameraBoundariesAreasByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCameraGetOrganizationCameraBoundariesAreasByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraBoundariesAreasByDevice")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraBoundariesAreasByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationCameraBoundariesLinesByDevice Returns all configured crossingline boundaries of cameras
+/* Returns all configured crossingline boundaries of cameras
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCameraBoundariesLinesByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *CameraService) GetOrganizationCameraBoundariesLinesByDevice(organizationID string, getOrganizationCameraBoundariesLinesByDeviceQueryParams *GetOrganizationCameraBoundariesLinesByDeviceQueryParams) (*ResponseCameraGetOrganizationCameraBoundariesLinesByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/boundaries/lines/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCameraBoundariesLinesByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCameraGetOrganizationCameraBoundariesLinesByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraBoundariesLinesByDevice")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraBoundariesLinesByDevice)
+	return result, response, err
+
+}
+
 //GetOrganizationCameraCustomAnalyticsArtifacts List Custom Analytics Artifacts
 /* List Custom Analytics Artifacts
 
@@ -1145,6 +1416,42 @@ func (s *CameraService) GetOrganizationCameraCustomAnalyticsArtifact(organizatio
 
 }
 
+//GetOrganizationCameraDetectionsHistoryByBoundaryByInterval Returns analytics data for timespans
+/* Returns analytics data for timespans
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams Filtering parameter
+
+
+*/
+func (s *CameraService) GetOrganizationCameraDetectionsHistoryByBoundaryByInterval(organizationID string, getOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams *GetOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams) (*ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/detections/history/byBoundary/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraDetectionsHistoryByBoundaryByInterval")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval)
+	return result, response, err
+
+}
+
 //GetOrganizationCameraOnboardingStatuses Fetch onboarding status of cameras
 /* Fetch onboarding status of cameras
 
@@ -1177,6 +1484,142 @@ func (s *CameraService) GetOrganizationCameraOnboardingStatuses(organizationID s
 	}
 
 	result := response.Result().(*ResponseCameraGetOrganizationCameraOnboardingStatuses)
+	return result, response, err
+
+}
+
+//GetOrganizationCameraPermissions List the permissions scopes for this organization
+/* List the permissions scopes for this organization
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+func (s *CameraService) GetOrganizationCameraPermissions(organizationID string) (*ResponseCameraGetOrganizationCameraPermissions, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/permissions"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCameraGetOrganizationCameraPermissions{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraPermissions")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraPermissions)
+	return result, response, err
+
+}
+
+//GetOrganizationCameraPermission Retrieve a single permission scope
+/* Retrieve a single permission scope
+
+@param organizationID organizationId path parameter. Organization ID
+@param permissionScopeID permissionScopeId path parameter. Permission scope ID
+
+
+*/
+func (s *CameraService) GetOrganizationCameraPermission(organizationID string, permissionScopeID string) (*ResponseCameraGetOrganizationCameraPermission, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/permissions/{permissionScopeId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{permissionScopeId}", fmt.Sprintf("%v", permissionScopeID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCameraGetOrganizationCameraPermission{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraPermission")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraPermission)
+	return result, response, err
+
+}
+
+//GetOrganizationCameraRoles List all the roles in this organization
+/* List all the roles in this organization
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+func (s *CameraService) GetOrganizationCameraRoles(organizationID string) (*ResponseCameraGetOrganizationCameraRoles, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/roles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCameraGetOrganizationCameraRoles{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraRoles")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraRoles)
+	return result, response, err
+
+}
+
+//GetOrganizationCameraRole Retrieve a single role.
+/* Retrieve a single role.
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+
+
+*/
+func (s *CameraService) GetOrganizationCameraRole(organizationID string, roleID string) (*ResponseCameraGetOrganizationCameraRole, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCameraGetOrganizationCameraRole{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCameraRole")
+	}
+
+	result := response.Result().(*ResponseCameraGetOrganizationCameraRole)
 	return result, response, err
 
 }
@@ -1291,7 +1734,7 @@ func (s *CameraService) CreateNetworkCameraWirelessProfile(networkID string, req
 
 */
 
-func (s *CameraService) CreateOrganizationCameraCustomAnalyticsArtifact(organizationID string, requestCameraCreateOrganizationCameraCustomAnalyticsArtifact *RequestCameraCreateOrganizationCameraCustomAnalyticsArtifact) (*resty.Response, error) {
+func (s *CameraService) CreateOrganizationCameraCustomAnalyticsArtifact(organizationID string, requestCameraCreateOrganizationCameraCustomAnalyticsArtifact *RequestCameraCreateOrganizationCameraCustomAnalyticsArtifact) (*ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/customAnalytics/artifacts"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -1300,7 +1743,42 @@ func (s *CameraService) CreateOrganizationCameraCustomAnalyticsArtifact(organiza
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraCreateOrganizationCameraCustomAnalyticsArtifact).
-		// SetResult(&ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact{}).
+		SetResult(&ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationCameraCustomAnalyticsArtifact")
+	}
+
+	result := response.Result().(*ResponseCameraCreateOrganizationCameraCustomAnalyticsArtifact)
+	return result, response, err
+
+}
+
+//CreateOrganizationCameraRole Creates new role for this organization.
+/* Creates new role for this organization.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *CameraService) CreateOrganizationCameraRole(organizationID string, requestCameraCreateOrganizationCameraRole *RequestCameraCreateOrganizationCameraRole) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/roles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCameraCreateOrganizationCameraRole).
+		// SetResult(&ResponseCameraCreateOrganizationCameraRole{}).
 		SetError(&Error).
 		Post(path)
 
@@ -1310,7 +1788,7 @@ func (s *CameraService) CreateOrganizationCameraCustomAnalyticsArtifact(organiza
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationCameraCustomAnalyticsArtifact")
+		return response, fmt.Errorf("error with operation CreateOrganizationCameraRole")
 	}
 
 	return response, err
@@ -1322,7 +1800,7 @@ func (s *CameraService) CreateOrganizationCameraCustomAnalyticsArtifact(organiza
 
 @param serial serial path parameter.
 */
-func (s *CameraService) UpdateDeviceCameraCustomAnalytics(serial string, requestCameraUpdateDeviceCameraCustomAnalytics *RequestCameraUpdateDeviceCameraCustomAnalytics) (*resty.Response, error) {
+func (s *CameraService) UpdateDeviceCameraCustomAnalytics(serial string, requestCameraUpdateDeviceCameraCustomAnalytics *RequestCameraUpdateDeviceCameraCustomAnalytics) (*ResponseCameraUpdateDeviceCameraCustomAnalytics, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/customAnalytics"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -1331,19 +1809,21 @@ func (s *CameraService) UpdateDeviceCameraCustomAnalytics(serial string, request
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraUpdateDeviceCameraCustomAnalytics).
+		SetResult(&ResponseCameraUpdateDeviceCameraCustomAnalytics{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceCameraCustomAnalytics")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceCameraCustomAnalytics")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCameraUpdateDeviceCameraCustomAnalytics)
+	return result, response, err
 
 }
 
@@ -1412,7 +1892,7 @@ func (s *CameraService) UpdateDeviceCameraSense(serial string, requestCameraUpda
 
 @param serial serial path parameter.
 */
-func (s *CameraService) UpdateDeviceCameraVideoSettings(serial string, requestCameraUpdateDeviceCameraVideoSettings *RequestCameraUpdateDeviceCameraVideoSettings) (*resty.Response, error) {
+func (s *CameraService) UpdateDeviceCameraVideoSettings(serial string, requestCameraUpdateDeviceCameraVideoSettings *RequestCameraUpdateDeviceCameraVideoSettings) (*ResponseCameraUpdateDeviceCameraVideoSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/video/settings"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -1421,19 +1901,21 @@ func (s *CameraService) UpdateDeviceCameraVideoSettings(serial string, requestCa
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraUpdateDeviceCameraVideoSettings).
+		SetResult(&ResponseCameraUpdateDeviceCameraVideoSettings{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceCameraVideoSettings")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceCameraVideoSettings")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCameraUpdateDeviceCameraVideoSettings)
+	return result, response, err
 
 }
 
@@ -1561,6 +2043,38 @@ func (s *CameraService) UpdateOrganizationCameraOnboardingStatuses(organizationI
 
 }
 
+//UpdateOrganizationCameraRole Update an existing role in this organization.
+/* Update an existing role in this organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+*/
+func (s *CameraService) UpdateOrganizationCameraRole(organizationID string, roleID string, requestCameraUpdateOrganizationCameraRole *RequestCameraUpdateOrganizationCameraRole) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/camera/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCameraUpdateOrganizationCameraRole).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation UpdateOrganizationCameraRole")
+	}
+
+	return response, err
+
+}
+
 //DeleteNetworkCameraQualityRetentionProfile Delete an existing quality retention profile for this network.
 /* Delete an existing quality retention profile for this network.
 
@@ -1657,6 +2171,40 @@ func (s *CameraService) DeleteOrganizationCameraCustomAnalyticsArtifact(organiza
 
 	if response.IsError() {
 		return response, fmt.Errorf("error with operation DeleteOrganizationCameraCustomAnalyticsArtifact")
+	}
+
+	return response, err
+
+}
+
+//DeleteOrganizationCameraRole Delete an existing role for this organization.
+/* Delete an existing role for this organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+
+
+*/
+func (s *CameraService) DeleteOrganizationCameraRole(organizationID string, roleID string) (*resty.Response, error) {
+	//organizationID string,roleID string
+	path := "/api/v1/organizations/{organizationId}/camera/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteOrganizationCameraRole")
 	}
 
 	return response, err

--- a/sdk/cellular_gateway.go
+++ b/sdk/cellular_gateway.go
@@ -20,23 +20,39 @@ type GetOrganizationCellularGatewayUplinkStatusesQueryParams struct {
 }
 
 type ResponseCellularGatewayGetDeviceCellularGatewayLan struct {
-	DeviceLanIP        string                                                                  `json:"deviceLanIp,omitempty"`        //
-	DeviceName         string                                                                  `json:"deviceName,omitempty"`         //
-	DeviceSubnet       string                                                                  `json:"deviceSubnet,omitempty"`       //
-	FixedIPAssignments *[]ResponseCellularGatewayGetDeviceCellularGatewayLanFixedIPAssignments `json:"fixedIpAssignments,omitempty"` //
-	ReservedIPRanges   *[]ResponseCellularGatewayGetDeviceCellularGatewayLanReservedIPRanges   `json:"reservedIpRanges,omitempty"`   //
+	DeviceLanIP        string                                                                  `json:"deviceLanIp,omitempty"`        // Lan IP of the MG
+	DeviceName         string                                                                  `json:"deviceName,omitempty"`         // Name of the MG.
+	DeviceSubnet       string                                                                  `json:"deviceSubnet,omitempty"`       // Subnet configuration of the MG.
+	FixedIPAssignments *[]ResponseCellularGatewayGetDeviceCellularGatewayLanFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // list of all fixed IP assignments for a single MG
+	ReservedIPRanges   *[]ResponseCellularGatewayGetDeviceCellularGatewayLanReservedIPRanges   `json:"reservedIpRanges,omitempty"`   // list of all reserved IP ranges for a single MG
 }
 type ResponseCellularGatewayGetDeviceCellularGatewayLanFixedIPAssignments struct {
-	IP   string `json:"ip,omitempty"`   //
-	Mac  string `json:"mac,omitempty"`  //
-	Name string `json:"name,omitempty"` //
+	IP   string `json:"ip,omitempty"`   // The IP address you want to assign to a specific server or device
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the server or device that hosts the internal resource that you wish to receive the specified IP address
+	Name string `json:"name,omitempty"` // A descriptive name of the assignment
 }
 type ResponseCellularGatewayGetDeviceCellularGatewayLanReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` //
-	End     string `json:"end,omitempty"`     //
-	Start   string `json:"start,omitempty"`   //
+	Comment string `json:"comment,omitempty"` // Comment explaining the reserved IP range
+	End     string `json:"end,omitempty"`     // Ending IP included in the reserved range of IPs
+	Start   string `json:"start,omitempty"`   // Starting IP included in the reserved range of IPs
 }
-type ResponseCellularGatewayUpdateDeviceCellularGatewayLan interface{}
+type ResponseCellularGatewayUpdateDeviceCellularGatewayLan struct {
+	DeviceLanIP        string                                                                     `json:"deviceLanIp,omitempty"`        // Lan IP of the MG
+	DeviceName         string                                                                     `json:"deviceName,omitempty"`         // Name of the MG.
+	DeviceSubnet       string                                                                     `json:"deviceSubnet,omitempty"`       // Subnet configuration of the MG.
+	FixedIPAssignments *[]ResponseCellularGatewayUpdateDeviceCellularGatewayLanFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // list of all fixed IP assignments for a single MG
+	ReservedIPRanges   *[]ResponseCellularGatewayUpdateDeviceCellularGatewayLanReservedIPRanges   `json:"reservedIpRanges,omitempty"`   // list of all reserved IP ranges for a single MG
+}
+type ResponseCellularGatewayUpdateDeviceCellularGatewayLanFixedIPAssignments struct {
+	IP   string `json:"ip,omitempty"`   // The IP address you want to assign to a specific server or device
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the server or device that hosts the internal resource that you wish to receive the specified IP address
+	Name string `json:"name,omitempty"` // A descriptive name of the assignment
+}
+type ResponseCellularGatewayUpdateDeviceCellularGatewayLanReservedIPRanges struct {
+	Comment string `json:"comment,omitempty"` // Comment explaining the reserved IP range
+	End     string `json:"end,omitempty"`     // Ending IP included in the reserved range of IPs
+	Start   string `json:"start,omitempty"`   // Starting IP included in the reserved range of IPs
+}
 type ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRules struct {
 	Rules *[]ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` //
 }
@@ -83,13 +99,19 @@ type ResponseCellularGatewayGetNetworkCellularGatewaySubnetPoolSubnets struct {
 }
 type ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool interface{}
 type ResponseCellularGatewayGetNetworkCellularGatewayUplink struct {
-	BandwidthLimits *ResponseCellularGatewayGetNetworkCellularGatewayUplinkBandwidthLimits `json:"bandwidthLimits,omitempty"` //
+	BandwidthLimits *ResponseCellularGatewayGetNetworkCellularGatewayUplinkBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth settings for the 'cellular' uplink
 }
 type ResponseCellularGatewayGetNetworkCellularGatewayUplinkBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). 'null' indicates no limit.
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). 'null' indicates no limit.
 }
-type ResponseCellularGatewayUpdateNetworkCellularGatewayUplink interface{}
+type ResponseCellularGatewayUpdateNetworkCellularGatewayUplink struct {
+	BandwidthLimits *ResponseCellularGatewayUpdateNetworkCellularGatewayUplinkBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth settings for the 'cellular' uplink
+}
+type ResponseCellularGatewayUpdateNetworkCellularGatewayUplinkBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). 'null' indicates no limit.
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). 'null' indicates no limit.
+}
 type ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses []ResponseItemCellularGatewayGetOrganizationCellularGatewayUplinkStatuses // Array of ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses
 type ResponseItemCellularGatewayGetOrganizationCellularGatewayUplinkStatuses struct {
 	LastReportedAt string                                                                            `json:"lastReportedAt,omitempty"` // Last reported time for the device
@@ -136,7 +158,7 @@ type RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules struct
 	Rules *[]RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
 }
 type RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules struct {
-	Access     string   `json:"access,omitempty"`     // *any* or *restricted*. Specify the right to make inbound connections on the specified ports or port ranges. If *restricted*, a list of allowed IPs is mandatory.
+	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
 	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
 	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
 	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
@@ -408,7 +430,7 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayUplinkStatuses(or
 
 @param serial serial path parameter.
 */
-func (s *CellularGatewayService) UpdateDeviceCellularGatewayLan(serial string, requestCellularGatewayUpdateDeviceCellularGatewayLan *RequestCellularGatewayUpdateDeviceCellularGatewayLan) (*resty.Response, error) {
+func (s *CellularGatewayService) UpdateDeviceCellularGatewayLan(serial string, requestCellularGatewayUpdateDeviceCellularGatewayLan *RequestCellularGatewayUpdateDeviceCellularGatewayLan) (*ResponseCellularGatewayUpdateDeviceCellularGatewayLan, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellularGateway/lan"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -417,19 +439,21 @@ func (s *CellularGatewayService) UpdateDeviceCellularGatewayLan(serial string, r
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCellularGatewayUpdateDeviceCellularGatewayLan).
+		SetResult(&ResponseCellularGatewayUpdateDeviceCellularGatewayLan{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceCellularGatewayLan")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceCellularGatewayLan")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCellularGatewayUpdateDeviceCellularGatewayLan)
+	return result, response, err
 
 }
 
@@ -560,7 +584,7 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewaySubnetPool(networkI
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *CellularGatewayService) UpdateNetworkCellularGatewayUplink(networkID string, requestCellularGatewayUpdateNetworkCellularGatewayUplink *RequestCellularGatewayUpdateNetworkCellularGatewayUplink) (*resty.Response, error) {
+func (s *CellularGatewayService) UpdateNetworkCellularGatewayUplink(networkID string, requestCellularGatewayUpdateNetworkCellularGatewayUplink *RequestCellularGatewayUpdateNetworkCellularGatewayUplink) (*ResponseCellularGatewayUpdateNetworkCellularGatewayUplink, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/uplink"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -569,18 +593,20 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewayUplink(networkID st
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCellularGatewayUpdateNetworkCellularGatewayUplink).
+		SetResult(&ResponseCellularGatewayUpdateNetworkCellularGatewayUplink{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkCellularGatewayUplink")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkCellularGatewayUplink")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCellularGatewayUpdateNetworkCellularGatewayUplink)
+	return result, response, err
 
 }

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -19,36 +19,116 @@ type GetDeviceLossAndLatencyHistoryQueryParams struct {
 	T1         string  `url:"t1,omitempty"`         //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
 	Timespan   float64 `url:"timespan,omitempty"`   //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
 	Resolution int     `url:"resolution,omitempty"` //The time resolution in seconds for returned data. The valid resolutions are: 60, 600, 3600, 86400. The default is 60.
-	Uplink     string  `url:"uplink,omitempty"`     //The WAN uplink used to obtain the requested stats. Valid uplinks are wan1, wan2, cellular. The default is wan1.
+	Uplink     string  `url:"uplink,omitempty"`     //The WAN uplink used to obtain the requested stats. Valid uplinks are wan1, wan2, wan3, cellular. The default is wan1.
 	IP         string  `url:"ip,omitempty"`         //The destination IP used to obtain the requested stats. This is required.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesPacketLossByClientQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	Macs          []string `url:"macs[],omitempty"`        //Filter results by client mac address(es).
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
+}
+type GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
+}
+type GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
 }
 
 type ResponseDevicesGetDevice struct {
-	Address        string                                  `json:"address,omitempty"`        //
-	BeaconIDParams *ResponseDevicesGetDeviceBeaconIDParams `json:"beaconIdParams,omitempty"` //
-	Firmware       string                                  `json:"firmware,omitempty"`       //
-	FloorPlanID    string                                  `json:"floorPlanId,omitempty"`    //
-	LanIP          string                                  `json:"lanIp,omitempty"`          //
-	Lat            *float64                                `json:"lat,omitempty"`            //
-	Lng            *float64                                `json:"lng,omitempty"`            //
-	Mac            string                                  `json:"mac,omitempty"`            //
-	Model          string                                  `json:"model,omitempty"`          //
-	Name           string                                  `json:"name,omitempty"`           //
-	NetworkID      string                                  `json:"networkId,omitempty"`      //
-	Notes          string                                  `json:"notes,omitempty"`          //
-	Serial         string                                  `json:"serial,omitempty"`         //
-	Tags           []string                                `json:"tags,omitempty"`           //
+	Address     string                             `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseDevicesGetDeviceDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                             `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                             `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                             `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                           `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                           `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                             `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                             `json:"model,omitempty"`       // Model of the device
+	Name        string                             `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                             `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                             `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                             `json:"productType,omitempty"` // Product type of the device
+	Serial      string                             `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                           `json:"tags,omitempty"`        // List of tags assigned to the device
 }
-type ResponseDevicesGetDeviceBeaconIDParams struct {
-	Major *int   `json:"major,omitempty"` //
-	Minor *int   `json:"minor,omitempty"` //
-	UUID  string `json:"uuid,omitempty"`  //
+type ResponseDevicesGetDeviceDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseDevicesUpdateDevice interface{}
 type ResponseDevicesBlinkDeviceLeds struct {
-	Duration *int `json:"duration,omitempty"` //
-	Duty     *int `json:"duty,omitempty"`     //
-	Period   *int `json:"period,omitempty"`   //
+	Duration *int `json:"duration,omitempty"` // The duration in seconds. Will be between 5 and 120. Default is 20 seconds
+	Duty     *int `json:"duty,omitempty"`     // The duty cycle as the percent active. Will be between 10 and 90. Default is 50
+	Period   *int `json:"period,omitempty"`   // The period in milliseconds. Will be between 100 and 1000. Default is 160 milliseconds
 }
 type ResponseDevicesGetDeviceCellularSims struct {
 	Sims *[]ResponseDevicesGetDeviceCellularSimsSims `json:"sims,omitempty"` //
@@ -70,26 +150,106 @@ type ResponseDevicesGetDeviceCellularSimsSimsApnsAuthentication struct {
 type ResponseDevicesUpdateDeviceCellularSims interface{}
 type ResponseDevicesGetDeviceClients []ResponseItemDevicesGetDeviceClients // Array of ResponseDevicesGetDeviceClients
 type ResponseItemDevicesGetDeviceClients struct {
-	Description  string                                    `json:"description,omitempty"`  //
-	DhcpHostname string                                    `json:"dhcpHostname,omitempty"` //
-	ID           string                                    `json:"id,omitempty"`           //
-	IP           string                                    `json:"ip,omitempty"`           //
-	Mac          string                                    `json:"mac,omitempty"`          //
-	MdnsName     string                                    `json:"mdnsName,omitempty"`     //
-	NamedVLAN    string                                    `json:"namedVlan,omitempty"`    //
-	Usage        *ResponseItemDevicesGetDeviceClientsUsage `json:"usage,omitempty"`        //
-	User         string                                    `json:"user,omitempty"`         //
-	VLAN         string                                    `json:"vlan,omitempty"`         //
+	AdaptivePolicyGroup string                                    `json:"adaptivePolicyGroup,omitempty"` // A description of the adaptive policy group
+	Description         string                                    `json:"description,omitempty"`         // Short description of the client
+	DhcpHostname        string                                    `json:"dhcpHostname,omitempty"`        // The client's DHCP hostname
+	ID                  string                                    `json:"id,omitempty"`                  // The ID of the client
+	IP                  string                                    `json:"ip,omitempty"`                  // The IP address of the client
+	Mac                 string                                    `json:"mac,omitempty"`                 // The MAC address of the client
+	MdnsName            string                                    `json:"mdnsName,omitempty"`            // The client's MDNS name
+	NamedVLAN           string                                    `json:"namedVlan,omitempty"`           // The owner-assigned name of the VLAN the client is connected to
+	Switchport          string                                    `json:"switchport,omitempty"`          // The name of the switchport with clients on it, if the device is a switch
+	Usage               *ResponseItemDevicesGetDeviceClientsUsage `json:"usage,omitempty"`               // Client usage data for sent and received
+	User                string                                    `json:"user,omitempty"`                // The client user's name
+	VLAN                string                                    `json:"vlan,omitempty"`                // The client-assigned name of the VLAN the client is connected to
 }
 type ResponseItemDevicesGetDeviceClientsUsage struct {
-	Recv *int `json:"recv,omitempty"` //
-	Sent *int `json:"sent,omitempty"` //
+	Recv *float64 `json:"recv,omitempty"` // Usage received by the client
+	Sent *float64 `json:"sent,omitempty"` // Usage sent by the client
+}
+type ResponseDevicesCreateDeviceLiveToolsArpTable struct {
+	ArpTableID string                                                `json:"arpTableId,omitempty"` // Id of the ARP table request. Used to check the status of the request.
+	Callback   *ResponseDevicesCreateDeviceLiveToolsArpTableCallback `json:"callback,omitempty"`   // Information for callback used to send back results
+	Request    *ResponseDevicesCreateDeviceLiveToolsArpTableRequest  `json:"request,omitempty"`    // ARP table request parameters
+	Status     string                                                `json:"status,omitempty"`     // Status of the ARP table request.
+	URL        string                                                `json:"url,omitempty"`        // GET this url to check the status of your ARP table request.
+}
+type ResponseDevicesCreateDeviceLiveToolsArpTableCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
+}
+type ResponseDevicesCreateDeviceLiveToolsArpTableRequest struct {
+	Serial string `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesGetDeviceLiveToolsArpTable struct {
+	ArpTableID string                                              `json:"arpTableId,omitempty"` // Id of the ARP table request. Used to check the status of the request.
+	Entries    *[]ResponseDevicesGetDeviceLiveToolsArpTableEntries `json:"entries,omitempty"`    // The ARP table entries
+	Error      string                                              `json:"error,omitempty"`      // An error message for a failed execution
+	Request    *ResponseDevicesGetDeviceLiveToolsArpTableRequest   `json:"request,omitempty"`    // ARP table request parameters
+	Status     string                                              `json:"status,omitempty"`     // Status of the ARP table request.
+	URL        string                                              `json:"url,omitempty"`        // GET this url to check the status of your ARP table request.
+}
+type ResponseDevicesGetDeviceLiveToolsArpTableEntries struct {
+	IP            string `json:"ip,omitempty"`            // The IP address of the ARP table entry
+	LastUpdatedAt string `json:"lastUpdatedAt,omitempty"` // Time of the last update of the ARP table entry
+	Mac           string `json:"mac,omitempty"`           // The MAC address of the ARP table entry
+	VLANID        *int   `json:"vlanId,omitempty"`        // The VLAN ID of the ARP table entry
+}
+type ResponseDevicesGetDeviceLiveToolsArpTableRequest struct {
+	Serial string `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesCreateDeviceLiveToolsCableTest struct {
+	CableTestID string                                                 `json:"cableTestId,omitempty"` // Id of the cable test request. Used to check the status of the request.
+	Callback    *ResponseDevicesCreateDeviceLiveToolsCableTestCallback `json:"callback,omitempty"`    // Information for callback used to send back results
+	Request     *ResponseDevicesCreateDeviceLiveToolsCableTestRequest  `json:"request,omitempty"`     // Cable test request parameters
+	Status      string                                                 `json:"status,omitempty"`      // Status of the cable test request.
+	URL         string                                                 `json:"url,omitempty"`         // GET this url to check the status of your cable test request.
+}
+type ResponseDevicesCreateDeviceLiveToolsCableTestCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
+}
+type ResponseDevicesCreateDeviceLiveToolsCableTestRequest struct {
+	Ports  []string `json:"ports,omitempty"`  // A list of ports for which to perform the cable test.
+	Serial string   `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesGetDeviceLiveToolsCableTest struct {
+	CableTestID string                                               `json:"cableTestId,omitempty"` // Id of the cable test request. Used to check the status of the request.
+	Error       string                                               `json:"error,omitempty"`       // An error message for a failed execution
+	Request     *ResponseDevicesGetDeviceLiveToolsCableTestRequest   `json:"request,omitempty"`     // Cable test request parameters
+	Results     *[]ResponseDevicesGetDeviceLiveToolsCableTestResults `json:"results,omitempty"`     // Results of the cable test request, one for each requested port.
+	Status      string                                               `json:"status,omitempty"`      // Status of the cable test request.
+	URL         string                                               `json:"url,omitempty"`         // GET this url to check the status of your cable test request.
+}
+type ResponseDevicesGetDeviceLiveToolsCableTestRequest struct {
+	Ports  []string `json:"ports,omitempty"`  // A list of ports for which to perform the cable test.
+	Serial string   `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesGetDeviceLiveToolsCableTestResults struct {
+	Error     string                                                    `json:"error,omitempty"`     // If an error occurred during the cable test, the error message will be populated here.
+	Pairs     *[]ResponseDevicesGetDeviceLiveToolsCableTestResultsPairs `json:"pairs,omitempty"`     // Results for each twisted pair within the cable.
+	Port      string                                                    `json:"port,omitempty"`      // The port for which the test was performed.
+	SpeedMbps *int                                                      `json:"speedMbps,omitempty"` // Speed in Mbps.  A speed of 0 indicates the port is down or the port speed is automatic.
+	Status    string                                                    `json:"status,omitempty"`    // The current status of the port. If the cable test is still being performed on the port, "in-progress" is used. If an error occurred during the cable test, "error" is used and the error property will be populated.
+}
+type ResponseDevicesGetDeviceLiveToolsCableTestResultsPairs struct {
+	Index        *int   `json:"index,omitempty"`        // The index of the twisted pair tested.
+	LengthMeters *int   `json:"lengthMeters,omitempty"` // The detected length of the twisted pair.
+	Status       string `json:"status,omitempty"`       // The test result of the twisted pair tested.
 }
 type ResponseDevicesCreateDeviceLiveToolsPing struct {
-	PingID  string                                           `json:"pingId,omitempty"`  // Id to check the status of your ping request.
-	Request *ResponseDevicesCreateDeviceLiveToolsPingRequest `json:"request,omitempty"` // Ping request parameters
-	Status  string                                           `json:"status,omitempty"`  // Status of the ping request.
-	URL     string                                           `json:"url,omitempty"`     // GET this url to check the status of your ping request.
+	Callback *ResponseDevicesCreateDeviceLiveToolsPingCallback `json:"callback,omitempty"` // Information for callback used to send back results
+	PingID   string                                            `json:"pingId,omitempty"`   // Id to check the status of your ping request.
+	Request  *ResponseDevicesCreateDeviceLiveToolsPingRequest  `json:"request,omitempty"`  // Ping request parameters
+	Status   string                                            `json:"status,omitempty"`   // Status of the ping request.
+	URL      string                                            `json:"url,omitempty"`      // GET this url to check the status of your ping request.
+}
+type ResponseDevicesCreateDeviceLiveToolsPingCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesCreateDeviceLiveToolsPingRequest struct {
 	Count  *int   `json:"count,omitempty"`  // Number of pings to send
@@ -129,10 +289,16 @@ type ResponseDevicesGetDeviceLiveToolsPingResultsReplies struct {
 	Size       *int     `json:"size,omitempty"`       // Size of the packet in bytes
 }
 type ResponseDevicesCreateDeviceLiveToolsPingDevice struct {
-	PingID  string                                                 `json:"pingId,omitempty"`  // Id to check the status of your ping request.
-	Request *ResponseDevicesCreateDeviceLiveToolsPingDeviceRequest `json:"request,omitempty"` // Ping request parameters
-	Status  string                                                 `json:"status,omitempty"`  // Status of the ping request.
-	URL     string                                                 `json:"url,omitempty"`     // GET this url to check the status of your ping request.
+	Callback *ResponseDevicesCreateDeviceLiveToolsPingDeviceCallback `json:"callback,omitempty"` // Information for callback used to send back results
+	PingID   string                                                  `json:"pingId,omitempty"`   // Id to check the status of your ping request.
+	Request  *ResponseDevicesCreateDeviceLiveToolsPingDeviceRequest  `json:"request,omitempty"`  // Ping request parameters
+	Status   string                                                  `json:"status,omitempty"`   // Status of the ping request.
+	URL      string                                                  `json:"url,omitempty"`      // GET this url to check the status of your ping request.
+}
+type ResponseDevicesCreateDeviceLiveToolsPingDeviceCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesCreateDeviceLiveToolsPingDeviceRequest struct {
 	Count  *int   `json:"count,omitempty"`  // Number of pings to send
@@ -140,11 +306,17 @@ type ResponseDevicesCreateDeviceLiveToolsPingDeviceRequest struct {
 	Target string `json:"target,omitempty"` // IP address or FQDN to ping
 }
 type ResponseDevicesGetDeviceLiveToolsPingDevice struct {
-	PingID  string                                              `json:"pingId,omitempty"`  // Id to check the status of your ping request.
-	Request *ResponseDevicesGetDeviceLiveToolsPingDeviceRequest `json:"request,omitempty"` // Ping request parameters
-	Results *ResponseDevicesGetDeviceLiveToolsPingDeviceResults `json:"results,omitempty"` // Results of the ping request.
-	Status  string                                              `json:"status,omitempty"`  // Status of the ping request.
-	URL     string                                              `json:"url,omitempty"`     // GET this url to check the status of your ping request.
+	Callback *ResponseDevicesGetDeviceLiveToolsPingDeviceCallback `json:"callback,omitempty"` // Information for callback used to send back results
+	PingID   string                                               `json:"pingId,omitempty"`   // Id to check the status of your ping request.
+	Request  *ResponseDevicesGetDeviceLiveToolsPingDeviceRequest  `json:"request,omitempty"`  // Ping request parameters
+	Results  *ResponseDevicesGetDeviceLiveToolsPingDeviceResults  `json:"results,omitempty"`  // Results of the ping request.
+	Status   string                                               `json:"status,omitempty"`   // Status of the ping request.
+	URL      string                                               `json:"url,omitempty"`      // GET this url to check the status of your ping request.
+}
+type ResponseDevicesGetDeviceLiveToolsPingDeviceCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesGetDeviceLiveToolsPingDeviceRequest struct {
 	Count  *int   `json:"count,omitempty"`  // Number of pings to send
@@ -171,9 +343,79 @@ type ResponseDevicesGetDeviceLiveToolsPingDeviceResultsReplies struct {
 	SequenceID *int     `json:"sequenceId,omitempty"` // Sequence ID of the packet
 	Size       *int     `json:"size,omitempty"`       // Size of the packet in bytes
 }
+type ResponseDevicesCreateDeviceLiveToolsThroughputTest struct {
+	Callback         *ResponseDevicesCreateDeviceLiveToolsThroughputTestCallback `json:"callback,omitempty"`         // Information for callback used to send back results
+	Error            string                                                      `json:"error,omitempty"`            // Description of the error.
+	Request          *ResponseDevicesCreateDeviceLiveToolsThroughputTestRequest  `json:"request,omitempty"`          // The parameters of the throughput test request
+	Result           *ResponseDevicesCreateDeviceLiveToolsThroughputTestResult   `json:"result,omitempty"`           // Result of the throughput test request
+	Status           string                                                      `json:"status,omitempty"`           // Status of the throughput test request
+	ThroughputTestID string                                                      `json:"throughputTestId,omitempty"` // ID of throughput test job
+	URL              string                                                      `json:"url,omitempty"`              // GET this url to check the status of your throughput test request
+}
+type ResponseDevicesCreateDeviceLiveToolsThroughputTestCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
+}
+type ResponseDevicesCreateDeviceLiveToolsThroughputTestRequest struct {
+	Serial string `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesCreateDeviceLiveToolsThroughputTestResult struct {
+	Speeds *ResponseDevicesCreateDeviceLiveToolsThroughputTestResultSpeeds `json:"speeds,omitempty"` // Shows the speeds (Mbps)
+}
+type ResponseDevicesCreateDeviceLiveToolsThroughputTestResultSpeeds struct {
+	Downstream *int `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
+}
+type ResponseDevicesGetDeviceLiveToolsThroughputTest struct {
+	Error            string                                                  `json:"error,omitempty"`            // Description of the error.
+	Request          *ResponseDevicesGetDeviceLiveToolsThroughputTestRequest `json:"request,omitempty"`          // The parameters of the throughput test request
+	Result           *ResponseDevicesGetDeviceLiveToolsThroughputTestResult  `json:"result,omitempty"`           // Result of the throughput test request
+	Status           string                                                  `json:"status,omitempty"`           // Status of the throughput test request
+	ThroughputTestID string                                                  `json:"throughputTestId,omitempty"` // ID of throughput test job
+	URL              string                                                  `json:"url,omitempty"`              // GET this url to check the status of your throughput test request
+}
+type ResponseDevicesGetDeviceLiveToolsThroughputTestRequest struct {
+	Serial string `json:"serial,omitempty"` // Device serial number
+}
+type ResponseDevicesGetDeviceLiveToolsThroughputTestResult struct {
+	Speeds *ResponseDevicesGetDeviceLiveToolsThroughputTestResultSpeeds `json:"speeds,omitempty"` // Shows the speeds (Mbps)
+}
+type ResponseDevicesGetDeviceLiveToolsThroughputTestResultSpeeds struct {
+	Downstream *int `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
+}
+type ResponseDevicesCreateDeviceLiveToolsWakeOnLan struct {
+	Callback    *ResponseDevicesCreateDeviceLiveToolsWakeOnLanCallback `json:"callback,omitempty"`    // Information for callback used to send back results
+	Error       string                                                 `json:"error,omitempty"`       // An error message for a failed execution
+	Request     *ResponseDevicesCreateDeviceLiveToolsWakeOnLanRequest  `json:"request,omitempty"`     // The parameters of the Wake-on-LAN request
+	Status      string                                                 `json:"status,omitempty"`      // Status of the Wake-on-LAN request
+	URL         string                                                 `json:"url,omitempty"`         // GET this url to check the status of your ping request
+	WakeOnLanID string                                                 `json:"wakeOnLanId,omitempty"` // ID of the Wake-on-LAN job
+}
+type ResponseDevicesCreateDeviceLiveToolsWakeOnLanCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
+}
+type ResponseDevicesCreateDeviceLiveToolsWakeOnLanRequest struct {
+	Mac    string `json:"mac,omitempty"`    // The target's MAC address
+	Serial string `json:"serial,omitempty"` // Device serial number
+	VLANID *int   `json:"vlanId,omitempty"` // The target's VLAN (1 to 4094)
+}
+type ResponseDevicesGetDeviceLiveToolsWakeOnLan struct {
+	Error       string                                             `json:"error,omitempty"`       // An error message for a failed execution
+	Request     *ResponseDevicesGetDeviceLiveToolsWakeOnLanRequest `json:"request,omitempty"`     // The parameters of the Wake-on-LAN request
+	Status      string                                             `json:"status,omitempty"`      // Status of the Wake-on-LAN request
+	URL         string                                             `json:"url,omitempty"`         // GET this url to check the status of your ping request
+	WakeOnLanID string                                             `json:"wakeOnLanId,omitempty"` // ID of the Wake-on-LAN job
+}
+type ResponseDevicesGetDeviceLiveToolsWakeOnLanRequest struct {
+	Mac    string `json:"mac,omitempty"`    // The target's MAC address
+	Serial string `json:"serial,omitempty"` // Device serial number
+	VLANID *int   `json:"vlanId,omitempty"` // The target's VLAN (1 to 4094)
+}
 type ResponseDevicesGetDeviceLldpCdp struct {
-	Ports     *ResponseDevicesGetDeviceLldpCdpPorts `json:"ports,omitempty"`     //
-	SourceMac string                                `json:"sourceMac,omitempty"` //
+	Ports     *ResponseDevicesGetDeviceLldpCdpPorts `json:"ports,omitempty"`     // Mapping of ports to lldp and/or cdp information
+	SourceMac string                                `json:"sourceMac,omitempty"` // Source MAC address
 }
 type ResponseDevicesGetDeviceLldpCdpPorts struct {
 	Status12 *ResponseDevicesGetDeviceLldpCdpPorts12 `json:"12,omitempty"` //
@@ -206,62 +448,118 @@ type ResponseDevicesGetDeviceLldpCdpPorts8Cdp struct {
 }
 type ResponseDevicesGetDeviceLossAndLatencyHistory []ResponseItemDevicesGetDeviceLossAndLatencyHistory // Array of ResponseDevicesGetDeviceLossAndLatencyHistory
 type ResponseItemDevicesGetDeviceLossAndLatencyHistory struct {
-	EndTime     string   `json:"endTime,omitempty"`     //
-	Goodput     *int     `json:"goodput,omitempty"`     //
-	Jitter      *float64 `json:"jitter,omitempty"`      //
-	LatencyMs   *float64 `json:"latencyMs,omitempty"`   //
-	LossPercent *float64 `json:"lossPercent,omitempty"` //
-	StartTime   string   `json:"startTime,omitempty"`   //
+	EndTime     string   `json:"endTime,omitempty"`     // End time of the sample
+	Goodput     *int     `json:"goodput,omitempty"`     // Number of useful information bits delivered
+	Jitter      *float64 `json:"jitter,omitempty"`      // Jitter, in milliseconds
+	LatencyMs   *float64 `json:"latencyMs,omitempty"`   // Latency in milliseconds
+	LossPercent *float64 `json:"lossPercent,omitempty"` // Percentage of packets lost
+	StartTime   string   `json:"startTime,omitempty"`   // Start time of the sample
 }
 type ResponseDevicesGetDeviceManagementInterface struct {
-	DdnsHostnames *ResponseDevicesGetDeviceManagementInterfaceDdnsHostnames `json:"ddnsHostnames,omitempty"` //
-	Wan1          *ResponseDevicesGetDeviceManagementInterfaceWan1          `json:"wan1,omitempty"`          //
-	Wan2          *ResponseDevicesGetDeviceManagementInterfaceWan2          `json:"wan2,omitempty"`          //
+	DdnsHostnames *ResponseDevicesGetDeviceManagementInterfaceDdnsHostnames `json:"ddnsHostnames,omitempty"` // Dynamic DNS hostnames.
+	Wan1          *ResponseDevicesGetDeviceManagementInterfaceWan1          `json:"wan1,omitempty"`          // WAN 1 settings
+	Wan2          *ResponseDevicesGetDeviceManagementInterfaceWan2          `json:"wan2,omitempty"`          // WAN 2 settings (only for MX devices)
 }
 type ResponseDevicesGetDeviceManagementInterfaceDdnsHostnames struct {
-	ActiveDdnsHostname string `json:"activeDdnsHostname,omitempty"` //
-	DdnsHostnameWan1   string `json:"ddnsHostnameWan1,omitempty"`   //
-	DdnsHostnameWan2   string `json:"ddnsHostnameWan2,omitempty"`   //
+	ActiveDdnsHostname string `json:"activeDdnsHostname,omitempty"` // Active dynamic DNS hostname.
+	DdnsHostnameWan1   string `json:"ddnsHostnameWan1,omitempty"`   // WAN 1 dynamic DNS hostname.
+	DdnsHostnameWan2   string `json:"ddnsHostnameWan2,omitempty"`   // WAN 2 dynamic DNS hostname.
 }
 type ResponseDevicesGetDeviceManagementInterfaceWan1 struct {
-	StaticDNS        []string `json:"staticDns,omitempty"`        //
-	StaticGatewayIP  string   `json:"staticGatewayIp,omitempty"`  //
-	StaticIP         string   `json:"staticIp,omitempty"`         //
-	StaticSubnetMask string   `json:"staticSubnetMask,omitempty"` //
-	UsingStaticIP    *bool    `json:"usingStaticIp,omitempty"`    //
-	VLAN             *int     `json:"vlan,omitempty"`             //
-	WanEnabled       string   `json:"wanEnabled,omitempty"`       //
+	StaticDNS        []string `json:"staticDns,omitempty"`        // Up to two DNS IPs.
+	StaticGatewayIP  string   `json:"staticGatewayIp,omitempty"`  // The IP of the gateway on the WAN.
+	StaticIP         string   `json:"staticIp,omitempty"`         // The IP the device should use on the WAN.
+	StaticSubnetMask string   `json:"staticSubnetMask,omitempty"` // The subnet mask for the WAN.
+	UsingStaticIP    *bool    `json:"usingStaticIp,omitempty"`    // Configure the interface to have static IP settings or use DHCP.
+	VLAN             *int     `json:"vlan,omitempty"`             // The VLAN that management traffic should be tagged with. Applies whether usingStaticIp is true or false.
+	WanEnabled       string   `json:"wanEnabled,omitempty"`       // Enable or disable the interface (only for MX devices). Valid values are 'enabled', 'disabled', and 'not configured'.
 }
 type ResponseDevicesGetDeviceManagementInterfaceWan2 struct {
-	UsingStaticIP *bool  `json:"usingStaticIp,omitempty"` //
-	VLAN          *int   `json:"vlan,omitempty"`          //
-	WanEnabled    string `json:"wanEnabled,omitempty"`    //
+	StaticDNS        []string `json:"staticDns,omitempty"`        // Up to two DNS IPs.
+	StaticGatewayIP  string   `json:"staticGatewayIp,omitempty"`  // The IP of the gateway on the WAN.
+	StaticIP         string   `json:"staticIp,omitempty"`         // The IP the device should use on the WAN.
+	StaticSubnetMask string   `json:"staticSubnetMask,omitempty"` // The subnet mask for the WAN.
+	UsingStaticIP    *bool    `json:"usingStaticIp,omitempty"`    // Configure the interface to have static IP settings or use DHCP.
+	VLAN             *int     `json:"vlan,omitempty"`             // The VLAN that management traffic should be tagged with. Applies whether usingStaticIp is true or false.
+	WanEnabled       string   `json:"wanEnabled,omitempty"`       // Enable or disable the interface (only for MX devices). Valid values are 'enabled', 'disabled', and 'not configured'.
 }
-type ResponseDevicesUpdateDeviceManagementInterface interface{}
-type ResponseDevicesRebootDevice interface{}
+type ResponseDevicesUpdateDeviceManagementInterface struct {
+	DdnsHostnames *ResponseDevicesUpdateDeviceManagementInterfaceDdnsHostnames `json:"ddnsHostnames,omitempty"` // Dynamic DNS hostnames.
+	Wan1          *ResponseDevicesUpdateDeviceManagementInterfaceWan1          `json:"wan1,omitempty"`          // WAN 1 settings
+	Wan2          *ResponseDevicesUpdateDeviceManagementInterfaceWan2          `json:"wan2,omitempty"`          // WAN 2 settings (only for MX devices)
+}
+type ResponseDevicesUpdateDeviceManagementInterfaceDdnsHostnames struct {
+	ActiveDdnsHostname string `json:"activeDdnsHostname,omitempty"` // Active dynamic DNS hostname.
+	DdnsHostnameWan1   string `json:"ddnsHostnameWan1,omitempty"`   // WAN 1 dynamic DNS hostname.
+	DdnsHostnameWan2   string `json:"ddnsHostnameWan2,omitempty"`   // WAN 2 dynamic DNS hostname.
+}
+type ResponseDevicesUpdateDeviceManagementInterfaceWan1 struct {
+	StaticDNS        []string `json:"staticDns,omitempty"`        // Up to two DNS IPs.
+	StaticGatewayIP  string   `json:"staticGatewayIp,omitempty"`  // The IP of the gateway on the WAN.
+	StaticIP         string   `json:"staticIp,omitempty"`         // The IP the device should use on the WAN.
+	StaticSubnetMask string   `json:"staticSubnetMask,omitempty"` // The subnet mask for the WAN.
+	UsingStaticIP    *bool    `json:"usingStaticIp,omitempty"`    // Configure the interface to have static IP settings or use DHCP.
+	VLAN             *int     `json:"vlan,omitempty"`             // The VLAN that management traffic should be tagged with. Applies whether usingStaticIp is true or false.
+	WanEnabled       string   `json:"wanEnabled,omitempty"`       // Enable or disable the interface (only for MX devices). Valid values are 'enabled', 'disabled', and 'not configured'.
+}
+type ResponseDevicesUpdateDeviceManagementInterfaceWan2 struct {
+	StaticDNS        []string `json:"staticDns,omitempty"`        // Up to two DNS IPs.
+	StaticGatewayIP  string   `json:"staticGatewayIp,omitempty"`  // The IP of the gateway on the WAN.
+	StaticIP         string   `json:"staticIp,omitempty"`         // The IP the device should use on the WAN.
+	StaticSubnetMask string   `json:"staticSubnetMask,omitempty"` // The subnet mask for the WAN.
+	UsingStaticIP    *bool    `json:"usingStaticIp,omitempty"`    // Configure the interface to have static IP settings or use DHCP.
+	VLAN             *int     `json:"vlan,omitempty"`             // The VLAN that management traffic should be tagged with. Applies whether usingStaticIp is true or false.
+	WanEnabled       string   `json:"wanEnabled,omitempty"`       // Enable or disable the interface (only for MX devices). Valid values are 'enabled', 'disabled', and 'not configured'.
+}
+type ResponseDevicesRebootDevice struct {
+	Success *bool `json:"success,omitempty"` // Shows the success of the reboot
+}
 type ResponseDevicesGetNetworkDevices []ResponseItemDevicesGetNetworkDevices // Array of ResponseDevicesGetNetworkDevices
 type ResponseItemDevicesGetNetworkDevices struct {
-	Address        string                                              `json:"address,omitempty"`        //
-	BeaconIDParams *ResponseItemDevicesGetNetworkDevicesBeaconIDParams `json:"beaconIdParams,omitempty"` //
-	Firmware       string                                              `json:"firmware,omitempty"`       //
-	FloorPlanID    string                                              `json:"floorPlanId,omitempty"`    //
-	LanIP          string                                              `json:"lanIp,omitempty"`          //
-	Lat            *float64                                            `json:"lat,omitempty"`            //
-	Lng            *float64                                            `json:"lng,omitempty"`            //
-	Mac            string                                              `json:"mac,omitempty"`            //
-	Model          string                                              `json:"model,omitempty"`          //
-	Name           string                                              `json:"name,omitempty"`           //
-	NetworkID      string                                              `json:"networkId,omitempty"`      //
-	Notes          string                                              `json:"notes,omitempty"`          //
-	Serial         string                                              `json:"serial,omitempty"`         //
-	Tags           string                                              `json:"tags,omitempty"`           //
+	Address     string                                         `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseItemDevicesGetNetworkDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                         `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                         `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                         `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                       `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                       `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                         `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                         `json:"model,omitempty"`       // Model of the device
+	Name        string                                         `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                         `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                         `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                         `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                         `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                       `json:"tags,omitempty"`        // List of tags assigned to the device
 }
-type ResponseItemDevicesGetNetworkDevicesBeaconIDParams struct {
-	Major *int   `json:"major,omitempty"` //
-	Minor *int   `json:"minor,omitempty"` //
-	UUID  string `json:"uuid,omitempty"`  //
+type ResponseItemDevicesGetNetworkDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
-type ResponseDevicesVmxNetworkDevicesClaim interface{}
+type ResponseDevicesClaimNetworkDevices struct {
+	Serials []string `json:"serials,omitempty"` // The serials of the devices
+}
+type ResponseDevicesVmxNetworkDevicesClaim struct {
+	Address     string                                          `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseDevicesVmxNetworkDevicesClaimDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                          `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                          `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                          `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                        `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                        `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                          `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                          `json:"model,omitempty"`       // Model of the device
+	Name        string                                          `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                          `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                          `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                          `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                          `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                        `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseDevicesVmxNetworkDevicesClaimDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
 type ResponseDevicesCheckinNetworkSmDevices struct {
 	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of devices.
 }
@@ -286,6 +584,12 @@ type ResponseItemDevicesModifyNetworkSmDevicesTags struct {
 type ResponseDevicesMoveNetworkSmDevices struct {
 	IDs        []string `json:"ids,omitempty"`        // The Meraki Ids of the set of devices.
 	NewNetwork string   `json:"newNetwork,omitempty"` // The network to which the devices was moved.
+}
+type ResponseDevicesRebootNetworkSmDevices struct {
+	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of endpoints.
+}
+type ResponseDevicesShutdownNetworkSmDevices struct {
+	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of endpoints.
 }
 type ResponseDevicesWipeNetworkSmDevices struct {
 	ID string `json:"id,omitempty"` // The Meraki Id of the devices.
@@ -379,36 +683,197 @@ type ResponseItemDevicesGetNetworkSmDeviceSoftwares struct {
 	Vendor            string `json:"vendor,omitempty"`            // The vendor of the software.
 	Version           string `json:"version,omitempty"`           // Full version notation for the software.
 }
-type ResponseDevicesUnenrollNetworkSmDevice interface{}
+type ResponseDevicesUnenrollNetworkSmDevice struct {
+	Success *bool `json:"success,omitempty"` // Boolean indicating whether the operation was completed successfully.
+}
 type ResponseDevicesGetNetworkSmDeviceWLANLists []ResponseItemDevicesGetNetworkSmDeviceWLANLists // Array of ResponseDevicesGetNetworkSmDeviceWlanLists
 type ResponseItemDevicesGetNetworkSmDeviceWLANLists struct {
 	CreatedAt string `json:"createdAt,omitempty"` // When the Meraki record for the wlanList was created.
 	ID        string `json:"id,omitempty"`        // The Meraki managed Id of the wlanList record.
 	Xml       string `json:"xml,omitempty"`       // An XML string containing the WLAN List for the device.
 }
-type ResponseDevicesGetOrganizationInventoryDevice struct {
-	ClaimedAt             string   `json:"claimedAt,omitempty"`             // Claimed time of the device
-	LicenseExpirationDate string   `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
-	Mac                   string   `json:"mac,omitempty"`                   // MAC address of the device
-	Model                 string   `json:"model,omitempty"`                 // Model type of the device
-	Name                  string   `json:"name,omitempty"`                  // Name of the device
-	NetworkID             string   `json:"networkId,omitempty"`             // Network Id of the device
-	OrderNumber           string   `json:"orderNumber,omitempty"`           // Order number of the device
-	ProductType           string   `json:"productType,omitempty"`           // Product type of the device
-	Serial                string   `json:"serial,omitempty"`                // Serial number of the device
-	Tags                  []string `json:"tags,omitempty"`                  // Device tags
+
+type ResponseOrganizationsCloneOrganizationSwitchDevices interface{}
+type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
+	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Mac     string                                                                                     `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                                     `json:"serial,omitempty"`  // The serial number for the device.
 }
-type ResponseDevicesCloneOrganizationSwitchDevices interface{}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand struct {
+	Band    string                                                                                          `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork struct {
+	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand struct {
+	Band    string                                                                                           `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval struct {
+	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                      `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Mac     string                                                                                                      `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                                                      `json:"serial,omitempty"`  // The serial number for the device.
+	StartTs string                                                                                                      `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand struct {
+	Band    string                                                                                                           `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval struct {
+	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                       `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	StartTs string                                                                                                       `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand struct {
+	Band    string                                                                                                            `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByClient []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClient // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByClient
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClient struct {
+	Client     *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientClient     `json:"client,omitempty"`     // Client.
+	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientClient struct {
+	ID  string `json:"id,omitempty"`  // Client ID.
+	Mac string `json:"mac,omitempty"` // MAC address.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice struct {
+	Device     *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDevice     `json:"device,omitempty"`     // Device.
+	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDevice struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address
+	Name   string `json:"name,omitempty"`   // Name
+	Serial string `json:"serial,omitempty"` // Serial Number
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork struct {
+	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
 type RequestDevicesUpdateDevice struct {
 	Address         string   `json:"address,omitempty"`         // The address of a device
 	FloorPlanID     string   `json:"floorPlanId,omitempty"`     // The floor plan to associate to this device. null disassociates the device from the floorplan.
 	Lat             *float64 `json:"lat,omitempty"`             // The latitude of a device
 	Lng             *float64 `json:"lng,omitempty"`             // The longitude of a device
-	Mac             string   `json:"mac,omitempty"`             // Mac.
 	MoveMapMarker   *bool    `json:"moveMapMarker,omitempty"`   // Whether or not to set the latitude and longitude of a device based on the new address. Only applies when lat and lng are not specified.
 	Name            string   `json:"name,omitempty"`            // The name of a device
 	Notes           string   `json:"notes,omitempty"`           // The notes for the device. String. Limited to 255 characters.
-	SwitchProfileID string   `json:"switchProfileId,omitempty"` // The ID of a switch profile to bind to the device (for available switch profiles, see the 'Switch Profiles' endpoint). Use null to unbind the switch device from the current profile. For a device to be bindable to a switch profile, it must (1) be a switch, and (2) belong to a network that is bound to a configuration template.
+	SwitchProfileID string   `json:"switchProfileId,omitempty"` // The ID of a switch template to bind to the device (for available switch templates, see the 'Switch Templates' endpoint). Use null to unbind the switch device from the current profile. For a device to be bindable to a switch template, it must (1) be a switch, and (2) belong to a network that is bound to a configuration template.
 	Tags            []string `json:"tags,omitempty"`            // The list of tags of a device
 }
 type RequestDevicesBlinkDeviceLeds struct {
@@ -422,6 +887,7 @@ type RequestDevicesUpdateDeviceCellularSims struct {
 }
 type RequestDevicesUpdateDeviceCellularSimsSimFailover struct {
 	Enabled *bool `json:"enabled,omitempty"` // Failover to secondary SIM (optional)
+	Timeout *int  `json:"timeout,omitempty"` // Failover timeout in seconds (optional)
 }
 type RequestDevicesUpdateDeviceCellularSimsSims struct {
 	Apns      *[]RequestDevicesUpdateDeviceCellularSimsSimsApns `json:"apns,omitempty"`      // APN configurations. If empty, the default APN will be used.
@@ -438,12 +904,101 @@ type RequestDevicesUpdateDeviceCellularSimsSimsApnsAuthentication struct {
 	Type     string `json:"type,omitempty"`     // APN auth type.
 	Username string `json:"username,omitempty"` // APN username, if type is set.
 }
+type RequestDevicesCreateDeviceLiveToolsArpTable struct {
+	Callback *RequestDevicesCreateDeviceLiveToolsArpTableCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+}
+type RequestDevicesCreateDeviceLiveToolsArpTableCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsArpTableCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsArpTableCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                              `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                              `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsArpTableCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsArpTableCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
+type RequestDevicesCreateDeviceLiveToolsCableTest struct {
+	Callback *RequestDevicesCreateDeviceLiveToolsCableTestCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+	Ports    []string                                              `json:"ports,omitempty"`    // A list of ports for which to perform the cable test.
+}
+type RequestDevicesCreateDeviceLiveToolsCableTestCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsCableTestCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsCableTestCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                               `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                               `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsCableTestCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsCableTestCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
 type RequestDevicesCreateDeviceLiveToolsPing struct {
-	Count  *int   `json:"count,omitempty"`  // Count parameter to pass to ping. [1..5], default 5
-	Target string `json:"target,omitempty"` // FQDN, IPv4 or IPv6 address
+	Callback *RequestDevicesCreateDeviceLiveToolsPingCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+	Count    *int                                             `json:"count,omitempty"`    // Count parameter to pass to ping. [1..5], default 5
+	Target   string                                           `json:"target,omitempty"`   // FQDN, IPv4 or IPv6 address
+}
+type RequestDevicesCreateDeviceLiveToolsPingCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsPingCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsPingCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                          `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                          `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsPingCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsPingCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
 }
 type RequestDevicesCreateDeviceLiveToolsPingDevice struct {
-	Count *int `json:"count,omitempty"` // Count parameter to pass to ping. [1..5], default 5
+	Callback *RequestDevicesCreateDeviceLiveToolsPingDeviceCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+	Count    *int                                                   `json:"count,omitempty"`    // Count parameter to pass to ping. [1..5], default 5
+}
+type RequestDevicesCreateDeviceLiveToolsPingDeviceCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsPingDeviceCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsPingDeviceCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                                `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                                `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsPingDeviceCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsPingDeviceCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
+type RequestDevicesCreateDeviceLiveToolsThroughputTest struct {
+	Callback *RequestDevicesCreateDeviceLiveToolsThroughputTestCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+}
+type RequestDevicesCreateDeviceLiveToolsThroughputTestCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsThroughputTestCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsThroughputTestCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                                    `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                                    `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsThroughputTestCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsThroughputTestCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
+type RequestDevicesCreateDeviceLiveToolsWakeOnLan struct {
+	Callback *RequestDevicesCreateDeviceLiveToolsWakeOnLanCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+	Mac      string                                                `json:"mac,omitempty"`      // The target's MAC address
+	VLANID   *int                                                  `json:"vlanId,omitempty"`   // The target's VLAN (1 to 4094)
+}
+type RequestDevicesCreateDeviceLiveToolsWakeOnLanCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsWakeOnLanCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsWakeOnLanCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                               `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                               `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsWakeOnLanCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsWakeOnLanCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
 }
 type RequestDevicesUpdateDeviceManagementInterface struct {
 	Wan1 *RequestDevicesUpdateDeviceManagementInterfaceWan1 `json:"wan1,omitempty"` // WAN 1 settings
@@ -471,7 +1026,7 @@ type RequestDevicesClaimNetworkDevices struct {
 	Serials []string `json:"serials,omitempty"` // A list of serials of devices to claim
 }
 type RequestDevicesVmxNetworkDevicesClaim struct {
-	Size string `json:"size,omitempty"` // The size of the vMX you claim. It can be one of: small, medium, large, 100
+	Size string `json:"size,omitempty"` // The size of the vMX you claim. It can be one of: small, medium, large, xlarge, 100
 }
 type RequestDevicesRemoveNetworkDevices struct {
 	Serial string `json:"serial,omitempty"` // The serial of a device
@@ -495,7 +1050,7 @@ type RequestDevicesUpdateNetworkSmDevicesFieldsDeviceFields struct {
 type RequestDevicesLockNetworkSmDevices struct {
 	IDs      []string `json:"ids,omitempty"`      // The ids of the devices to be locked.
 	Pin      *int     `json:"pin,omitempty"`      // The pin number for locking macOS devices (a six digit number). Required only for macOS devices.
-	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the devices to be wiped.
+	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the devices to be locked.
 	Serials  []string `json:"serials,omitempty"`  // The serials of the devices to be locked.
 	WifiMacs []string `json:"wifiMacs,omitempty"` // The wifiMacs of the devices to be locked.
 }
@@ -514,11 +1069,34 @@ type RequestDevicesMoveNetworkSmDevices struct {
 	Serials    []string `json:"serials,omitempty"`    // The serials of the devices to be moved.
 	WifiMacs   []string `json:"wifiMacs,omitempty"`   // The wifiMacs of the devices to be moved.
 }
+type RequestDevicesRebootNetworkSmDevices struct {
+	IDs                          []string `json:"ids,omitempty"`                          // The ids of the endpoints to be rebooted.
+	KextPaths                    []string `json:"kextPaths,omitempty"`                    // The KextPaths of the endpoints to be rebooted. Available for macOS 11+
+	NotifyUser                   *bool    `json:"notifyUser,omitempty"`                   // Whether or not to notify the user before rebooting the endpoint. Available for macOS 11.3+
+	RebuildKernelCache           *bool    `json:"rebuildKernelCache,omitempty"`           // Whether or not to rebuild the kernel cache when rebooting the endpoint. Available for macOS 11+
+	RequestRequiresNetworkTether *bool    `json:"requestRequiresNetworkTether,omitempty"` // Whether or not the request requires network tethering. Available for macOS and supervised iOS or tvOS
+	Scope                        []string `json:"scope,omitempty"`                        // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the endpoints to be rebooted.
+	Serials                      []string `json:"serials,omitempty"`                      // The serials of the endpoints to be rebooted.
+	WifiMacs                     []string `json:"wifiMacs,omitempty"`                     // The wifiMacs of the endpoints to be rebooted.
+}
+type RequestDevicesShutdownNetworkSmDevices struct {
+	IDs      []string `json:"ids,omitempty"`      // The ids of the endpoints to be shutdown.
+	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the endpoints to be shutdown.
+	Serials  []string `json:"serials,omitempty"`  // The serials of the endpoints to be shutdown.
+	WifiMacs []string `json:"wifiMacs,omitempty"` // The wifiMacs of the endpoints to be shutdown.
+}
 type RequestDevicesWipeNetworkSmDevices struct {
 	ID      string `json:"id,omitempty"`      // The id of the device to be wiped.
 	Pin     *int   `json:"pin,omitempty"`     // The pin number (a six digit value) for wiping a macOS device. Required only for macOS devices.
 	Serial  string `json:"serial,omitempty"`  // The serial of the device to be wiped.
 	WifiMac string `json:"wifiMac,omitempty"` // The wifiMac of the device to be wiped.
+}
+type RequestDevicesInstallNetworkSmDeviceApps struct {
+	AppIDs []string `json:"appIds,omitempty"` // ids of applications to be installed
+	Force  *bool    `json:"force,omitempty"`  // By default, installation of an app which is believed to already be present on the device will be skipped. If you'd like to force the installation of the app, set this parameter to true.
+}
+type RequestDevicesUninstallNetworkSmDeviceApps struct {
+	AppIDs []string `json:"appIds,omitempty"` // ids of applications to be uninstalled
 }
 type RequestOrganizationsCloneOrganizationSwitchDevices struct {
 	SourceSerial  string   `json:"sourceSerial,omitempty"`  // Serial number of the source switch (must be on a network not bound to a template)
@@ -530,7 +1108,7 @@ type RequestOrganizationsCloneOrganizationSwitchDevices struct {
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device
 */
 func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}"
@@ -563,7 +1141,7 @@ func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *r
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-cellular-sims
 */
 func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesGetDeviceCellularSims, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellular/sims"
@@ -597,7 +1175,7 @@ func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesG
 @param serial serial path parameter.
 @param getDeviceClientsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-clients
 */
 func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryParams *GetDeviceClientsQueryParams) (*ResponseDevicesGetDeviceClients, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/clients"
@@ -627,13 +1205,83 @@ func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryPa
 
 }
 
+//GetDeviceLiveToolsArpTable Return an ARP table live tool job.
+/* Return an ARP table live tool job.
+
+@param serial serial path parameter.
+@param arpTableID arpTableId path parameter. Arp table ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-arp-table
+*/
+func (s *DevicesService) GetDeviceLiveToolsArpTable(serial string, arpTableID string) (*ResponseDevicesGetDeviceLiveToolsArpTable, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/arpTable/{arpTableId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{arpTableId}", fmt.Sprintf("%v", arpTableID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetDeviceLiveToolsArpTable{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceLiveToolsArpTable")
+	}
+
+	result := response.Result().(*ResponseDevicesGetDeviceLiveToolsArpTable)
+	return result, response, err
+
+}
+
+//GetDeviceLiveToolsCableTest Return a cable test live tool job.
+/* Return a cable test live tool job.
+
+@param serial serial path parameter.
+@param id id path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-cable-test
+*/
+func (s *DevicesService) GetDeviceLiveToolsCableTest(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsCableTest, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/cableTest/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetDeviceLiveToolsCableTest{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceLiveToolsCableTest")
+	}
+
+	result := response.Result().(*ResponseDevicesGetDeviceLiveToolsCableTest)
+	return result, response, err
+
+}
+
 //GetDeviceLiveToolsPing Return a ping job
 /* Return a ping job. Latency unit in response is in milliseconds. Size is in bytes.
 
 @param serial serial path parameter.
 @param id id path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-ping
 */
 func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPing, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/ping/{id}"
@@ -668,7 +1316,7 @@ func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*Resp
 @param serial serial path parameter.
 @param id id path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-ping-device
 */
 func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPingDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/pingDevice/{id}"
@@ -697,12 +1345,82 @@ func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) 
 
 }
 
+//GetDeviceLiveToolsThroughputTest Return a throughput test job
+/* Return a throughput test job
+
+@param serial serial path parameter.
+@param throughputTestID throughputTestId path parameter. Throughput test ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-throughput-test
+*/
+func (s *DevicesService) GetDeviceLiveToolsThroughputTest(serial string, throughputTestID string) (*ResponseDevicesGetDeviceLiveToolsThroughputTest, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/throughputTest/{throughputTestId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{throughputTestId}", fmt.Sprintf("%v", throughputTestID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetDeviceLiveToolsThroughputTest{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceLiveToolsThroughputTest")
+	}
+
+	result := response.Result().(*ResponseDevicesGetDeviceLiveToolsThroughputTest)
+	return result, response, err
+
+}
+
+//GetDeviceLiveToolsWakeOnLan Return a Wake-on-LAN job
+/* Return a Wake-on-LAN job
+
+@param serial serial path parameter.
+@param wakeOnLanID wakeOnLanId path parameter. Wake on lan ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-wake-on-lan
+*/
+func (s *DevicesService) GetDeviceLiveToolsWakeOnLan(serial string, wakeOnLanID string) (*ResponseDevicesGetDeviceLiveToolsWakeOnLan, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/wakeOnLan/{wakeOnLanId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{wakeOnLanId}", fmt.Sprintf("%v", wakeOnLanID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetDeviceLiveToolsWakeOnLan{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceLiveToolsWakeOnLan")
+	}
+
+	result := response.Result().(*ResponseDevicesGetDeviceLiveToolsWakeOnLan)
+	return result, response, err
+
+}
+
 //GetDeviceLldpCdp List LLDP and CDP information for a device
 /* List LLDP and CDP information for a device
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-lldp-cdp
 */
 func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDeviceLldpCdp, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lldpCdp"
@@ -730,13 +1448,13 @@ func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDev
 
 }
 
-//GetDeviceLossAndLatencyHistory Get the uplink loss percentage and latency in milliseconds, and goodput in kilobits per second for a wired network device.
-/* Get the uplink loss percentage and latency in milliseconds, and goodput in kilobits per second for a wired network device.
+//GetDeviceLossAndLatencyHistory Get the uplink loss percentage and latency in milliseconds, and goodput in kilobits per second for MX, MG and Z devices.
+/* Get the uplink loss percentage and latency in milliseconds, and goodput in kilobits per second for MX, MG and Z devices.
 
 @param serial serial path parameter.
 @param getDeviceLossAndLatencyHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-loss-and-latency-history
 */
 func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDeviceLossAndLatencyHistoryQueryParams *GetDeviceLossAndLatencyHistoryQueryParams) (*ResponseDevicesGetDeviceLossAndLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lossAndLatencyHistory"
@@ -771,7 +1489,7 @@ func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDevice
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-management-interface
 */
 func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseDevicesGetDeviceManagementInterface, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/managementInterface"
@@ -804,7 +1522,7 @@ func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseD
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-devices
 */
 func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGetNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices"
@@ -838,7 +1556,7 @@ func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGe
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-cellular-usage-history
 */
 func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCellularUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/cellularUsageHistory"
@@ -873,7 +1591,7 @@ func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-certs
 */
 func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCerts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/certs"
@@ -908,7 +1626,7 @@ func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID stri
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-device-profiles
 */
 func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceDeviceProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/deviceProfiles"
@@ -943,7 +1661,7 @@ func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, devi
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-network-adapters
 */
 func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceNetworkAdapters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/networkAdapters"
@@ -978,7 +1696,7 @@ func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, dev
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-restrictions
 */
 func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceRestrictions, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/restrictions"
@@ -1013,7 +1731,7 @@ func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, device
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-security-centers
 */
 func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSecurityCenters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/securityCenters"
@@ -1048,7 +1766,7 @@ func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, dev
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-softwares
 */
 func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSoftwares, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/softwares"
@@ -1083,7 +1801,7 @@ func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID 
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-wlan-lists
 */
 func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceWLANLists, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/wlanLists"
@@ -1112,15 +1830,118 @@ func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID 
 
 }
 
+//GetOrganizationDevicesAvailabilitiesChangeHistory List the availability history information for devices in an organization.
+/* List the availability history information for devices in an organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-devices-availabilities-change-history
+*/
+func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/availabilities/changeHistory"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationDevicesAvailabilitiesChangeHistory")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationDevicesBootsHistory Returns the history of device boots in reverse chronological order (most recent first)
+/* Returns the history of device boots in reverse chronological order (most recent first). Currently supported for MS devices only.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationDevicesBootsHistoryQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-devices-boots-history
+*/
+func (s *DevicesService) GetOrganizationDevicesBootsHistory(organizationID string, getOrganizationDevicesBootsHistoryQueryParams *GetOrganizationDevicesBootsHistoryQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/boots/history"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationDevicesBootsHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationDevicesBootsHistory")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationInventoryDevicesSwapsBulk List of device swaps for a given request ID ({id}).
+/* List of device swaps for a given request ID ({id}).
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-inventory-devices-swaps-bulk
+*/
+func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationInventoryDevicesSwapsBulk")
+	}
+
+	return response, err
+
+}
+
 //GetOrganizationInventoryDevice Return a single device from the inventory of an organization
 /* Return a single device from the inventory of an organization
 
 @param organizationID organizationId path parameter. Organization ID
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-inventory-device
 */
-func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, serial string) (*ResponseDevicesGetOrganizationInventoryDevice, *resty.Response, error) {
+func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, serial string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/{serial}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -1129,21 +1950,264 @@ func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, s
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseDevicesGetOrganizationInventoryDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation GetOrganizationInventoryDevice")
+		return response, fmt.Errorf("error with operation GetOrganizationInventoryDevice")
 	}
 
-	result := response.Result().(*ResponseDevicesGetOrganizationInventoryDevice)
-	return result, response, err
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationByDevice Get average channel utilization for all bands in a network, split by AP
+/* Get average channel utilization for all bands in a network, split by AP
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-device
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationByNetwork Get average channel utilization across all bands for all networks in the organization
+/* Get average channel utilization across all bands for all networks in the organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-network
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByNetwork")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval Get a time-series of average channel utilization for all bands, segmented by device.
+/* Get a time-series of average channel utilization for all bands, segmented by device.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-device-by-interval
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval Get a time-series of average channel utilization for all bands
+/* Get a time-series of average channel utilization for all bands
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-network-by-interval
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesPacketLossByClient Get average packet loss for the given timespan for all clients in the organization.
+/* Get average packet loss for the given timespan for all clients in the organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByClientQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-client
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByClientQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByClient")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesPacketLossByDevice Get average packet loss for the given timespan for all devices in the organization
+/* Get average packet loss for the given timespan for all devices in the organization. Does not include device's own traffic.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByDeviceQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-device
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessDevicesPacketLossByNetwork Get average packet loss for the given timespan for all networks in the organization.
+/* Get average packet loss for the given timespan for all networks in the organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByNetworkQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-network
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByNetwork")
+	}
+
+	return response, err
 
 }
 
@@ -1152,7 +2216,7 @@ func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, s
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!blink-device-leds
 */
 
 func (s *DevicesService) BlinkDeviceLeds(serial string, requestDevicesBlinkDeviceLeds *RequestDevicesBlinkDeviceLeds) (*ResponseDevicesBlinkDeviceLeds, *resty.Response, error) {
@@ -1182,12 +2246,82 @@ func (s *DevicesService) BlinkDeviceLeds(serial string, requestDevicesBlinkDevic
 
 }
 
+//CreateDeviceLiveToolsArpTable Enqueue a job to perform a ARP table request for the device
+/* Enqueue a job to perform a ARP table request for the device. This endpoint currently supports switches.
+
+@param serial serial path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-arp-table
+*/
+
+func (s *DevicesService) CreateDeviceLiveToolsArpTable(serial string, requestDevicesCreateDeviceLiveToolsArpTable *RequestDevicesCreateDeviceLiveToolsArpTable) (*ResponseDevicesCreateDeviceLiveToolsArpTable, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/arpTable"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesCreateDeviceLiveToolsArpTable).
+		SetResult(&ResponseDevicesCreateDeviceLiveToolsArpTable{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceLiveToolsArpTable")
+	}
+
+	result := response.Result().(*ResponseDevicesCreateDeviceLiveToolsArpTable)
+	return result, response, err
+
+}
+
+//CreateDeviceLiveToolsCableTest Enqueue a job to perform a cable test for the device on the specified ports.
+/* Enqueue a job to perform a cable test for the device on the specified ports.
+
+@param serial serial path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-cable-test
+*/
+
+func (s *DevicesService) CreateDeviceLiveToolsCableTest(serial string, requestDevicesCreateDeviceLiveToolsCableTest *RequestDevicesCreateDeviceLiveToolsCableTest) (*ResponseDevicesCreateDeviceLiveToolsCableTest, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/cableTest"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesCreateDeviceLiveToolsCableTest).
+		SetResult(&ResponseDevicesCreateDeviceLiveToolsCableTest{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceLiveToolsCableTest")
+	}
+
+	result := response.Result().(*ResponseDevicesCreateDeviceLiveToolsCableTest)
+	return result, response, err
+
+}
+
 //CreateDeviceLiveToolsPing Enqueue a job to ping a target host from the device
 /* Enqueue a job to ping a target host from the device
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-ping
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsPing(serial string, requestDevicesCreateDeviceLiveToolsPing *RequestDevicesCreateDeviceLiveToolsPing) (*ResponseDevicesCreateDeviceLiveToolsPing, *resty.Response, error) {
@@ -1222,7 +2356,7 @@ func (s *DevicesService) CreateDeviceLiveToolsPing(serial string, requestDevices
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-ping-device
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsPingDevice(serial string, requestDevicesCreateDeviceLiveToolsPingDevice *RequestDevicesCreateDeviceLiveToolsPingDevice) (*ResponseDevicesCreateDeviceLiveToolsPingDevice, *resty.Response, error) {
@@ -1252,15 +2386,85 @@ func (s *DevicesService) CreateDeviceLiveToolsPingDevice(serial string, requestD
 
 }
 
+//CreateDeviceLiveToolsThroughputTest Enqueue a job to test a device throughput, the test will run for 10 secs to test throughput
+/* Enqueue a job to test a device throughput, the test will run for 10 secs to test throughput
+
+@param serial serial path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-throughput-test
+*/
+
+func (s *DevicesService) CreateDeviceLiveToolsThroughputTest(serial string, requestDevicesCreateDeviceLiveToolsThroughputTest *RequestDevicesCreateDeviceLiveToolsThroughputTest) (*ResponseDevicesCreateDeviceLiveToolsThroughputTest, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/throughputTest"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesCreateDeviceLiveToolsThroughputTest).
+		SetResult(&ResponseDevicesCreateDeviceLiveToolsThroughputTest{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceLiveToolsThroughputTest")
+	}
+
+	result := response.Result().(*ResponseDevicesCreateDeviceLiveToolsThroughputTest)
+	return result, response, err
+
+}
+
+//CreateDeviceLiveToolsWakeOnLan Enqueue a job to send a Wake-on-LAN packet from the device
+/* Enqueue a job to send a Wake-on-LAN packet from the device
+
+@param serial serial path parameter.
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-wake-on-lan
+*/
+
+func (s *DevicesService) CreateDeviceLiveToolsWakeOnLan(serial string, requestDevicesCreateDeviceLiveToolsWakeOnLan *RequestDevicesCreateDeviceLiveToolsWakeOnLan) (*ResponseDevicesCreateDeviceLiveToolsWakeOnLan, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/wakeOnLan"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesCreateDeviceLiveToolsWakeOnLan).
+		SetResult(&ResponseDevicesCreateDeviceLiveToolsWakeOnLan{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceLiveToolsWakeOnLan")
+	}
+
+	result := response.Result().(*ResponseDevicesCreateDeviceLiveToolsWakeOnLan)
+	return result, response, err
+
+}
+
 //RebootDevice Reboot a device
 /* Reboot a device
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!reboot-device
 */
 
-func (s *DevicesService) RebootDevice(serial string) (*resty.Response, error) {
+func (s *DevicesService) RebootDevice(serial string) (*ResponseDevicesRebootDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/reboot"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -1268,33 +2472,33 @@ func (s *DevicesService) RebootDevice(serial string) (*resty.Response, error) {
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-
-		// SetResult(&ResponseDevicesRebootDevice{}).
+		SetResult(&ResponseDevicesRebootDevice{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation RebootDevice")
+		return nil, response, fmt.Errorf("error with operation RebootDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesRebootDevice)
+	return result, response, err
 
 }
 
-//ClaimNetworkDevices Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requsts against that device to succeed)
-/* Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requsts against that device to succeed)
+//ClaimNetworkDevices Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requests against that device to succeed)
+/* Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requests against that device to succeed). This operation can be used up to ten times within a single five minute window.
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!claim-network-devices
 */
 
-func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesClaimNetworkDevices *RequestDevicesClaimNetworkDevices) (*resty.Response, error) {
+func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesClaimNetworkDevices *RequestDevicesClaimNetworkDevices) (*ResponseDevicesClaimNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices/claim"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1303,19 +2507,21 @@ func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesCla
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesClaimNetworkDevices).
+		SetResult(&ResponseDevicesClaimNetworkDevices{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ClaimNetworkDevices")
+		return nil, response, fmt.Errorf("error with operation ClaimNetworkDevices")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesClaimNetworkDevices)
+	return result, response, err
 
 }
 
@@ -1324,10 +2530,10 @@ func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesCla
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!vmx-network-devices-claim
 */
 
-func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevicesVmxNetworkDevicesClaim *RequestDevicesVmxNetworkDevicesClaim) (*resty.Response, error) {
+func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevicesVmxNetworkDevicesClaim *RequestDevicesVmxNetworkDevicesClaim) (*ResponseDevicesVmxNetworkDevicesClaim, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices/claim/vmx"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1336,20 +2542,21 @@ func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevices
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesVmxNetworkDevicesClaim).
-		// SetResult(&ResponseDevicesVmxNetworkDevicesClaim{}).
+		SetResult(&ResponseDevicesVmxNetworkDevicesClaim{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation VmxNetworkDevicesClaim")
+		return nil, response, fmt.Errorf("error with operation VmxNetworkDevicesClaim")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesVmxNetworkDevicesClaim)
+	return result, response, err
 
 }
 
@@ -1358,7 +2565,7 @@ func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevices
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!remove-network-devices
 */
 
 func (s *DevicesService) RemoveNetworkDevices(networkID string, requestDevicesRemoveNetworkDevices *RequestDevicesRemoveNetworkDevices) (*resty.Response, error) {
@@ -1391,7 +2598,7 @@ func (s *DevicesService) RemoveNetworkDevices(networkID string, requestDevicesRe
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!checkin-network-sm-devices
 */
 
 func (s *DevicesService) CheckinNetworkSmDevices(networkID string, requestDevicesCheckinNetworkSmDevices *RequestDevicesCheckinNetworkSmDevices) (*ResponseDevicesCheckinNetworkSmDevices, *resty.Response, error) {
@@ -1426,7 +2633,7 @@ func (s *DevicesService) CheckinNetworkSmDevices(networkID string, requestDevice
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!lock-network-sm-devices
 */
 
 func (s *DevicesService) LockNetworkSmDevices(networkID string, requestDevicesLockNetworkSmDevices *RequestDevicesLockNetworkSmDevices) (*ResponseDevicesLockNetworkSmDevices, *resty.Response, error) {
@@ -1461,7 +2668,7 @@ func (s *DevicesService) LockNetworkSmDevices(networkID string, requestDevicesLo
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!modify-network-sm-devices-tags
 */
 
 func (s *DevicesService) ModifyNetworkSmDevicesTags(networkID string, requestDevicesModifyNetworkSmDevicesTags *RequestDevicesModifyNetworkSmDevicesTags) (*ResponseDevicesModifyNetworkSmDevicesTags, *resty.Response, error) {
@@ -1496,7 +2703,7 @@ func (s *DevicesService) ModifyNetworkSmDevicesTags(networkID string, requestDev
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!move-network-sm-devices
 */
 
 func (s *DevicesService) MoveNetworkSmDevices(networkID string, requestDevicesMoveNetworkSmDevices *RequestDevicesMoveNetworkSmDevices) (*ResponseDevicesMoveNetworkSmDevices, *resty.Response, error) {
@@ -1526,12 +2733,82 @@ func (s *DevicesService) MoveNetworkSmDevices(networkID string, requestDevicesMo
 
 }
 
+//RebootNetworkSmDevices Reboot a set of endpoints
+/* Reboot a set of endpoints
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!reboot-network-sm-devices
+*/
+
+func (s *DevicesService) RebootNetworkSmDevices(networkID string, requestDevicesRebootNetworkSmDevices *RequestDevicesRebootNetworkSmDevices) (*ResponseDevicesRebootNetworkSmDevices, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/reboot"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesRebootNetworkSmDevices).
+		SetResult(&ResponseDevicesRebootNetworkSmDevices{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation RebootNetworkSmDevices")
+	}
+
+	result := response.Result().(*ResponseDevicesRebootNetworkSmDevices)
+	return result, response, err
+
+}
+
+//ShutdownNetworkSmDevices Shutdown a set of endpoints
+/* Shutdown a set of endpoints
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!shutdown-network-sm-devices
+*/
+
+func (s *DevicesService) ShutdownNetworkSmDevices(networkID string, requestDevicesShutdownNetworkSmDevices *RequestDevicesShutdownNetworkSmDevices) (*ResponseDevicesShutdownNetworkSmDevices, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/shutdown"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesShutdownNetworkSmDevices).
+		SetResult(&ResponseDevicesShutdownNetworkSmDevices{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation ShutdownNetworkSmDevices")
+	}
+
+	result := response.Result().(*ResponseDevicesShutdownNetworkSmDevices)
+	return result, response, err
+
+}
+
 //WipeNetworkSmDevices Wipe a device
 /* Wipe a device
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!wipe-network-sm-devices
 */
 
 func (s *DevicesService) WipeNetworkSmDevices(networkID string, requestDevicesWipeNetworkSmDevices *RequestDevicesWipeNetworkSmDevices) (*ResponseDevicesWipeNetworkSmDevices, *resty.Response, error) {
@@ -1561,13 +2838,48 @@ func (s *DevicesService) WipeNetworkSmDevices(networkID string, requestDevicesWi
 
 }
 
+//InstallNetworkSmDeviceApps Install applications on a device
+/* Install applications on a device
+
+@param networkID networkId path parameter. Network ID
+@param deviceID deviceId path parameter. Device ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!install-network-sm-device-apps
+*/
+
+func (s *DevicesService) InstallNetworkSmDeviceApps(networkID string, deviceID string, requestDevicesInstallNetworkSmDeviceApps *RequestDevicesInstallNetworkSmDeviceApps) (*resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/installApps"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesInstallNetworkSmDeviceApps).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation InstallNetworkSmDeviceApps")
+	}
+
+	return response, err
+
+}
+
 //RefreshNetworkSmDeviceDetails Refresh the details of a device
 /* Refresh the details of a device
 
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!refresh-network-sm-device-details
 */
 
 func (s *DevicesService) RefreshNetworkSmDeviceDetails(networkID string, deviceID string) (*resty.Response, error) {
@@ -1601,10 +2913,10 @@ func (s *DevicesService) RefreshNetworkSmDeviceDetails(networkID string, deviceI
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!unenroll-network-sm-device
 */
 
-func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID string) (*resty.Response, error) {
+func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID string) (*ResponseDevicesUnenrollNetworkSmDevice, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/unenroll"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1613,8 +2925,43 @@ func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID stri
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesUnenrollNetworkSmDevice{}).
+		SetError(&Error).
+		Post(path)
 
-		// SetResult(&ResponseDevicesUnenrollNetworkSmDevice{}).
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UnenrollNetworkSmDevice")
+	}
+
+	result := response.Result().(*ResponseDevicesUnenrollNetworkSmDevice)
+	return result, response, err
+
+}
+
+//UninstallNetworkSmDeviceApps Uninstall applications on a device
+/* Uninstall applications on a device
+
+@param networkID networkId path parameter. Network ID
+@param deviceID deviceId path parameter. Device ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!uninstall-network-sm-device-apps
+*/
+
+func (s *DevicesService) UninstallNetworkSmDeviceApps(networkID string, deviceID string, requestDevicesUninstallNetworkSmDeviceApps *RequestDevicesUninstallNetworkSmDeviceApps) (*resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/uninstallApps"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesUninstallNetworkSmDeviceApps).
 		SetError(&Error).
 		Post(path)
 
@@ -1624,7 +2971,39 @@ func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID stri
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UnenrollNetworkSmDevice")
+		return response, fmt.Errorf("error with operation UninstallNetworkSmDeviceApps")
+	}
+
+	return response, err
+
+}
+
+//CreateOrganizationInventoryDevicesSwapsBulk Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
+/* Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
+
+@param organizationID organizationId path parameter. Organization ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-organization-inventory-devices-swaps-bulk
+*/
+
+func (s *DevicesService) CreateOrganizationInventoryDevicesSwapsBulk(organizationID string) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation CreateOrganizationInventoryDevicesSwapsBulk")
 	}
 
 	return response, err
@@ -1636,7 +3015,7 @@ func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID stri
 
 @param organizationID organizationId path parameter. Organization ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!clone-organization-switch-devices
 */
 
 func (s *DevicesService) CloneOrganizationSwitchDevices(organizationID string) (*resty.Response, error) {
@@ -1728,7 +3107,7 @@ func (s *DevicesService) UpdateDeviceCellularSims(serial string, requestDevicesU
 
 @param serial serial path parameter.
 */
-func (s *DevicesService) UpdateDeviceManagementInterface(serial string, requestDevicesUpdateDeviceManagementInterface *RequestDevicesUpdateDeviceManagementInterface) (*resty.Response, error) {
+func (s *DevicesService) UpdateDeviceManagementInterface(serial string, requestDevicesUpdateDeviceManagementInterface *RequestDevicesUpdateDeviceManagementInterface) (*ResponseDevicesUpdateDeviceManagementInterface, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/managementInterface"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -1737,19 +3116,21 @@ func (s *DevicesService) UpdateDeviceManagementInterface(serial string, requestD
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesUpdateDeviceManagementInterface).
+		SetResult(&ResponseDevicesUpdateDeviceManagementInterface{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceManagementInterface")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceManagementInterface")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesUpdateDeviceManagementInterface)
+	return result, response, err
 
 }
 

--- a/sdk/insight.go
+++ b/sdk/insight.go
@@ -54,14 +54,24 @@ type ResponseItemInsightGetOrganizationInsightMonitoredMediaServers struct {
 	ID                          string `json:"id,omitempty"`                          // Monitored media server id
 	Name                        string `json:"name,omitempty"`                        // The name of the VoIP provider
 }
-type ResponseInsightCreateOrganizationInsightMonitoredMediaServer interface{}
-type ResponseInsightGetOrganizationInsightMonitoredMediaServer struct {
-	Address                     string `json:"address,omitempty"`                     //
-	BestEffortMonitoringEnabled *bool  `json:"bestEffortMonitoringEnabled,omitempty"` //
-	ID                          string `json:"id,omitempty"`                          //
-	Name                        string `json:"name,omitempty"`                        //
+type ResponseInsightCreateOrganizationInsightMonitoredMediaServer struct {
+	Address                     string `json:"address,omitempty"`                     // The IP address (IPv4 only) or hostname of the media server to monitor
+	BestEffortMonitoringEnabled *bool  `json:"bestEffortMonitoringEnabled,omitempty"` // Indicates that if the media server doesn't respond to ICMP pings, the nearest hop will be used in its stead
+	ID                          string `json:"id,omitempty"`                          // Monitored media server id
+	Name                        string `json:"name,omitempty"`                        // The name of the VoIP provider
 }
-type ResponseInsightUpdateOrganizationInsightMonitoredMediaServer interface{}
+type ResponseInsightGetOrganizationInsightMonitoredMediaServer struct {
+	Address                     string `json:"address,omitempty"`                     // The IP address (IPv4 only) or hostname of the media server to monitor
+	BestEffortMonitoringEnabled *bool  `json:"bestEffortMonitoringEnabled,omitempty"` // Indicates that if the media server doesn't respond to ICMP pings, the nearest hop will be used in its stead
+	ID                          string `json:"id,omitempty"`                          // Monitored media server id
+	Name                        string `json:"name,omitempty"`                        // The name of the VoIP provider
+}
+type ResponseInsightUpdateOrganizationInsightMonitoredMediaServer struct {
+	Address                     string `json:"address,omitempty"`                     // The IP address (IPv4 only) or hostname of the media server to monitor
+	BestEffortMonitoringEnabled *bool  `json:"bestEffortMonitoringEnabled,omitempty"` // Indicates that if the media server doesn't respond to ICMP pings, the nearest hop will be used in its stead
+	ID                          string `json:"id,omitempty"`                          // Monitored media server id
+	Name                        string `json:"name,omitempty"`                        // The name of the VoIP provider
+}
 type RequestInsightCreateOrganizationInsightMonitoredMediaServer struct {
 	Address                     string `json:"address,omitempty"`                     // The IP address (IPv4 only) or hostname of the media server to monitor
 	BestEffortMonitoringEnabled *bool  `json:"bestEffortMonitoringEnabled,omitempty"` // Indicates that if the media server doesn't respond to ICMP pings, the nearest hop will be used in its stead.
@@ -220,7 +230,7 @@ func (s *InsightService) GetOrganizationInsightMonitoredMediaServer(organization
 
 */
 
-func (s *InsightService) CreateOrganizationInsightMonitoredMediaServer(organizationID string, requestInsightCreateOrganizationInsightMonitoredMediaServer *RequestInsightCreateOrganizationInsightMonitoredMediaServer) (*resty.Response, error) {
+func (s *InsightService) CreateOrganizationInsightMonitoredMediaServer(organizationID string, requestInsightCreateOrganizationInsightMonitoredMediaServer *RequestInsightCreateOrganizationInsightMonitoredMediaServer) (*ResponseInsightCreateOrganizationInsightMonitoredMediaServer, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/insight/monitoredMediaServers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -229,20 +239,21 @@ func (s *InsightService) CreateOrganizationInsightMonitoredMediaServer(organizat
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestInsightCreateOrganizationInsightMonitoredMediaServer).
-		// SetResult(&ResponseInsightCreateOrganizationInsightMonitoredMediaServer{}).
+		SetResult(&ResponseInsightCreateOrganizationInsightMonitoredMediaServer{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationInsightMonitoredMediaServer")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationInsightMonitoredMediaServer")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseInsightCreateOrganizationInsightMonitoredMediaServer)
+	return result, response, err
 
 }
 
@@ -252,7 +263,7 @@ func (s *InsightService) CreateOrganizationInsightMonitoredMediaServer(organizat
 @param organizationID organizationId path parameter. Organization ID
 @param monitoredMediaServerID monitoredMediaServerId path parameter. Monitored media server ID
 */
-func (s *InsightService) UpdateOrganizationInsightMonitoredMediaServer(organizationID string, monitoredMediaServerID string, requestInsightUpdateOrganizationInsightMonitoredMediaServer *RequestInsightUpdateOrganizationInsightMonitoredMediaServer) (*resty.Response, error) {
+func (s *InsightService) UpdateOrganizationInsightMonitoredMediaServer(organizationID string, monitoredMediaServerID string, requestInsightUpdateOrganizationInsightMonitoredMediaServer *RequestInsightUpdateOrganizationInsightMonitoredMediaServer) (*ResponseInsightUpdateOrganizationInsightMonitoredMediaServer, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/insight/monitoredMediaServers/{monitoredMediaServerId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -262,19 +273,21 @@ func (s *InsightService) UpdateOrganizationInsightMonitoredMediaServer(organizat
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestInsightUpdateOrganizationInsightMonitoredMediaServer).
+		SetResult(&ResponseInsightUpdateOrganizationInsightMonitoredMediaServer{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationInsightMonitoredMediaServer")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationInsightMonitoredMediaServer")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseInsightUpdateOrganizationInsightMonitoredMediaServer)
+	return result, response, err
 
 }
 

--- a/sdk/licensing.go
+++ b/sdk/licensing.go
@@ -10,6 +10,30 @@ import (
 
 type LicensingService service
 
+type GetAdministeredLicensingSubscriptionEntitlementsQueryParams struct {
+	Skus []string `url:"skus[],omitempty"` //Filter to entitlements with the specified SKUs
+}
+type GetAdministeredLicensingSubscriptionSubscriptionsQueryParams struct {
+	PerPage         int      `url:"perPage,omitempty"`           //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter   string   `url:"startingAfter,omitempty"`     //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore    string   `url:"endingBefore,omitempty"`      //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SubscriptionIDs []string `url:"subscriptionIds[],omitempty"` //List of subscription ids to fetch
+	OrganizationIDs []string `url:"organizationIds[],omitempty"` //Organizations to get associated subscriptions for
+	Statuses        []string `url:"statuses[],omitempty"`        //List of statuses that returned subscriptions can have
+	ProductTypes    []string `url:"productTypes[],omitempty"`    //List of product types that returned subscriptions need to have entitlements for.
+	StartDate       string   `url:"startDate,omitempty"`         //Filter subscriptions by start date, ISO 8601 format. To filter with a range of dates, use 'startDate[<option>]=?' in the request. Accepted options include lt, gt, lte, gte.
+	EndDate         string   `url:"endDate,omitempty"`           //Filter subscriptions by end date, ISO 8601 format. To filter with a range of dates, use 'endDate[<option>]=?' in the request. Accepted options include lt, gt, lte, gte.
+}
+type ClaimAdministeredLicensingSubscriptionSubscriptionsQueryParams struct {
+	Validate bool `url:"validate,omitempty"` //Check if the provided claim key is valid and can be claimed into the organization.
+}
+type GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams struct {
+	OrganizationIDs []string `url:"organizationIds[],omitempty"` //Organizations to get subscription compliance information for
+	SubscriptionIDs []string `url:"subscriptionIds[],omitempty"` //Subscription ids
+}
+type BindAdministeredLicensingSubscriptionSubscriptionQueryParams struct {
+	Validate bool `url:"validate,omitempty"` //Check if the provided networks can be bound to the subscription. Returns any licensing problems and does not commit the results.
+}
 type GetOrganizationLicensingCotermLicensesQueryParams struct {
 	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -18,6 +42,144 @@ type GetOrganizationLicensingCotermLicensesQueryParams struct {
 	Expired       bool   `url:"expired,omitempty"`       //Filter for licenses that are expired
 }
 
+type ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements struct {
+	FeatureTier  string `json:"featureTier,omitempty"`  // The feature tier associated with the entitlement (null for add-ons)
+	IsAddOn      *bool  `json:"isAddOn,omitempty"`      // Whether or not the entitlement is an add-on
+	Name         string `json:"name,omitempty"`         // The user-facing name of the entitlement
+	ProductClass string `json:"productClass,omitempty"` // The product class associated with the entitlement
+	ProductType  string `json:"productType,omitempty"`  // The product type of the entitlement
+	Sku          string `json:"sku,omitempty"`          // The SKU identifier of the entitlement
+}
+type ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions []ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptions // Array of ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptions struct {
+	Counts         *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
+	Description    string                                                                                `json:"description,omitempty"`    // Subscription description
+	EndDate        string                                                                                `json:"endDate,omitempty"`        // Subscription expiration date
+	Entitlements   *[]ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlements `json:"entitlements,omitempty"`   // Entitlement info
+	Name           string                                                                                `json:"name,omitempty"`           // Subscription name
+	ProductTypes   []string                                                                              `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
+	StartDate      string                                                                                `json:"startDate,omitempty"`      // Subscription start date
+	Status         string                                                                                `json:"status,omitempty"`         // Subscription status
+	SubscriptionID string                                                                                `json:"subscriptionId,omitempty"` // Subscription's ID
+	WebOrderID     string                                                                                `json:"webOrderId,omitempty"`     // Web order id
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCounts struct {
+	Networks *int                                                                               `json:"networks,omitempty"` // Number of networks bound to this subscription
+	Seats    *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`    // Seat distribution
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCountsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlements struct {
+	Seats *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
+	Sku   string                                                                                   `json:"sku,omitempty"`   // SKU of the required product
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptions struct {
+	Counts         *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
+	Description    string                                                                              `json:"description,omitempty"`    // Subscription description
+	EndDate        string                                                                              `json:"endDate,omitempty"`        // Subscription expiration date
+	Entitlements   *[]ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlements `json:"entitlements,omitempty"`   // Entitlement info
+	Name           string                                                                              `json:"name,omitempty"`           // Subscription name
+	ProductTypes   []string                                                                            `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
+	StartDate      string                                                                              `json:"startDate,omitempty"`      // Subscription start date
+	Status         string                                                                              `json:"status,omitempty"`         // Subscription status
+	SubscriptionID string                                                                              `json:"subscriptionId,omitempty"` // Subscription's ID
+	WebOrderID     string                                                                              `json:"webOrderId,omitempty"`     // Web order id
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCounts struct {
+	Networks *int                                                                             `json:"networks,omitempty"` // Number of networks bound to this subscription
+	Seats    *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`    // Seat distribution
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCountsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlements struct {
+	Seats *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
+	Sku   string                                                                                 `json:"sku,omitempty"`   // SKU of the required product
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey struct {
+	Counts         *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
+	Description    string                                                                                         `json:"description,omitempty"`    // Subscription description
+	EndDate        string                                                                                         `json:"endDate,omitempty"`        // Subscription expiration date
+	Entitlements   *[]ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlements `json:"entitlements,omitempty"`   // Entitlement info
+	Name           string                                                                                         `json:"name,omitempty"`           // Subscription name
+	ProductTypes   []string                                                                                       `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
+	StartDate      string                                                                                         `json:"startDate,omitempty"`      // Subscription start date
+	Status         string                                                                                         `json:"status,omitempty"`         // Subscription status
+	SubscriptionID string                                                                                         `json:"subscriptionId,omitempty"` // Subscription's ID
+	WebOrderID     string                                                                                         `json:"webOrderId,omitempty"`     // Web order id
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCounts struct {
+	Networks *int                                                                                        `json:"networks,omitempty"` // Number of networks bound to this subscription
+	Seats    *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCountsSeats `json:"seats,omitempty"`    // Seat distribution
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCountsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlements struct {
+	Seats *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
+	Sku   string                                                                                            `json:"sku,omitempty"`   // SKU of the required product
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlementsSeats struct {
+	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
+	Available *int `json:"available,omitempty"` // Number of seats available for use
+	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
+}
+type ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses []ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses // Array of ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses struct {
+	Subscription *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesSubscription `json:"subscription,omitempty"` // Subscription details
+	Violations   *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolations   `json:"violations,omitempty"`   // Violations
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesSubscription struct {
+	ID     string `json:"id,omitempty"`     // Subscription's ID
+	Name   string `json:"name,omitempty"`   // Friendly name to identify the subscription
+	Status string `json:"status,omitempty"` // One of the following: "inactive" | "active" | "out_of_compliance" | "expired" | "canceled"
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolations struct {
+	ByProductClass *[]ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClass `json:"byProductClass,omitempty"` // List of violations by product class that are not compliance
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClass struct {
+	GracePeriodEndsAt string                                                                                                                   `json:"gracePeriodEndsAt,omitempty"` // End date of the grace period in ISO 8601 format
+	Missing           *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClassMissing `json:"missing,omitempty"`           // Missing entitlements details
+	ProductClass      string                                                                                                                   `json:"productClass,omitempty"`      // Name of the product class
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClassMissing struct {
+	Entitlements *[]ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClassMissingEntitlements `json:"entitlements,omitempty"` // List of missing entitlements
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesViolationsByProductClassMissingEntitlements struct {
+	Quantity *int   `json:"quantity,omitempty"` // Number required
+	Sku      string `json:"sku,omitempty"`      // SKU of the required product
+}
+type ResponseLicensingBindAdministeredLicensingSubscriptionSubscription struct {
+	Errors                   []string                                                                                      `json:"errors,omitempty"`                   // Array of errors if failed
+	InsufficientEntitlements *[]ResponseLicensingBindAdministeredLicensingSubscriptionSubscriptionInsufficientEntitlements `json:"insufficientEntitlements,omitempty"` // A list of entitlements required to successfully bind the networks to the subscription
+	Networks                 *[]ResponseLicensingBindAdministeredLicensingSubscriptionSubscriptionNetworks                 `json:"networks,omitempty"`                 // Unbound networks
+	SubscriptionID           string                                                                                        `json:"subscriptionId,omitempty"`           // Subscription ID
+}
+type ResponseLicensingBindAdministeredLicensingSubscriptionSubscriptionInsufficientEntitlements struct {
+	Quantity *int   `json:"quantity,omitempty"` // Number required
+	Sku      string `json:"sku,omitempty"`      // SKU of the required product
+}
+type ResponseLicensingBindAdministeredLicensingSubscriptionSubscriptionNetworks struct {
+	ID   string `json:"id,omitempty"`   // Network ID
+	Name string `json:"name,omitempty"` // Network name
+}
 type ResponseLicensingGetOrganizationLicensingCotermLicenses []ResponseItemLicensingGetOrganizationLicensingCotermLicenses // Array of ResponseLicensingGetOrganizationLicensingCotermLicenses
 type ResponseItemLicensingGetOrganizationLicensingCotermLicenses struct {
 	ClaimedAt      string                                                                 `json:"claimedAt,omitempty"`      // When the license was claimed into the organization
@@ -86,6 +248,18 @@ type ResponseLicensingMoveOrganizationLicensingCotermLicensesRemainderLicensesEd
 	Edition     string `json:"edition,omitempty"`     // The name of the license edition
 	ProductType string `json:"productType,omitempty"` // The product type of the license edition
 }
+type RequestLicensingClaimAdministeredLicensingSubscriptionSubscriptions struct {
+	ClaimKey       string `json:"claimKey,omitempty"`       // The subscription's claim key
+	Description    string `json:"description,omitempty"`    // Extra details or notes about the subscription
+	Name           string `json:"name,omitempty"`           // Friendly name to identify the subscription
+	OrganizationID string `json:"organizationId,omitempty"` // The id of the organization claiming the subscription
+}
+type RequestLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey struct {
+	ClaimKey string `json:"claimKey,omitempty"` // The subscription's claim key
+}
+type RequestLicensingBindAdministeredLicensingSubscriptionSubscription struct {
+	NetworkIDs []string `json:"networkIds,omitempty"` // List of network ids to bind to the subscription
+}
 type RequestLicensingMoveOrganizationLicensingCotermLicenses struct {
 	Destination *RequestLicensingMoveOrganizationLicensingCotermLicensesDestination `json:"destination,omitempty"` // Destination data for the license move
 	Licenses    *[]RequestLicensingMoveOrganizationLicensingCotermLicensesLicenses  `json:"licenses,omitempty"`    // The list of licenses to move
@@ -101,6 +275,108 @@ type RequestLicensingMoveOrganizationLicensingCotermLicensesLicenses struct {
 type RequestLicensingMoveOrganizationLicensingCotermLicensesLicensesCounts struct {
 	Count *int   `json:"count,omitempty"` // The number of counts to move
 	Model string `json:"model,omitempty"` // The license model type to move counts of
+}
+
+//GetAdministeredLicensingSubscriptionEntitlements Retrieve the list of purchasable entitlements
+/* Retrieve the list of purchasable entitlements
+
+@param getAdministeredLicensingSubscriptionEntitlementsQueryParams Filtering parameter
+
+
+*/
+func (s *LicensingService) GetAdministeredLicensingSubscriptionEntitlements(getAdministeredLicensingSubscriptionEntitlementsQueryParams *GetAdministeredLicensingSubscriptionEntitlementsQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/entitlements"
+	s.rateLimiterBucket.Wait(1)
+
+	queryString, _ := query.Values(getAdministeredLicensingSubscriptionEntitlementsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetAdministeredLicensingSubscriptionEntitlements")
+	}
+
+	result := response.Result().(*ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements)
+	return result, response, err
+
+}
+
+//GetAdministeredLicensingSubscriptionSubscriptions List available subscriptions
+/* List available subscriptions
+
+@param getAdministeredLicensingSubscriptionSubscriptionsQueryParams Filtering parameter
+
+
+*/
+func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptions(getAdministeredLicensingSubscriptionSubscriptionsQueryParams *GetAdministeredLicensingSubscriptionSubscriptionsQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/subscriptions"
+	s.rateLimiterBucket.Wait(1)
+
+	queryString, _ := query.Values(getAdministeredLicensingSubscriptionSubscriptionsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetAdministeredLicensingSubscriptionSubscriptions")
+	}
+
+	result := response.Result().(*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions)
+	return result, response, err
+
+}
+
+//GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses Get compliance status for requested subscriptions
+/* Get compliance status for requested subscriptions
+
+@param getAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams Filtering parameter
+
+
+*/
+func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses(getAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams *GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/subscriptions/compliance/statuses"
+	s.rateLimiterBucket.Wait(1)
+
+	queryString, _ := query.Values(getAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses")
+	}
+
+	result := response.Result().(*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses)
+	return result, response, err
+
 }
 
 //GetOrganizationLicensingCotermLicenses List the licenses in a coterm organization
@@ -135,6 +411,113 @@ func (s *LicensingService) GetOrganizationLicensingCotermLicenses(organizationID
 	}
 
 	result := response.Result().(*ResponseLicensingGetOrganizationLicensingCotermLicenses)
+	return result, response, err
+
+}
+
+//ClaimAdministeredLicensingSubscriptionSubscriptions Claim a subscription into an organization.
+/* Claim a subscription into an organization.
+
+@param claimAdministeredLicensingSubscriptionSubscriptionsQueryParams Filtering parameter
+
+
+*/
+
+func (s *LicensingService) ClaimAdministeredLicensingSubscriptionSubscriptions(requestLicensingClaimAdministeredLicensingSubscriptionSubscriptions *RequestLicensingClaimAdministeredLicensingSubscriptionSubscriptions, claimAdministeredLicensingSubscriptionSubscriptionsQueryParams *ClaimAdministeredLicensingSubscriptionSubscriptionsQueryParams) (*ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptions, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/subscriptions/claim"
+	s.rateLimiterBucket.Wait(1)
+
+	queryString, _ := query.Values(claimAdministeredLicensingSubscriptionSubscriptionsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetBody(requestLicensingClaimAdministeredLicensingSubscriptionSubscriptions).
+		SetResult(&ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptions{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation ClaimAdministeredLicensingSubscriptionSubscriptions")
+	}
+
+	result := response.Result().(*ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptions)
+	return result, response, err
+
+}
+
+//ValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey Find a subscription by claim key
+/* Find a subscription by claim key. Returns 400 if the key has already been claimed.
+
+
+
+ */
+
+func (s *LicensingService) ValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey(requestLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey *RequestLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey) (*ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/subscriptions/claimKey/validate"
+	s.rateLimiterBucket.Wait(1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey).
+		SetResult(&ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation ValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey")
+	}
+
+	result := response.Result().(*ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey)
+	return result, response, err
+
+}
+
+//BindAdministeredLicensingSubscriptionSubscription Bind networks to a subscription
+/* Bind networks to a subscription
+
+@param subscriptionID subscriptionId path parameter. Subscription ID
+@param bindAdministeredLicensingSubscriptionSubscriptionQueryParams Filtering parameter
+
+
+*/
+
+func (s *LicensingService) BindAdministeredLicensingSubscriptionSubscription(subscriptionID string, requestLicensingBindAdministeredLicensingSubscriptionSubscription *RequestLicensingBindAdministeredLicensingSubscriptionSubscription, bindAdministeredLicensingSubscriptionSubscriptionQueryParams *BindAdministeredLicensingSubscriptionSubscriptionQueryParams) (*ResponseLicensingBindAdministeredLicensingSubscriptionSubscription, *resty.Response, error) {
+	path := "/api/v1/administered/licensing/subscription/subscriptions/{subscriptionId}/bind"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{subscriptionId}", fmt.Sprintf("%v", subscriptionID), -1)
+
+	queryString, _ := query.Values(bindAdministeredLicensingSubscriptionSubscriptionQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetBody(requestLicensingBindAdministeredLicensingSubscriptionSubscription).
+		SetResult(&ResponseLicensingBindAdministeredLicensingSubscriptionSubscription{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation BindAdministeredLicensingSubscriptionSubscription")
+	}
+
+	result := response.Result().(*ResponseLicensingBindAdministeredLicensingSubscriptionSubscription)
 	return result, response, err
 
 }

--- a/sdk/networks.go
+++ b/sdk/networks.go
@@ -30,7 +30,7 @@ type GetNetworkBluetoothClientQueryParams struct {
 type GetNetworkClientsQueryParams struct {
 	T0                      string   `url:"t0,omitempty"`                        //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
 	Timespan                float64  `url:"timespan,omitempty"`                  //The timespan for which the information will be fetched. If specifying timespan, do not specify parameter t0. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
-	PerPage                 int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 10.
+	PerPage                 int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 5000. Default is 10.
 	StartingAfter           string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore            string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	Statuses                []string `url:"statuses[],omitempty"`                //Filters clients based on status. Can be one of 'Online' or 'Offline'.
@@ -42,6 +42,7 @@ type GetNetworkClientsQueryParams struct {
 	PskGroup                string   `url:"pskGroup,omitempty"`                  //Filters clients based on partial or full match for the iPSK name field.
 	Description             string   `url:"description,omitempty"`               //Filters clients based on a partial or full match for the description field.
 	VLAN                    string   `url:"vlan,omitempty"`                      //Filters clients based on the full match for the VLAN field.
+	NamedVLAN               string   `url:"namedVlan,omitempty"`                 //Filters clients based on the partial or full match for the named VLAN field.
 	RecentDeviceConnections []string `url:"recentDeviceConnections[],omitempty"` //Filters clients based on recent connection type. Can be one of 'Wired' or 'Wireless'.
 }
 type GetNetworkClientsApplicationUsageQueryParams struct {
@@ -99,6 +100,9 @@ type GetNetworkEventsQueryParams struct {
 	StartingAfter      string   `url:"startingAfter,omitempty"`        //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore       string   `url:"endingBefore,omitempty"`         //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
+type DeleteNetworkMerakiAuthUserQueryParams struct {
+	Delete bool `url:"delete,omitempty"` //If the ID supplied is for a splash guest or client VPN user, and that user is not authorized for any other networks in the organization, then also delete the user. 802.1X RADIUS users are always deleted regardless of this optional attribute.
+}
 type GetNetworkNetworkHealthChannelUtilizationQueryParams struct {
 	T0            string  `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
 	T1            string  `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
@@ -149,7 +153,14 @@ type GetNetworkTrafficQueryParams struct {
 	Timespan   float64 `url:"timespan,omitempty"`   //The timespan for which the information will be fetched. If specifying timespan, do not specify parameter t0. The value must be in seconds and be less than or equal to 30 days.
 	DeviceType string  `url:"deviceType,omitempty"` //Filter the data by device type: 'combined', 'wireless', 'switch' or 'appliance'. Defaults to 'combined'. When using 'combined', for each rule the data will come from the device type with the most usage.
 }
-
+type GetNetworkVLANProfilesAssignmentsByDeviceQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	Serials       []string `url:"serials[],omitempty"`      //Optional parameter to filter devices by serials. All devices returned belong to serial numbers that are an exact match.
+	ProductTypes  []string `url:"productTypes[],omitempty"` //Optional parameter to filter devices by product types.
+	StackIDs      []string `url:"stackIds[],omitempty"`     //Optional parameter to filter devices by Switch Stack ids.
+}
 type ResponseNetworksGetNetwork struct {
 	EnrollmentString        string   `json:"enrollmentString,omitempty"`        // Enrollment string for the network
 	ID                      string   `json:"id,omitempty"`                      // Network ID
@@ -231,7 +242,19 @@ type ResponseNetworksGetNetworkAlertsSettingsDefaultDestinations struct {
 	SNMP          *bool    `json:"snmp,omitempty"`          //
 }
 type ResponseNetworksUpdateNetworkAlertsSettings interface{}
-type ResponseNetworksBindNetwork interface{}
+type ResponseNetworksBindNetwork struct {
+	ConfigTemplateID        string   `json:"configTemplateId,omitempty"`        // ID of the config template the network is being bound to
+	EnrollmentString        string   `json:"enrollmentString,omitempty"`        // Enrollment string for the network
+	ID                      string   `json:"id,omitempty"`                      // Network ID
+	IsBoundToConfigTemplate *bool    `json:"isBoundToConfigTemplate,omitempty"` // If the network is bound to a config template
+	Name                    string   `json:"name,omitempty"`                    // Network name
+	Notes                   string   `json:"notes,omitempty"`                   // Notes for the network
+	OrganizationID          string   `json:"organizationId,omitempty"`          // Organization ID
+	ProductTypes            []string `json:"productTypes,omitempty"`            // List of the product types that the network supports
+	Tags                    []string `json:"tags,omitempty"`                    // Network tags
+	TimeZone                string   `json:"timeZone,omitempty"`                // Timezone of the network
+	URL                     string   `json:"url,omitempty"`                     // URL to the network Dashboard UI
+}
 type ResponseNetworksGetNetworkBluetoothClients []ResponseItemNetworksGetNetworkBluetoothClients // Array of ResponseNetworksGetNetworkBluetoothClients
 type ResponseItemNetworksGetNetworkBluetoothClients struct {
 	DeviceName      string   `json:"deviceName,omitempty"`      //
@@ -307,22 +330,34 @@ type ResponseItemNetworksGetNetworkClientsApplicationUsageApplicationUsage struc
 }
 type ResponseNetworksGetNetworkClientsBandwidthUsageHistory []ResponseItemNetworksGetNetworkClientsBandwidthUsageHistory // Array of ResponseNetworksGetNetworkClientsBandwidthUsageHistory
 type ResponseItemNetworksGetNetworkClientsBandwidthUsageHistory struct {
-	Total *int   `json:"total,omitempty"` //
-	Ts    string `json:"ts,omitempty"`    //
+	Downstream *float64 `json:"downstream,omitempty"` // The downstream traffic over a time range for clients on a network
+	Total      *float64 `json:"total,omitempty"`      // The total traffic over a time range for clients on a network
+	Ts         string   `json:"ts,omitempty"`         // The timestamp
+	Upstream   *float64 `json:"upstream,omitempty"`   // The upstream traffic over a time range for clients on a network
 }
 type ResponseNetworksGetNetworkClientsOverview struct {
-	Counts *ResponseNetworksGetNetworkClientsOverviewCounts `json:"counts,omitempty"` //
-	Usages *ResponseNetworksGetNetworkClientsOverviewUsages `json:"usages,omitempty"` //
+	Counts *ResponseNetworksGetNetworkClientsOverviewCounts `json:"counts,omitempty"` // The number of clients on a network over a given time range
+	Usages *ResponseNetworksGetNetworkClientsOverviewUsages `json:"usages,omitempty"` // The average usage of the clients on a network over a given time range
 }
 type ResponseNetworksGetNetworkClientsOverviewCounts struct {
-	Total          *int `json:"total,omitempty"`          //
-	WithHeavyUsage *int `json:"withHeavyUsage,omitempty"` //
+	Total          *int `json:"total,omitempty"`          // The total number of clients on a network
+	WithHeavyUsage *int `json:"withHeavyUsage,omitempty"` // The total number of clients with heavy usage on a network
 }
 type ResponseNetworksGetNetworkClientsOverviewUsages struct {
-	Average               *int `json:"average,omitempty"`               //
-	WithHeavyUsageAverage *int `json:"withHeavyUsageAverage,omitempty"` //
+	Average               *int `json:"average,omitempty"`               // The average usage of all clients on a network
+	WithHeavyUsageAverage *int `json:"withHeavyUsageAverage,omitempty"` // The average usage of all clients with heavy usage on a network
 }
-type ResponseNetworksProvisionNetworkClients interface{}
+type ResponseNetworksProvisionNetworkClients struct {
+	Clients       *[]ResponseNetworksProvisionNetworkClientsClients `json:"clients,omitempty"`       // The list of clients to provision
+	DevicePolicy  string                                            `json:"devicePolicy,omitempty"`  // The name of the client's policy
+	GroupPolicyID string                                            `json:"groupPolicyId,omitempty"` // The group policy identifier of the client
+}
+type ResponseNetworksProvisionNetworkClientsClients struct {
+	ClientID string `json:"clientId,omitempty"` // The identifier of the client
+	Mac      string `json:"mac,omitempty"`      // The MAC address of the client
+	Message  string `json:"message,omitempty"`  // The client's display message if its group policy is 'Blocked'
+	Name     string `json:"name,omitempty"`     // The name of the client
+}
 type ResponseNetworksGetNetworkClientsUsageHistories []ResponseItemNetworksGetNetworkClientsUsageHistories // Array of ResponseNetworksGetNetworkClientsUsageHistories
 type ResponseItemNetworksGetNetworkClientsUsageHistories struct {
 	ClientID     string                                                             `json:"clientId,omitempty"`     //
@@ -363,11 +398,15 @@ type ResponseNetworksGetNetworkClientClientVpnConnections struct {
 	RemoteIP       string `json:"remoteIp,omitempty"`       // The IP address of the VPN the client last connected to
 }
 type ResponseNetworksGetNetworkClientPolicy struct {
-	DevicePolicy  string `json:"devicePolicy,omitempty"`  //
-	GroupPolicyID string `json:"groupPolicyId,omitempty"` //
-	Mac           string `json:"mac,omitempty"`           //
+	DevicePolicy  string `json:"devicePolicy,omitempty"`  // The name of the client's policy
+	GroupPolicyID string `json:"groupPolicyId,omitempty"` // The group policy identifier of the client
+	Mac           string `json:"mac,omitempty"`           // The MAC address of the client
 }
-type ResponseNetworksUpdateNetworkClientPolicy interface{}
+type ResponseNetworksUpdateNetworkClientPolicy struct {
+	DevicePolicy  string `json:"devicePolicy,omitempty"`  // The name of the client's policy
+	GroupPolicyID string `json:"groupPolicyId,omitempty"` // The group policy identifier of the client
+	Mac           string `json:"mac,omitempty"`           // The MAC address of the client
+}
 type ResponseNetworksGetNetworkClientSplashAuthorizationStatus struct {
 	SSIDs *ResponseNetworksGetNetworkClientSplashAuthorizationStatusSSIDs `json:"ssids,omitempty"` //
 }
@@ -386,45 +425,68 @@ type ResponseNetworksGetNetworkClientSplashAuthorizationStatusSSIDs2 struct {
 type ResponseNetworksUpdateNetworkClientSplashAuthorizationStatus interface{}
 type ResponseNetworksGetNetworkClientTrafficHistory []ResponseItemNetworksGetNetworkClientTrafficHistory // Array of ResponseNetworksGetNetworkClientTrafficHistory
 type ResponseItemNetworksGetNetworkClientTrafficHistory struct {
-	ActiveSeconds *int   `json:"activeSeconds,omitempty"` //
-	Application   string `json:"application,omitempty"`   //
-	Destination   string `json:"destination,omitempty"`   //
-	NumFlows      *int   `json:"numFlows,omitempty"`      //
-	Port          *int   `json:"port,omitempty"`          //
-	Protocol      string `json:"protocol,omitempty"`      //
-	Recv          *int   `json:"recv,omitempty"`          //
-	Sent          *int   `json:"sent,omitempty"`          //
-	Ts            string `json:"ts,omitempty"`            //
+	ActiveSeconds *int     `json:"activeSeconds,omitempty"` // The amount of seconds the client was active
+	Application   string   `json:"application,omitempty"`   // The name of the application the client is connected to
+	Destination   string   `json:"destination,omitempty"`   // The IP or web address the client is connected to
+	NumFlows      *int     `json:"numFlows,omitempty"`      // The number of flows the client has
+	Port          *int     `json:"port,omitempty"`          // The port the client is connected to
+	Protocol      string   `json:"protocol,omitempty"`      // The client protocol
+	Recv          *float64 `json:"recv,omitempty"`          // Usage received by the client
+	Sent          *float64 `json:"sent,omitempty"`          // Usage sent by the client
+	Ts            string   `json:"ts,omitempty"`            // The timestamp of when the client was connected to an application
 }
 type ResponseNetworksGetNetworkClientUsageHistory []ResponseItemNetworksGetNetworkClientUsageHistory // Array of ResponseNetworksGetNetworkClientUsageHistory
 type ResponseItemNetworksGetNetworkClientUsageHistory struct {
-	Received *int   `json:"received,omitempty"` //
-	Sent     *int   `json:"sent,omitempty"`     //
-	Ts       string `json:"ts,omitempty"`       //
+	Received *float64 `json:"received,omitempty"` // Usage received by the client on a given day
+	Sent     *float64 `json:"sent,omitempty"`     // Usage sent by the client on a given day
+	Ts       string   `json:"ts,omitempty"`       // The day's timestamp
 }
 type ResponseNetworksGetNetworkDevices []ResponseItemNetworksGetNetworkDevices // Array of ResponseNetworksGetNetworkDevices
 type ResponseItemNetworksGetNetworkDevices struct {
-	Address        string                                               `json:"address,omitempty"`        //
-	BeaconIDParams *ResponseItemNetworksGetNetworkDevicesBeaconIDParams `json:"beaconIdParams,omitempty"` //
-	Firmware       string                                               `json:"firmware,omitempty"`       //
-	FloorPlanID    string                                               `json:"floorPlanId,omitempty"`    //
-	LanIP          string                                               `json:"lanIp,omitempty"`          //
-	Lat            *float64                                             `json:"lat,omitempty"`            //
-	Lng            *float64                                             `json:"lng,omitempty"`            //
-	Mac            string                                               `json:"mac,omitempty"`            //
-	Model          string                                               `json:"model,omitempty"`          //
-	Name           string                                               `json:"name,omitempty"`           //
-	NetworkID      string                                               `json:"networkId,omitempty"`      //
-	Notes          string                                               `json:"notes,omitempty"`          //
-	Serial         string                                               `json:"serial,omitempty"`         //
-	Tags           string                                               `json:"tags,omitempty"`           //
+	Address     string                                          `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseItemNetworksGetNetworkDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                          `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                          `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                          `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                        `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                        `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                          `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                          `json:"model,omitempty"`       // Model of the device
+	Name        string                                          `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                          `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                          `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                          `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                          `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                        `json:"tags,omitempty"`        // List of tags assigned to the device
 }
-type ResponseItemNetworksGetNetworkDevicesBeaconIDParams struct {
-	Major *int   `json:"major,omitempty"` //
-	Minor *int   `json:"minor,omitempty"` //
-	UUID  string `json:"uuid,omitempty"`  //
+type ResponseItemNetworksGetNetworkDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
-type ResponseNetworksVmxNetworkDevicesClaim interface{}
+type ResponseNetworksClaimNetworkDevices struct {
+	Serials []string `json:"serials,omitempty"` // The serials of the devices
+}
+type ResponseNetworksVmxNetworkDevicesClaim struct {
+	Address     string                                           `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseNetworksVmxNetworkDevicesClaimDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                           `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                           `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                           `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                         `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                         `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                           `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                           `json:"model,omitempty"`       // Model of the device
+	Name        string                                           `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                           `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                           `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                           `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                           `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                         `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseNetworksVmxNetworkDevicesClaimDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
 type ResponseNetworksGetNetworkEvents struct {
 	Events      *[]ResponseNetworksGetNetworkEventsEvents `json:"events,omitempty"`      // An array of events that took place in the network.
 	Message     string                                    `json:"message,omitempty"`     // A message regarding the events sent. Usually 'null' unless there are no events
@@ -1335,7 +1397,25 @@ type ResponseItemNetworksGetNetworkFirmwareUpgradesStagedGroupsAssignedDevicesSw
 	ID   string `json:"id,omitempty"`   // ID of the Switch Stack
 	Name string `json:"name,omitempty"` // Name of the Switch Stack
 }
-type ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup interface{}
+type ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup struct {
+	AssignedDevices *ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevices `json:"assignedDevices,omitempty"` // The devices and Switch Stacks assigned to the Group
+	Description     string                                                                   `json:"description,omitempty"`     // Description of the Staged Upgrade Group
+	GroupID         string                                                                   `json:"groupId,omitempty"`         // Id of staged upgrade group
+	IsDefault       *bool                                                                    `json:"isDefault,omitempty"`       // Boolean indicating the default Group. Any device that does not have a group explicitly assigned will upgrade with this group
+	Name            string                                                                   `json:"name,omitempty"`            // Name of the Staged Upgrade Group
+}
+type ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevices struct {
+	Devices      *[]ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevicesDevices      `json:"devices,omitempty"`      // Data Array of Devices containing the name and serial
+	SwitchStacks *[]ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevicesSwitchStacks `json:"switchStacks,omitempty"` // Data Array of Switch Stacks containing the name and id
+}
+type ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevicesDevices struct {
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Serial string `json:"serial,omitempty"` // Serial of the device
+}
+type ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroupAssignedDevicesSwitchStacks struct {
+	ID   string `json:"id,omitempty"`   // ID of the Switch Stack
+	Name string `json:"name,omitempty"` // Name of the Switch Stack
+}
 type ResponseNetworksGetNetworkFirmwareUpgradesStagedGroup struct {
 	AssignedDevices *ResponseNetworksGetNetworkFirmwareUpgradesStagedGroupAssignedDevices `json:"assignedDevices,omitempty"` // The devices and Switch Stacks assigned to the Group
 	Description     string                                                                `json:"description,omitempty"`     // Description of the Staged Upgrade Group
@@ -1355,7 +1435,25 @@ type ResponseNetworksGetNetworkFirmwareUpgradesStagedGroupAssignedDevicesSwitchS
 	ID   string `json:"id,omitempty"`   // ID of the Switch Stack
 	Name string `json:"name,omitempty"` // Name of the Switch Stack
 }
-type ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroup interface{}
+type ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroup struct {
+	AssignedDevices *ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevices `json:"assignedDevices,omitempty"` // The devices and Switch Stacks assigned to the Group
+	Description     string                                                                   `json:"description,omitempty"`     // Description of the Staged Upgrade Group
+	GroupID         string                                                                   `json:"groupId,omitempty"`         // Id of staged upgrade group
+	IsDefault       *bool                                                                    `json:"isDefault,omitempty"`       // Boolean indicating the default Group. Any device that does not have a group explicitly assigned will upgrade with this group
+	Name            string                                                                   `json:"name,omitempty"`            // Name of the Staged Upgrade Group
+}
+type ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevices struct {
+	Devices      *[]ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevicesDevices      `json:"devices,omitempty"`      // Data Array of Devices containing the name and serial
+	SwitchStacks *[]ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevicesSwitchStacks `json:"switchStacks,omitempty"` // Data Array of Switch Stacks containing the name and id
+}
+type ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevicesDevices struct {
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Serial string `json:"serial,omitempty"` // Serial of the device
+}
+type ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroupAssignedDevicesSwitchStacks struct {
+	ID   string `json:"id,omitempty"`   // ID of the Switch Stack
+	Name string `json:"name,omitempty"` // Name of the Switch Stack
+}
 type ResponseNetworksGetNetworkFirmwareUpgradesStagedStages []ResponseItemNetworksGetNetworkFirmwareUpgradesStagedStages // Array of ResponseNetworksGetNetworkFirmwareUpgradesStagedStages
 type ResponseItemNetworksGetNetworkFirmwareUpgradesStagedStages struct {
 	Group *ResponseItemNetworksGetNetworkFirmwareUpgradesStagedStagesGroup `json:"group,omitempty"` // The Staged Upgrade Group
@@ -1376,384 +1474,812 @@ type ResponseItemNetworksUpdateNetworkFirmwareUpgradesStagedStagesGroup struct {
 }
 type ResponseNetworksGetNetworkFloorPlans []ResponseItemNetworksGetNetworkFloorPlans // Array of ResponseNetworksGetNetworkFloorPlans
 type ResponseItemNetworksGetNetworkFloorPlans struct {
-	BottomLeftCorner  *ResponseItemNetworksGetNetworkFloorPlansBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  //
-	BottomRightCorner *ResponseItemNetworksGetNetworkFloorPlansBottomRightCorner `json:"bottomRightCorner,omitempty"` //
-	Center            *ResponseItemNetworksGetNetworkFloorPlansCenter            `json:"center,omitempty"`            //
-	Devices           *[]ResponseItemNetworksGetNetworkFloorPlansDevices         `json:"devices,omitempty"`           //
-	FloorPlanID       string                                                     `json:"floorPlanId,omitempty"`       //
-	Height            *float64                                                   `json:"height,omitempty"`            //
-	ImageExtension    string                                                     `json:"imageExtension,omitempty"`    //
-	ImageMd5          string                                                     `json:"imageMd5,omitempty"`          //
-	ImageURL          string                                                     `json:"imageUrl,omitempty"`          //
-	ImageURLExpiresAt string                                                     `json:"imageUrlExpiresAt,omitempty"` //
-	Name              string                                                     `json:"name,omitempty"`              //
-	TopLeftCorner     *ResponseItemNetworksGetNetworkFloorPlansTopLeftCorner     `json:"topLeftCorner,omitempty"`     //
-	TopRightCorner    *ResponseItemNetworksGetNetworkFloorPlansTopRightCorner    `json:"topRightCorner,omitempty"`    //
-	Width             *int                                                       `json:"width,omitempty"`             //
+	BottomLeftCorner  *ResponseItemNetworksGetNetworkFloorPlansBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  // The longitude and latitude of the bottom left corner of your floor plan.
+	BottomRightCorner *ResponseItemNetworksGetNetworkFloorPlansBottomRightCorner `json:"bottomRightCorner,omitempty"` // The longitude and latitude of the bottom right corner of your floor plan.
+	Center            *ResponseItemNetworksGetNetworkFloorPlansCenter            `json:"center,omitempty"`            // The longitude and latitude of the center of your floor plan. The 'center' or two adjacent corners (e.g. 'topLeftCorner' and 'bottomLeftCorner') must be specified. If 'center' is specified, the floor plan is placed over that point with no rotation. If two adjacent corners are specified, the floor plan is rotated to line up with the two specified points. The aspect ratio of the floor plan's image is preserved regardless of which corners/center are specified. (This means if that more than two corners are specified, only two corners may be used to preserve the floor plan's aspect ratio.). No two points can have the same latitude, longitude pair.
+	Devices           *[]ResponseItemNetworksGetNetworkFloorPlansDevices         `json:"devices,omitempty"`           // List of devices for the floorplan
+	FloorPlanID       string                                                     `json:"floorPlanId,omitempty"`       // Floor plan ID
+	Height            *float64                                                   `json:"height,omitempty"`            // The height of your floor plan.
+	ImageExtension    string                                                     `json:"imageExtension,omitempty"`    // The format type of the image.
+	ImageMd5          string                                                     `json:"imageMd5,omitempty"`          // The file contents (a base 64 encoded string) of your new image. Supported formats are PNG, GIF, and JPG. Note that all images are saved as PNG files, regardless of the format they are uploaded in. If you upload a new image, and you do NOT specify any new geolocation fields ('center, 'topLeftCorner', etc), the floor plan will be recentered with no rotation in order to maintain the aspect ratio of your new image.
+	ImageURL          string                                                     `json:"imageUrl,omitempty"`          // The url link for the floor plan image.
+	ImageURLExpiresAt string                                                     `json:"imageUrlExpiresAt,omitempty"` // The time the image url link will expire.
+	Name              string                                                     `json:"name,omitempty"`              // The name of your floor plan.
+	TopLeftCorner     *ResponseItemNetworksGetNetworkFloorPlansTopLeftCorner     `json:"topLeftCorner,omitempty"`     // The longitude and latitude of the top left corner of your floor plan.
+	TopRightCorner    *ResponseItemNetworksGetNetworkFloorPlansTopRightCorner    `json:"topRightCorner,omitempty"`    // The longitude and latitude of the top right corner of your floor plan.
+	Width             *float64                                                   `json:"width,omitempty"`             // The width of your floor plan.
 }
 type ResponseItemNetworksGetNetworkFloorPlansBottomLeftCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseItemNetworksGetNetworkFloorPlansBottomRightCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseItemNetworksGetNetworkFloorPlansCenter struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseItemNetworksGetNetworkFloorPlansDevices struct {
-	Address        string                                                         `json:"address,omitempty"`        //
-	BeaconIDParams *ResponseItemNetworksGetNetworkFloorPlansDevicesBeaconIDParams `json:"beaconIdParams,omitempty"` //
-	Firmware       string                                                         `json:"firmware,omitempty"`       //
-	FloorPlanID    string                                                         `json:"floorPlanId,omitempty"`    //
-	LanIP          string                                                         `json:"lanIp,omitempty"`          //
-	Lat            *float64                                                       `json:"lat,omitempty"`            //
-	Lng            *float64                                                       `json:"lng,omitempty"`            //
-	Mac            string                                                         `json:"mac,omitempty"`            //
-	Model          string                                                         `json:"model,omitempty"`          //
-	Name           string                                                         `json:"name,omitempty"`           //
-	NetworkID      string                                                         `json:"networkId,omitempty"`      //
-	Notes          string                                                         `json:"notes,omitempty"`          //
-	Serial         string                                                         `json:"serial,omitempty"`         //
-	Tags           []string                                                       `json:"tags,omitempty"`           //
+	Address     string                                                    `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseItemNetworksGetNetworkFloorPlansDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                                    `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                                    `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                                    `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                                  `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                                  `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                                    `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                                    `json:"model,omitempty"`       // Model of the device
+	Name        string                                                    `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                                    `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                                    `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                                    `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                                    `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                                  `json:"tags,omitempty"`        // List of tags assigned to the device
 }
-type ResponseItemNetworksGetNetworkFloorPlansDevicesBeaconIDParams struct {
-	Major *int   `json:"major,omitempty"` //
-	Minor *int   `json:"minor,omitempty"` //
-	UUID  string `json:"uuid,omitempty"`  //
+type ResponseItemNetworksGetNetworkFloorPlansDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseItemNetworksGetNetworkFloorPlansTopLeftCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseItemNetworksGetNetworkFloorPlansTopRightCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
-type ResponseNetworksCreateNetworkFloorPlan interface{}
+type ResponseNetworksCreateNetworkFloorPlan struct {
+	BottomLeftCorner  *ResponseNetworksCreateNetworkFloorPlanBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  // The longitude and latitude of the bottom left corner of your floor plan.
+	BottomRightCorner *ResponseNetworksCreateNetworkFloorPlanBottomRightCorner `json:"bottomRightCorner,omitempty"` // The longitude and latitude of the bottom right corner of your floor plan.
+	Center            *ResponseNetworksCreateNetworkFloorPlanCenter            `json:"center,omitempty"`            // The longitude and latitude of the center of your floor plan. The 'center' or two adjacent corners (e.g. 'topLeftCorner' and 'bottomLeftCorner') must be specified. If 'center' is specified, the floor plan is placed over that point with no rotation. If two adjacent corners are specified, the floor plan is rotated to line up with the two specified points. The aspect ratio of the floor plan's image is preserved regardless of which corners/center are specified. (This means if that more than two corners are specified, only two corners may be used to preserve the floor plan's aspect ratio.). No two points can have the same latitude, longitude pair.
+	Devices           *[]ResponseNetworksCreateNetworkFloorPlanDevices         `json:"devices,omitempty"`           // List of devices for the floorplan
+	FloorPlanID       string                                                   `json:"floorPlanId,omitempty"`       // Floor plan ID
+	Height            *float64                                                 `json:"height,omitempty"`            // The height of your floor plan.
+	ImageExtension    string                                                   `json:"imageExtension,omitempty"`    // The format type of the image.
+	ImageMd5          string                                                   `json:"imageMd5,omitempty"`          // The file contents (a base 64 encoded string) of your new image. Supported formats are PNG, GIF, and JPG. Note that all images are saved as PNG files, regardless of the format they are uploaded in. If you upload a new image, and you do NOT specify any new geolocation fields ('center, 'topLeftCorner', etc), the floor plan will be recentered with no rotation in order to maintain the aspect ratio of your new image.
+	ImageURL          string                                                   `json:"imageUrl,omitempty"`          // The url link for the floor plan image.
+	ImageURLExpiresAt string                                                   `json:"imageUrlExpiresAt,omitempty"` // The time the image url link will expire.
+	Name              string                                                   `json:"name,omitempty"`              // The name of your floor plan.
+	TopLeftCorner     *ResponseNetworksCreateNetworkFloorPlanTopLeftCorner     `json:"topLeftCorner,omitempty"`     // The longitude and latitude of the top left corner of your floor plan.
+	TopRightCorner    *ResponseNetworksCreateNetworkFloorPlanTopRightCorner    `json:"topRightCorner,omitempty"`    // The longitude and latitude of the top right corner of your floor plan.
+	Width             *float64                                                 `json:"width,omitempty"`             // The width of your floor plan.
+}
+type ResponseNetworksCreateNetworkFloorPlanBottomLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksCreateNetworkFloorPlanBottomRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksCreateNetworkFloorPlanCenter struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksCreateNetworkFloorPlanDevices struct {
+	Address     string                                                  `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseNetworksCreateNetworkFloorPlanDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                                  `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                                  `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                                  `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                                `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                                `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                                  `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                                  `json:"model,omitempty"`       // Model of the device
+	Name        string                                                  `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                                  `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                                  `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                                  `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                                  `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                                `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseNetworksCreateNetworkFloorPlanDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseNetworksCreateNetworkFloorPlanTopLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksCreateNetworkFloorPlanTopRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksDeleteNetworkFloorPlan struct {
+	BottomLeftCorner  *ResponseNetworksDeleteNetworkFloorPlanBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  // The longitude and latitude of the bottom left corner of your floor plan.
+	BottomRightCorner *ResponseNetworksDeleteNetworkFloorPlanBottomRightCorner `json:"bottomRightCorner,omitempty"` // The longitude and latitude of the bottom right corner of your floor plan.
+	Center            *ResponseNetworksDeleteNetworkFloorPlanCenter            `json:"center,omitempty"`            // The longitude and latitude of the center of your floor plan. The 'center' or two adjacent corners (e.g. 'topLeftCorner' and 'bottomLeftCorner') must be specified. If 'center' is specified, the floor plan is placed over that point with no rotation. If two adjacent corners are specified, the floor plan is rotated to line up with the two specified points. The aspect ratio of the floor plan's image is preserved regardless of which corners/center are specified. (This means if that more than two corners are specified, only two corners may be used to preserve the floor plan's aspect ratio.). No two points can have the same latitude, longitude pair.
+	Devices           *[]ResponseNetworksDeleteNetworkFloorPlanDevices         `json:"devices,omitempty"`           // List of devices for the floorplan
+	FloorPlanID       string                                                   `json:"floorPlanId,omitempty"`       // Floor plan ID
+	Height            *float64                                                 `json:"height,omitempty"`            // The height of your floor plan.
+	ImageExtension    string                                                   `json:"imageExtension,omitempty"`    // The format type of the image.
+	ImageMd5          string                                                   `json:"imageMd5,omitempty"`          // The file contents (a base 64 encoded string) of your new image. Supported formats are PNG, GIF, and JPG. Note that all images are saved as PNG files, regardless of the format they are uploaded in. If you upload a new image, and you do NOT specify any new geolocation fields ('center, 'topLeftCorner', etc), the floor plan will be recentered with no rotation in order to maintain the aspect ratio of your new image.
+	ImageURL          string                                                   `json:"imageUrl,omitempty"`          // The url link for the floor plan image.
+	ImageURLExpiresAt string                                                   `json:"imageUrlExpiresAt,omitempty"` // The time the image url link will expire.
+	Name              string                                                   `json:"name,omitempty"`              // The name of your floor plan.
+	TopLeftCorner     *ResponseNetworksDeleteNetworkFloorPlanTopLeftCorner     `json:"topLeftCorner,omitempty"`     // The longitude and latitude of the top left corner of your floor plan.
+	TopRightCorner    *ResponseNetworksDeleteNetworkFloorPlanTopRightCorner    `json:"topRightCorner,omitempty"`    // The longitude and latitude of the top right corner of your floor plan.
+	Width             *float64                                                 `json:"width,omitempty"`             // The width of your floor plan.
+}
+type ResponseNetworksDeleteNetworkFloorPlanBottomLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksDeleteNetworkFloorPlanBottomRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksDeleteNetworkFloorPlanCenter struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksDeleteNetworkFloorPlanDevices struct {
+	Address     string                                                  `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseNetworksDeleteNetworkFloorPlanDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                                  `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                                  `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                                  `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                                `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                                `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                                  `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                                  `json:"model,omitempty"`       // Model of the device
+	Name        string                                                  `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                                  `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                                  `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                                  `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                                  `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                                `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseNetworksDeleteNetworkFloorPlanDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseNetworksDeleteNetworkFloorPlanTopLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksDeleteNetworkFloorPlanTopRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
 type ResponseNetworksGetNetworkFloorPlan struct {
-	BottomLeftCorner  *ResponseNetworksGetNetworkFloorPlanBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  //
-	BottomRightCorner *ResponseNetworksGetNetworkFloorPlanBottomRightCorner `json:"bottomRightCorner,omitempty"` //
-	Center            *ResponseNetworksGetNetworkFloorPlanCenter            `json:"center,omitempty"`            //
-	Devices           *[]ResponseNetworksGetNetworkFloorPlanDevices         `json:"devices,omitempty"`           //
-	FloorPlanID       string                                                `json:"floorPlanId,omitempty"`       //
-	Height            *float64                                              `json:"height,omitempty"`            //
-	ImageExtension    string                                                `json:"imageExtension,omitempty"`    //
-	ImageMd5          string                                                `json:"imageMd5,omitempty"`          //
-	ImageURL          string                                                `json:"imageUrl,omitempty"`          //
-	ImageURLExpiresAt string                                                `json:"imageUrlExpiresAt,omitempty"` //
-	Name              string                                                `json:"name,omitempty"`              //
-	TopLeftCorner     *ResponseNetworksGetNetworkFloorPlanTopLeftCorner     `json:"topLeftCorner,omitempty"`     //
-	TopRightCorner    *ResponseNetworksGetNetworkFloorPlanTopRightCorner    `json:"topRightCorner,omitempty"`    //
-	Width             *int                                                  `json:"width,omitempty"`             //
+	BottomLeftCorner  *ResponseNetworksGetNetworkFloorPlanBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  // The longitude and latitude of the bottom left corner of your floor plan.
+	BottomRightCorner *ResponseNetworksGetNetworkFloorPlanBottomRightCorner `json:"bottomRightCorner,omitempty"` // The longitude and latitude of the bottom right corner of your floor plan.
+	Center            *ResponseNetworksGetNetworkFloorPlanCenter            `json:"center,omitempty"`            // The longitude and latitude of the center of your floor plan. The 'center' or two adjacent corners (e.g. 'topLeftCorner' and 'bottomLeftCorner') must be specified. If 'center' is specified, the floor plan is placed over that point with no rotation. If two adjacent corners are specified, the floor plan is rotated to line up with the two specified points. The aspect ratio of the floor plan's image is preserved regardless of which corners/center are specified. (This means if that more than two corners are specified, only two corners may be used to preserve the floor plan's aspect ratio.). No two points can have the same latitude, longitude pair.
+	Devices           *[]ResponseNetworksGetNetworkFloorPlanDevices         `json:"devices,omitempty"`           // List of devices for the floorplan
+	FloorPlanID       string                                                `json:"floorPlanId,omitempty"`       // Floor plan ID
+	Height            *float64                                              `json:"height,omitempty"`            // The height of your floor plan.
+	ImageExtension    string                                                `json:"imageExtension,omitempty"`    // The format type of the image.
+	ImageMd5          string                                                `json:"imageMd5,omitempty"`          // The file contents (a base 64 encoded string) of your new image. Supported formats are PNG, GIF, and JPG. Note that all images are saved as PNG files, regardless of the format they are uploaded in. If you upload a new image, and you do NOT specify any new geolocation fields ('center, 'topLeftCorner', etc), the floor plan will be recentered with no rotation in order to maintain the aspect ratio of your new image.
+	ImageURL          string                                                `json:"imageUrl,omitempty"`          // The url link for the floor plan image.
+	ImageURLExpiresAt string                                                `json:"imageUrlExpiresAt,omitempty"` // The time the image url link will expire.
+	Name              string                                                `json:"name,omitempty"`              // The name of your floor plan.
+	TopLeftCorner     *ResponseNetworksGetNetworkFloorPlanTopLeftCorner     `json:"topLeftCorner,omitempty"`     // The longitude and latitude of the top left corner of your floor plan.
+	TopRightCorner    *ResponseNetworksGetNetworkFloorPlanTopRightCorner    `json:"topRightCorner,omitempty"`    // The longitude and latitude of the top right corner of your floor plan.
+	Width             *float64                                              `json:"width,omitempty"`             // The width of your floor plan.
 }
 type ResponseNetworksGetNetworkFloorPlanBottomLeftCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseNetworksGetNetworkFloorPlanBottomRightCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseNetworksGetNetworkFloorPlanCenter struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseNetworksGetNetworkFloorPlanDevices struct {
-	Address        string                                                    `json:"address,omitempty"`        //
-	BeaconIDParams *ResponseNetworksGetNetworkFloorPlanDevicesBeaconIDParams `json:"beaconIdParams,omitempty"` //
-	Firmware       string                                                    `json:"firmware,omitempty"`       //
-	FloorPlanID    string                                                    `json:"floorPlanId,omitempty"`    //
-	LanIP          string                                                    `json:"lanIp,omitempty"`          //
-	Lat            *float64                                                  `json:"lat,omitempty"`            //
-	Lng            *float64                                                  `json:"lng,omitempty"`            //
-	Mac            string                                                    `json:"mac,omitempty"`            //
-	Model          string                                                    `json:"model,omitempty"`          //
-	Name           string                                                    `json:"name,omitempty"`           //
-	NetworkID      string                                                    `json:"networkId,omitempty"`      //
-	Notes          string                                                    `json:"notes,omitempty"`          //
-	Serial         string                                                    `json:"serial,omitempty"`         //
-	Tags           []string                                                  `json:"tags,omitempty"`           //
+	Address     string                                               `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseNetworksGetNetworkFloorPlanDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                               `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                               `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                               `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                             `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                             `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                               `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                               `json:"model,omitempty"`       // Model of the device
+	Name        string                                               `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                               `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                               `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                               `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                               `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                             `json:"tags,omitempty"`        // List of tags assigned to the device
 }
-type ResponseNetworksGetNetworkFloorPlanDevicesBeaconIDParams struct {
-	Major *int   `json:"major,omitempty"` //
-	Minor *int   `json:"minor,omitempty"` //
-	UUID  string `json:"uuid,omitempty"`  //
+type ResponseNetworksGetNetworkFloorPlanDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseNetworksGetNetworkFloorPlanTopLeftCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
 type ResponseNetworksGetNetworkFloorPlanTopRightCorner struct {
-	Lat *float64 `json:"lat,omitempty"` //
-	Lng *float64 `json:"lng,omitempty"` //
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
 }
-type ResponseNetworksUpdateNetworkFloorPlan interface{}
+type ResponseNetworksUpdateNetworkFloorPlan struct {
+	BottomLeftCorner  *ResponseNetworksUpdateNetworkFloorPlanBottomLeftCorner  `json:"bottomLeftCorner,omitempty"`  // The longitude and latitude of the bottom left corner of your floor plan.
+	BottomRightCorner *ResponseNetworksUpdateNetworkFloorPlanBottomRightCorner `json:"bottomRightCorner,omitempty"` // The longitude and latitude of the bottom right corner of your floor plan.
+	Center            *ResponseNetworksUpdateNetworkFloorPlanCenter            `json:"center,omitempty"`            // The longitude and latitude of the center of your floor plan. The 'center' or two adjacent corners (e.g. 'topLeftCorner' and 'bottomLeftCorner') must be specified. If 'center' is specified, the floor plan is placed over that point with no rotation. If two adjacent corners are specified, the floor plan is rotated to line up with the two specified points. The aspect ratio of the floor plan's image is preserved regardless of which corners/center are specified. (This means if that more than two corners are specified, only two corners may be used to preserve the floor plan's aspect ratio.). No two points can have the same latitude, longitude pair.
+	Devices           *[]ResponseNetworksUpdateNetworkFloorPlanDevices         `json:"devices,omitempty"`           // List of devices for the floorplan
+	FloorPlanID       string                                                   `json:"floorPlanId,omitempty"`       // Floor plan ID
+	Height            *float64                                                 `json:"height,omitempty"`            // The height of your floor plan.
+	ImageExtension    string                                                   `json:"imageExtension,omitempty"`    // The format type of the image.
+	ImageMd5          string                                                   `json:"imageMd5,omitempty"`          // The file contents (a base 64 encoded string) of your new image. Supported formats are PNG, GIF, and JPG. Note that all images are saved as PNG files, regardless of the format they are uploaded in. If you upload a new image, and you do NOT specify any new geolocation fields ('center, 'topLeftCorner', etc), the floor plan will be recentered with no rotation in order to maintain the aspect ratio of your new image.
+	ImageURL          string                                                   `json:"imageUrl,omitempty"`          // The url link for the floor plan image.
+	ImageURLExpiresAt string                                                   `json:"imageUrlExpiresAt,omitempty"` // The time the image url link will expire.
+	Name              string                                                   `json:"name,omitempty"`              // The name of your floor plan.
+	TopLeftCorner     *ResponseNetworksUpdateNetworkFloorPlanTopLeftCorner     `json:"topLeftCorner,omitempty"`     // The longitude and latitude of the top left corner of your floor plan.
+	TopRightCorner    *ResponseNetworksUpdateNetworkFloorPlanTopRightCorner    `json:"topRightCorner,omitempty"`    // The longitude and latitude of the top right corner of your floor plan.
+	Width             *float64                                                 `json:"width,omitempty"`             // The width of your floor plan.
+}
+type ResponseNetworksUpdateNetworkFloorPlanBottomLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksUpdateNetworkFloorPlanBottomRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksUpdateNetworkFloorPlanCenter struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksUpdateNetworkFloorPlanDevices struct {
+	Address     string                                                  `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseNetworksUpdateNetworkFloorPlanDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                                  `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                                  `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                                  `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                                `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                                `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                                  `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                                  `json:"model,omitempty"`       // Model of the device
+	Name        string                                                  `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                                  `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                                  `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                                  `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                                  `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                                `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseNetworksUpdateNetworkFloorPlanDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseNetworksUpdateNetworkFloorPlanTopLeftCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseNetworksUpdateNetworkFloorPlanTopRightCorner struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
 type ResponseNetworksGetNetworkGroupPolicies []ResponseItemNetworksGetNetworkGroupPolicies // Array of ResponseNetworksGetNetworkGroupPolicies
 type ResponseItemNetworksGetNetworkGroupPolicies struct {
-	Bandwidth                 *ResponseItemNetworksGetNetworkGroupPoliciesBandwidth                 `json:"bandwidth,omitempty"`                 //
-	BonjourForwarding         *ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwarding         `json:"bonjourForwarding,omitempty"`         //
-	ContentFiltering          *ResponseItemNetworksGetNetworkGroupPoliciesContentFiltering          `json:"contentFiltering,omitempty"`          //
-	FirewallAndTrafficShaping *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //
-	GroupPolicyID             string                                                                `json:"groupPolicyId,omitempty"`             //
-	Name                      string                                                                `json:"name,omitempty"`                      //
-	Scheduling                *ResponseItemNetworksGetNetworkGroupPoliciesScheduling                `json:"scheduling,omitempty"`                //
-	SplashAuthSettings        string                                                                `json:"splashAuthSettings,omitempty"`        //
-	VLANTagging               *ResponseItemNetworksGetNetworkGroupPoliciesVLANTagging               `json:"vlanTagging,omitempty"`               //
+	Bandwidth                 *ResponseItemNetworksGetNetworkGroupPoliciesBandwidth                 `json:"bandwidth,omitempty"`                 //     The bandwidth settings for clients bound to your group policy.
+	BonjourForwarding         *ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwarding         `json:"bonjourForwarding,omitempty"`         // The Bonjour settings for your group policy. Only valid if your network has a wireless configuration.
+	ContentFiltering          *ResponseItemNetworksGetNetworkGroupPoliciesContentFiltering          `json:"contentFiltering,omitempty"`          // The content filtering settings for your group policy
+	FirewallAndTrafficShaping *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //     The firewall and traffic shaping rules and settings for your policy.
+	GroupPolicyID             string                                                                `json:"groupPolicyId,omitempty"`             // The ID of the group policy
+	Scheduling                *ResponseItemNetworksGetNetworkGroupPoliciesScheduling                `json:"scheduling,omitempty"`                //     The schedule for the group policy. Schedules are applied to days of the week.
+	SplashAuthSettings        string                                                                `json:"splashAuthSettings,omitempty"`        // Whether clients bound to your policy will bypass splash authorization or behave according to the network's rules. Can be one of 'network default' or 'bypass'. Only available if your network has a wireless configuration.
+	VLANTagging               *ResponseItemNetworksGetNetworkGroupPoliciesVLANTagging               `json:"vlanTagging,omitempty"`               // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesBandwidth struct {
-	BandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	Settings        string                                                               `json:"settings,omitempty"`        //
+	BandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying upload and download speed for clients bound to the group policy. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                               `json:"settings,omitempty"`        // How bandwidth limits are enforced. Can be 'network default', 'ignore' or 'custom'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesBandwidthBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). null indicates no limit
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). null indicates no limit
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwarding struct {
-	Rules    *[]ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwardingRules `json:"rules,omitempty"`    //
-	Settings string                                                               `json:"settings,omitempty"` //
+	Rules    *[]ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwardingRules `json:"rules,omitempty"`    // A list of the Bonjour forwarding rules for your group policy. If 'settings' is set to 'custom', at least one rule must be specified.
+	Settings string                                                               `json:"settings,omitempty"` // How Bonjour rules are applied. Can be 'network default', 'ignore' or 'custom'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesBonjourForwardingRules struct {
-	Description string   `json:"description,omitempty"` //
-	Services    []string `json:"services,omitempty"`    //
-	VLANID      string   `json:"vlanId,omitempty"`      //
+	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesContentFiltering struct {
-	AllowedURLPatterns   *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   //
-	BlockedURLCategories *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` //
-	BlockedURLPatterns   *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   //
+	AllowedURLPatterns   *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   // Settings for allowed URL patterns
+	BlockedURLCategories *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` // Settings for blocked URL categories
+	BlockedURLPatterns   *ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   // Settings for blocked URL patterns
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringAllowedURLPatterns struct {
-	Patterns []string `json:"patterns,omitempty"` //
-	Settings string   `json:"settings,omitempty"` //
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are allowed
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLCategories struct {
-	Categories []string `json:"categories,omitempty"` //
-	Settings   string   `json:"settings,omitempty"`   //
+	Categories []string `json:"categories,omitempty"` // A list of URL categories to block
+	Settings   string   `json:"settings,omitempty"`   // How URL categories are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesContentFilteringBlockedURLPatterns struct {
-	Patterns []string `json:"patterns,omitempty"` //
-	Settings string   `json:"settings,omitempty"` //
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are blocked
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShaping struct {
-	L3FirewallRules     *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     //
-	L7FirewallRules     *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     //
-	Settings            string                                                                                     `json:"settings,omitempty"`            //
-	TrafficShapingRules *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //
+	L3FirewallRules     *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     // An ordered array of the L3 firewall rules
+	L7FirewallRules     *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     // An ordered array of L7 firewall rules
+	Settings            string                                                                                     `json:"settings,omitempty"`            // How firewall and traffic shaping rules are enforced. Can be 'network default', 'ignore' or 'custom'.
+	TrafficShapingRules *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL3FirewallRules struct {
-	Comment  string `json:"comment,omitempty"`  //
-	DestCidr string `json:"destCidr,omitempty"` //
-	DestPort string `json:"destPort,omitempty"` //
-	Policy   string `json:"policy,omitempty"`   //
-	Protocol string `json:"protocol,omitempty"` //
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Destination IP address (in IP or CIDR notation), a fully-qualified domain name (FQDN, if your network supports it) or 'any'.
+	DestPort string `json:"destPort,omitempty"` // Destination port (integer in the range 1-65535), a port range (e.g. 8080-9090), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingL7FirewallRules struct {
-	Policy string `json:"policy,omitempty"` //
-	Type   string `json:"type,omitempty"`   //
-	Value  string `json:"value,omitempty"`  //
+	Policy string `json:"policy,omitempty"` // The policy applied to matching traffic. Must be 'deny'.
+	Type   string `json:"type,omitempty"`   // Type of the L7 Rule. Must be 'application', 'applicationCategory', 'host', 'port' or 'ipRange'
+	Value  string `json:"value,omitempty"`  // The 'value' of what you want to block. If 'type' is 'host', 'port' or 'ipRange', 'value' must be a string matching either a hostname (e.g. somewhere.com), a port (e.g. 8080), or an IP range (e.g. 192.1.0.0/16). If 'type' is 'application' or 'applicationCategory', then 'value' must be an object with an ID for the application.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRules struct {
-	Definitions              *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //
-	DscpTagValue             *int                                                                                                             `json:"dscpTagValue,omitempty"`             //
-	PcpTagValue              *int                                                                                                             `json:"pcpTagValue,omitempty"`              //
-	PerClientBandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //
+	Definitions              *[]ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                                             `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                                             `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
+	Priority                 string                                                                                                           `json:"priority,omitempty"`                 //     A string, indicating the priority level for packets bound to your rule.     Can be 'low', 'normal' or 'high'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesDefinitions struct {
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits struct {
-	BandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	Settings        string                                                                                                                          `json:"settings,omitempty"`        //
+	BandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                                          `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesScheduling struct {
-	Enabled   *bool                                                           `json:"enabled,omitempty"`   //
-	Friday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingFriday    `json:"friday,omitempty"`    //
-	Monday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingMonday    `json:"monday,omitempty"`    //
-	Saturday  *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSaturday  `json:"saturday,omitempty"`  //
-	Sunday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSunday    `json:"sunday,omitempty"`    //
-	Thursday  *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingThursday  `json:"thursday,omitempty"`  //
-	Tuesday   *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingTuesday   `json:"tuesday,omitempty"`   //
-	Wednesday *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingWednesday `json:"wednesday,omitempty"` //
+	Enabled   *bool                                                           `json:"enabled,omitempty"`   // Whether scheduling is enabled (true) or disabled (false). Defaults to false. If true, the schedule objects for each day of the week (monday - sunday) are parsed.
+	Friday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingFriday    `json:"friday,omitempty"`    // The schedule object for Friday.
+	Monday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingMonday    `json:"monday,omitempty"`    // The schedule object for Monday.
+	Saturday  *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSaturday  `json:"saturday,omitempty"`  // The schedule object for Saturday.
+	Sunday    *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSunday    `json:"sunday,omitempty"`    // The schedule object for Sunday.
+	Thursday  *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingThursday  `json:"thursday,omitempty"`  // The schedule object for Thursday.
+	Tuesday   *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingTuesday   `json:"tuesday,omitempty"`   // The schedule object for Tuesday.
+	Wednesday *ResponseItemNetworksGetNetworkGroupPoliciesSchedulingWednesday `json:"wednesday,omitempty"` // The schedule object for Wednesday.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingFriday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingMonday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSaturday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingSunday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingThursday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingTuesday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesSchedulingWednesday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesVLANTagging struct {
-	Settings string `json:"settings,omitempty"` //
-	VLANID   string `json:"vlanId,omitempty"`   //
+	Settings string `json:"settings,omitempty"` // How VLAN tagging is applied. Can be 'network default', 'ignore' or 'custom'.
+	VLANID   string `json:"vlanId,omitempty"`   // The ID of the vlan you want to tag. This only applies if 'settings' is set to 'custom'.
 }
-type ResponseNetworksCreateNetworkGroupPolicy interface{}
+type ResponseNetworksCreateNetworkGroupPolicy struct {
+	Bandwidth                 *ResponseNetworksCreateNetworkGroupPolicyBandwidth                 `json:"bandwidth,omitempty"`                 //     The bandwidth settings for clients bound to your group policy.
+	BonjourForwarding         *ResponseNetworksCreateNetworkGroupPolicyBonjourForwarding         `json:"bonjourForwarding,omitempty"`         // The Bonjour settings for your group policy. Only valid if your network has a wireless configuration.
+	ContentFiltering          *ResponseNetworksCreateNetworkGroupPolicyContentFiltering          `json:"contentFiltering,omitempty"`          // The content filtering settings for your group policy
+	FirewallAndTrafficShaping *ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //     The firewall and traffic shaping rules and settings for your policy.
+	GroupPolicyID             string                                                             `json:"groupPolicyId,omitempty"`             // The ID of the group policy
+	Scheduling                *ResponseNetworksCreateNetworkGroupPolicyScheduling                `json:"scheduling,omitempty"`                //     The schedule for the group policy. Schedules are applied to days of the week.
+	SplashAuthSettings        string                                                             `json:"splashAuthSettings,omitempty"`        // Whether clients bound to your policy will bypass splash authorization or behave according to the network's rules. Can be one of 'network default' or 'bypass'. Only available if your network has a wireless configuration.
+	VLANTagging               *ResponseNetworksCreateNetworkGroupPolicyVLANTagging               `json:"vlanTagging,omitempty"`               // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
+}
+type ResponseNetworksCreateNetworkGroupPolicyBandwidth struct {
+	BandwidthLimits *ResponseNetworksCreateNetworkGroupPolicyBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying upload and download speed for clients bound to the group policy. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                            `json:"settings,omitempty"`        // How bandwidth limits are enforced. Can be 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyBandwidthBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). null indicates no limit
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). null indicates no limit
+}
+type ResponseNetworksCreateNetworkGroupPolicyBonjourForwarding struct {
+	Rules    *[]ResponseNetworksCreateNetworkGroupPolicyBonjourForwardingRules `json:"rules,omitempty"`    // A list of the Bonjour forwarding rules for your group policy. If 'settings' is set to 'custom', at least one rule must be specified.
+	Settings string                                                            `json:"settings,omitempty"` // How Bonjour rules are applied. Can be 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyBonjourForwardingRules struct {
+	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required.
+}
+type ResponseNetworksCreateNetworkGroupPolicyContentFiltering struct {
+	AllowedURLPatterns   *ResponseNetworksCreateNetworkGroupPolicyContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   // Settings for allowed URL patterns
+	BlockedURLCategories *ResponseNetworksCreateNetworkGroupPolicyContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` // Settings for blocked URL categories
+	BlockedURLPatterns   *ResponseNetworksCreateNetworkGroupPolicyContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   // Settings for blocked URL patterns
+}
+type ResponseNetworksCreateNetworkGroupPolicyContentFilteringAllowedURLPatterns struct {
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are allowed
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyContentFilteringBlockedURLCategories struct {
+	Categories []string `json:"categories,omitempty"` // A list of URL categories to block
+	Settings   string   `json:"settings,omitempty"`   // How URL categories are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyContentFilteringBlockedURLPatterns struct {
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are blocked
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShaping struct {
+	L3FirewallRules     *[]ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     // An ordered array of the L3 firewall rules
+	L7FirewallRules     *[]ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     // An ordered array of L7 firewall rules
+	Settings            string                                                                                  `json:"settings,omitempty"`            // How firewall and traffic shaping rules are enforced. Can be 'network default', 'ignore' or 'custom'.
+	TrafficShapingRules *[]ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules struct {
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Destination IP address (in IP or CIDR notation), a fully-qualified domain name (FQDN, if your network supports it) or 'any'.
+	DestPort string `json:"destPort,omitempty"` // Destination port (integer in the range 1-65535), a port range (e.g. 8080-9090), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules struct {
+	Policy string `json:"policy,omitempty"` // The policy applied to matching traffic. Must be 'deny'.
+	Type   string `json:"type,omitempty"`   // Type of the L7 Rule. Must be 'application', 'applicationCategory', 'host', 'port' or 'ipRange'
+	Value  string `json:"value,omitempty"`  // The 'value' of what you want to block. If 'type' is 'host', 'port' or 'ipRange', 'value' must be a string matching either a hostname (e.g. somewhere.com), a port (e.g. 8080), or an IP range (e.g. 192.1.0.0/16). If 'type' is 'application' or 'applicationCategory', then 'value' must be an object with an ID for the application.
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules struct {
+	Definitions              *[]ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                                          `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                                          `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
+	Priority                 string                                                                                                        `json:"priority,omitempty"`                 //     A string, indicating the priority level for packets bound to your rule.     Can be 'low', 'normal' or 'high'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions struct {
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits struct {
+	BandwidthLimits *ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                                       `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksCreateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
+}
+type ResponseNetworksCreateNetworkGroupPolicyScheduling struct {
+	Enabled   *bool                                                        `json:"enabled,omitempty"`   // Whether scheduling is enabled (true) or disabled (false). Defaults to false. If true, the schedule objects for each day of the week (monday - sunday) are parsed.
+	Friday    *ResponseNetworksCreateNetworkGroupPolicySchedulingFriday    `json:"friday,omitempty"`    // The schedule object for Friday.
+	Monday    *ResponseNetworksCreateNetworkGroupPolicySchedulingMonday    `json:"monday,omitempty"`    // The schedule object for Monday.
+	Saturday  *ResponseNetworksCreateNetworkGroupPolicySchedulingSaturday  `json:"saturday,omitempty"`  // The schedule object for Saturday.
+	Sunday    *ResponseNetworksCreateNetworkGroupPolicySchedulingSunday    `json:"sunday,omitempty"`    // The schedule object for Sunday.
+	Thursday  *ResponseNetworksCreateNetworkGroupPolicySchedulingThursday  `json:"thursday,omitempty"`  // The schedule object for Thursday.
+	Tuesday   *ResponseNetworksCreateNetworkGroupPolicySchedulingTuesday   `json:"tuesday,omitempty"`   // The schedule object for Tuesday.
+	Wednesday *ResponseNetworksCreateNetworkGroupPolicySchedulingWednesday `json:"wednesday,omitempty"` // The schedule object for Wednesday.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingFriday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingMonday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingSaturday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingSunday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingThursday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingTuesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicySchedulingWednesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksCreateNetworkGroupPolicyVLANTagging struct {
+	Settings string `json:"settings,omitempty"` // How VLAN tagging is applied. Can be 'network default', 'ignore' or 'custom'.
+	VLANID   string `json:"vlanId,omitempty"`   // The ID of the vlan you want to tag. This only applies if 'settings' is set to 'custom'.
+}
 type ResponseNetworksGetNetworkGroupPolicy struct {
-	Bandwidth                 *ResponseNetworksGetNetworkGroupPolicyBandwidth                 `json:"bandwidth,omitempty"`                 //
-	BonjourForwarding         *ResponseNetworksGetNetworkGroupPolicyBonjourForwarding         `json:"bonjourForwarding,omitempty"`         //
-	ContentFiltering          *ResponseNetworksGetNetworkGroupPolicyContentFiltering          `json:"contentFiltering,omitempty"`          //
-	FirewallAndTrafficShaping *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //
-	GroupPolicyID             string                                                          `json:"groupPolicyId,omitempty"`             //
-	Name                      string                                                          `json:"name,omitempty"`                      //
-	Scheduling                *ResponseNetworksGetNetworkGroupPolicyScheduling                `json:"scheduling,omitempty"`                //
-	SplashAuthSettings        string                                                          `json:"splashAuthSettings,omitempty"`        //
-	VLANTagging               *ResponseNetworksGetNetworkGroupPolicyVLANTagging               `json:"vlanTagging,omitempty"`               //
+	Bandwidth                 *ResponseNetworksGetNetworkGroupPolicyBandwidth                 `json:"bandwidth,omitempty"`                 //     The bandwidth settings for clients bound to your group policy.
+	BonjourForwarding         *ResponseNetworksGetNetworkGroupPolicyBonjourForwarding         `json:"bonjourForwarding,omitempty"`         // The Bonjour settings for your group policy. Only valid if your network has a wireless configuration.
+	ContentFiltering          *ResponseNetworksGetNetworkGroupPolicyContentFiltering          `json:"contentFiltering,omitempty"`          // The content filtering settings for your group policy
+	FirewallAndTrafficShaping *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //     The firewall and traffic shaping rules and settings for your policy.
+	GroupPolicyID             string                                                          `json:"groupPolicyId,omitempty"`             // The ID of the group policy
+	Name                      string                                                          `json:"name,omitempty"`                      // The ID of the group policy
+	Scheduling                *ResponseNetworksGetNetworkGroupPolicyScheduling                `json:"scheduling,omitempty"`                //     The schedule for the group policy. Schedules are applied to days of the week.
+	SplashAuthSettings        string                                                          `json:"splashAuthSettings,omitempty"`        // Whether clients bound to your policy will bypass splash authorization or behave according to the network's rules. Can be one of 'network default' or 'bypass'. Only available if your network has a wireless configuration.
+	VLANTagging               *ResponseNetworksGetNetworkGroupPolicyVLANTagging               `json:"vlanTagging,omitempty"`               // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
 }
 type ResponseNetworksGetNetworkGroupPolicyBandwidth struct {
-	BandwidthLimits *ResponseNetworksGetNetworkGroupPolicyBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	Settings        string                                                         `json:"settings,omitempty"`        //
+	BandwidthLimits *ResponseNetworksGetNetworkGroupPolicyBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying upload and download speed for clients bound to the group policy. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                         `json:"settings,omitempty"`        // How bandwidth limits are enforced. Can be 'network default', 'ignore' or 'custom'.
 }
 type ResponseNetworksGetNetworkGroupPolicyBandwidthBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). null indicates no limit
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). null indicates no limit
 }
 type ResponseNetworksGetNetworkGroupPolicyBonjourForwarding struct {
-	Rules    *[]ResponseNetworksGetNetworkGroupPolicyBonjourForwardingRules `json:"rules,omitempty"`    //
-	Settings string                                                         `json:"settings,omitempty"` //
+	Rules    *[]ResponseNetworksGetNetworkGroupPolicyBonjourForwardingRules `json:"rules,omitempty"`    // A list of the Bonjour forwarding rules for your group policy. If 'settings' is set to 'custom', at least one rule must be specified.
+	Settings string                                                         `json:"settings,omitempty"` // How Bonjour rules are applied. Can be 'network default', 'ignore' or 'custom'.
 }
 type ResponseNetworksGetNetworkGroupPolicyBonjourForwardingRules struct {
-	Description string   `json:"description,omitempty"` //
-	Services    []string `json:"services,omitempty"`    //
-	VLANID      string   `json:"vlanId,omitempty"`      //
+	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required.
 }
 type ResponseNetworksGetNetworkGroupPolicyContentFiltering struct {
-	AllowedURLPatterns   *ResponseNetworksGetNetworkGroupPolicyContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   //
-	BlockedURLCategories *ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` //
-	BlockedURLPatterns   *ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   //
+	AllowedURLPatterns   *ResponseNetworksGetNetworkGroupPolicyContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   // Settings for allowed URL patterns
+	BlockedURLCategories *ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` // Settings for blocked URL categories
+	BlockedURLPatterns   *ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   // Settings for blocked URL patterns
 }
 type ResponseNetworksGetNetworkGroupPolicyContentFilteringAllowedURLPatterns struct {
-	Patterns []string `json:"patterns,omitempty"` //
-	Settings string   `json:"settings,omitempty"` //
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are allowed
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLCategories struct {
-	Categories []string `json:"categories,omitempty"` //
-	Settings   string   `json:"settings,omitempty"`   //
+	Categories []string `json:"categories,omitempty"` // A list of URL categories to block
+	Settings   string   `json:"settings,omitempty"`   // How URL categories are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseNetworksGetNetworkGroupPolicyContentFilteringBlockedURLPatterns struct {
-	Patterns []string `json:"patterns,omitempty"` //
-	Settings string   `json:"settings,omitempty"` //
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are blocked
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShaping struct {
-	L3FirewallRules     *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     //
-	L7FirewallRules     *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     //
-	Settings            string                                                                               `json:"settings,omitempty"`            //
-	TrafficShapingRules *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //
+	L3FirewallRules     *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     // An ordered array of the L3 firewall rules
+	L7FirewallRules     *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     // An ordered array of L7 firewall rules
+	Settings            string                                                                               `json:"settings,omitempty"`            // How firewall and traffic shaping rules are enforced. Can be 'network default', 'ignore' or 'custom'.
+	TrafficShapingRules *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules struct {
-	Comment  string `json:"comment,omitempty"`  //
-	DestCidr string `json:"destCidr,omitempty"` //
-	DestPort string `json:"destPort,omitempty"` //
-	Policy   string `json:"policy,omitempty"`   //
-	Protocol string `json:"protocol,omitempty"` //
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Destination IP address (in IP or CIDR notation), a fully-qualified domain name (FQDN, if your network supports it) or 'any'.
+	DestPort string `json:"destPort,omitempty"` // Destination port (integer in the range 1-65535), a port range (e.g. 8080-9090), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules struct {
-	Policy string `json:"policy,omitempty"` //
-	Type   string `json:"type,omitempty"`   //
-	Value  string `json:"value,omitempty"`  //
+	Policy string `json:"policy,omitempty"` // The policy applied to matching traffic. Must be 'deny'.
+	Type   string `json:"type,omitempty"`   // Type of the L7 Rule. Must be 'application', 'applicationCategory', 'host', 'port' or 'ipRange'
+	Value  string `json:"value,omitempty"`  // The 'value' of what you want to block. If 'type' is 'host', 'port' or 'ipRange', 'value' must be a string matching either a hostname (e.g. somewhere.com), a port (e.g. 8080), or an IP range (e.g. 192.1.0.0/16). If 'type' is 'application' or 'applicationCategory', then 'value' must be an object with an ID for the application.
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules struct {
-	Definitions              *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //
-	DscpTagValue             *int                                                                                                       `json:"dscpTagValue,omitempty"`             //
-	PcpTagValue              *int                                                                                                       `json:"pcpTagValue,omitempty"`              //
-	PerClientBandwidthLimits *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //
+	Definitions              *[]ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                                       `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                                       `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
+	Priority                 string                                                                                                     `json:"priority,omitempty"`                 //     A string, indicating the priority level for packets bound to your rule.     Can be 'low', 'normal' or 'high'.
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions struct {
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits struct {
-	BandwidthLimits *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	Settings        string                                                                                                                    `json:"settings,omitempty"`        //
+	BandwidthLimits *ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                                    `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
 }
 type ResponseNetworksGetNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
 }
 type ResponseNetworksGetNetworkGroupPolicyScheduling struct {
-	Enabled   *bool                                                     `json:"enabled,omitempty"`   //
-	Friday    *ResponseNetworksGetNetworkGroupPolicySchedulingFriday    `json:"friday,omitempty"`    //
-	Monday    *ResponseNetworksGetNetworkGroupPolicySchedulingMonday    `json:"monday,omitempty"`    //
-	Saturday  *ResponseNetworksGetNetworkGroupPolicySchedulingSaturday  `json:"saturday,omitempty"`  //
-	Sunday    *ResponseNetworksGetNetworkGroupPolicySchedulingSunday    `json:"sunday,omitempty"`    //
-	Thursday  *ResponseNetworksGetNetworkGroupPolicySchedulingThursday  `json:"thursday,omitempty"`  //
-	Tuesday   *ResponseNetworksGetNetworkGroupPolicySchedulingTuesday   `json:"tuesday,omitempty"`   //
-	Wednesday *ResponseNetworksGetNetworkGroupPolicySchedulingWednesday `json:"wednesday,omitempty"` //
+	Enabled   *bool                                                     `json:"enabled,omitempty"`   // Whether scheduling is enabled (true) or disabled (false). Defaults to false. If true, the schedule objects for each day of the week (monday - sunday) are parsed.
+	Friday    *ResponseNetworksGetNetworkGroupPolicySchedulingFriday    `json:"friday,omitempty"`    // The schedule object for Friday.
+	Monday    *ResponseNetworksGetNetworkGroupPolicySchedulingMonday    `json:"monday,omitempty"`    // The schedule object for Monday.
+	Saturday  *ResponseNetworksGetNetworkGroupPolicySchedulingSaturday  `json:"saturday,omitempty"`  // The schedule object for Saturday.
+	Sunday    *ResponseNetworksGetNetworkGroupPolicySchedulingSunday    `json:"sunday,omitempty"`    // The schedule object for Sunday.
+	Thursday  *ResponseNetworksGetNetworkGroupPolicySchedulingThursday  `json:"thursday,omitempty"`  // The schedule object for Thursday.
+	Tuesday   *ResponseNetworksGetNetworkGroupPolicySchedulingTuesday   `json:"tuesday,omitempty"`   // The schedule object for Tuesday.
+	Wednesday *ResponseNetworksGetNetworkGroupPolicySchedulingWednesday `json:"wednesday,omitempty"` // The schedule object for Wednesday.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingFriday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingMonday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingSaturday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingSunday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingThursday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingTuesday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicySchedulingWednesday struct {
-	Active *bool  `json:"active,omitempty"` //
-	From   string `json:"from,omitempty"`   //
-	To     string `json:"to,omitempty"`     //
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type ResponseNetworksGetNetworkGroupPolicyVLANTagging struct {
-	Settings string `json:"settings,omitempty"` //
-	VLANID   string `json:"vlanId,omitempty"`   //
+	Settings string `json:"settings,omitempty"` // How VLAN tagging is applied. Can be 'network default', 'ignore' or 'custom'.
+	VLANID   string `json:"vlanId,omitempty"`   // The ID of the vlan you want to tag. This only applies if 'settings' is set to 'custom'.
 }
-type ResponseNetworksUpdateNetworkGroupPolicy interface{}
+type ResponseNetworksUpdateNetworkGroupPolicy struct {
+	Bandwidth                 *ResponseNetworksUpdateNetworkGroupPolicyBandwidth                 `json:"bandwidth,omitempty"`                 //     The bandwidth settings for clients bound to your group policy.
+	BonjourForwarding         *ResponseNetworksUpdateNetworkGroupPolicyBonjourForwarding         `json:"bonjourForwarding,omitempty"`         // The Bonjour settings for your group policy. Only valid if your network has a wireless configuration.
+	ContentFiltering          *ResponseNetworksUpdateNetworkGroupPolicyContentFiltering          `json:"contentFiltering,omitempty"`          // The content filtering settings for your group policy
+	FirewallAndTrafficShaping *ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShaping `json:"firewallAndTrafficShaping,omitempty"` //     The firewall and traffic shaping rules and settings for your policy.
+	GroupPolicyID             string                                                             `json:"groupPolicyId,omitempty"`             // The ID of the group policy
+	Scheduling                *ResponseNetworksUpdateNetworkGroupPolicyScheduling                `json:"scheduling,omitempty"`                //     The schedule for the group policy. Schedules are applied to days of the week.
+	SplashAuthSettings        string                                                             `json:"splashAuthSettings,omitempty"`        // Whether clients bound to your policy will bypass splash authorization or behave according to the network's rules. Can be one of 'network default' or 'bypass'. Only available if your network has a wireless configuration.
+	VLANTagging               *ResponseNetworksUpdateNetworkGroupPolicyVLANTagging               `json:"vlanTagging,omitempty"`               // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyBandwidth struct {
+	BandwidthLimits *ResponseNetworksUpdateNetworkGroupPolicyBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying upload and download speed for clients bound to the group policy. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                            `json:"settings,omitempty"`        // How bandwidth limits are enforced. Can be 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyBandwidthBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). null indicates no limit
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). null indicates no limit
+}
+type ResponseNetworksUpdateNetworkGroupPolicyBonjourForwarding struct {
+	Rules    *[]ResponseNetworksUpdateNetworkGroupPolicyBonjourForwardingRules `json:"rules,omitempty"`    // A list of the Bonjour forwarding rules for your group policy. If 'settings' is set to 'custom', at least one rule must be specified.
+	Settings string                                                            `json:"settings,omitempty"` // How Bonjour rules are applied. Can be 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyBonjourForwardingRules struct {
+	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyContentFiltering struct {
+	AllowedURLPatterns   *ResponseNetworksUpdateNetworkGroupPolicyContentFilteringAllowedURLPatterns   `json:"allowedUrlPatterns,omitempty"`   // Settings for allowed URL patterns
+	BlockedURLCategories *ResponseNetworksUpdateNetworkGroupPolicyContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` // Settings for blocked URL categories
+	BlockedURLPatterns   *ResponseNetworksUpdateNetworkGroupPolicyContentFilteringBlockedURLPatterns   `json:"blockedUrlPatterns,omitempty"`   // Settings for blocked URL patterns
+}
+type ResponseNetworksUpdateNetworkGroupPolicyContentFilteringAllowedURLPatterns struct {
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are allowed
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyContentFilteringBlockedURLCategories struct {
+	Categories []string `json:"categories,omitempty"` // A list of URL categories to block
+	Settings   string   `json:"settings,omitempty"`   // How URL categories are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyContentFilteringBlockedURLPatterns struct {
+	Patterns []string `json:"patterns,omitempty"` // A list of URL patterns that are blocked
+	Settings string   `json:"settings,omitempty"` // How URL patterns are applied. Can be 'network default', 'append' or 'override'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShaping struct {
+	L3FirewallRules     *[]ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules     `json:"l3FirewallRules,omitempty"`     // An ordered array of the L3 firewall rules
+	L7FirewallRules     *[]ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules     `json:"l7FirewallRules,omitempty"`     // An ordered array of L7 firewall rules
+	Settings            string                                                                                  `json:"settings,omitempty"`            // How firewall and traffic shaping rules are enforced. Can be 'network default', 'ignore' or 'custom'.
+	TrafficShapingRules *[]ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules `json:"trafficShapingRules,omitempty"` //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingL3FirewallRules struct {
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Destination IP address (in IP or CIDR notation), a fully-qualified domain name (FQDN, if your network supports it) or 'any'.
+	DestPort string `json:"destPort,omitempty"` // Destination port (integer in the range 1-65535), a port range (e.g. 8080-9090), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingL7FirewallRules struct {
+	Policy string `json:"policy,omitempty"` // The policy applied to matching traffic. Must be 'deny'.
+	Type   string `json:"type,omitempty"`   // Type of the L7 Rule. Must be 'application', 'applicationCategory', 'host', 'port' or 'ipRange'
+	Value  string `json:"value,omitempty"`  // The 'value' of what you want to block. If 'type' is 'host', 'port' or 'ipRange', 'value' must be a string matching either a hostname (e.g. somewhere.com), a port (e.g. 8080), or an IP range (e.g. 192.1.0.0/16). If 'type' is 'application' or 'applicationCategory', then 'value' must be an object with an ID for the application.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRules struct {
+	Definitions              *[]ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                                          `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                                          `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
+	Priority                 string                                                                                                        `json:"priority,omitempty"`                 //     A string, indicating the priority level for packets bound to your rule.     Can be 'low', 'normal' or 'high'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesDefinitions struct {
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimits struct {
+	BandwidthLimits *ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                                       `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyFirewallAndTrafficShapingTrafficShapingRulesPerClientBandwidthLimitsBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
+}
+type ResponseNetworksUpdateNetworkGroupPolicyScheduling struct {
+	Enabled   *bool                                                        `json:"enabled,omitempty"`   // Whether scheduling is enabled (true) or disabled (false). Defaults to false. If true, the schedule objects for each day of the week (monday - sunday) are parsed.
+	Friday    *ResponseNetworksUpdateNetworkGroupPolicySchedulingFriday    `json:"friday,omitempty"`    // The schedule object for Friday.
+	Monday    *ResponseNetworksUpdateNetworkGroupPolicySchedulingMonday    `json:"monday,omitempty"`    // The schedule object for Monday.
+	Saturday  *ResponseNetworksUpdateNetworkGroupPolicySchedulingSaturday  `json:"saturday,omitempty"`  // The schedule object for Saturday.
+	Sunday    *ResponseNetworksUpdateNetworkGroupPolicySchedulingSunday    `json:"sunday,omitempty"`    // The schedule object for Sunday.
+	Thursday  *ResponseNetworksUpdateNetworkGroupPolicySchedulingThursday  `json:"thursday,omitempty"`  // The schedule object for Thursday.
+	Tuesday   *ResponseNetworksUpdateNetworkGroupPolicySchedulingTuesday   `json:"tuesday,omitempty"`   // The schedule object for Tuesday.
+	Wednesday *ResponseNetworksUpdateNetworkGroupPolicySchedulingWednesday `json:"wednesday,omitempty"` // The schedule object for Wednesday.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingFriday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingMonday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingSaturday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingSunday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingThursday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingTuesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicySchedulingWednesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+}
+type ResponseNetworksUpdateNetworkGroupPolicyVLANTagging struct {
+	Settings string `json:"settings,omitempty"` // How VLAN tagging is applied. Can be 'network default', 'ignore' or 'custom'.
+	VLANID   string `json:"vlanId,omitempty"`   // The ID of the vlan you want to tag. This only applies if 'settings' is set to 'custom'.
+}
 type ResponseNetworksGetNetworkHealthAlerts []ResponseItemNetworksGetNetworkHealthAlerts // Array of ResponseNetworksGetNetworkHealthAlerts
 type ResponseItemNetworksGetNetworkHealthAlerts struct {
 	Category string                                           `json:"category,omitempty"` // Category of the alert
@@ -1861,74 +2387,116 @@ type ResponseNetworksUpdateNetworkMerakiAuthUserAuthorizations struct {
 }
 type ResponseNetworksGetNetworkMqttBrokers []ResponseItemNetworksGetNetworkMqttBrokers // Array of ResponseNetworksGetNetworkMqttBrokers
 type ResponseItemNetworksGetNetworkMqttBrokers struct {
-	Authentication *ResponseItemNetworksGetNetworkMqttBrokersAuthentication `json:"authentication,omitempty"` //
-	Host           string                                                   `json:"host,omitempty"`           //
-	ID             string                                                   `json:"id,omitempty"`             //
-	Name           string                                                   `json:"name,omitempty"`           //
-	Port           *int                                                     `json:"port,omitempty"`           //
-	Security       *ResponseItemNetworksGetNetworkMqttBrokersSecurity       `json:"security,omitempty"`       //
+	Authentication *ResponseItemNetworksGetNetworkMqttBrokersAuthentication `json:"authentication,omitempty"` // Authentication settings of the MQTT broker
+	Host           string                                                   `json:"host,omitempty"`           // Host name/IP address where the MQTT broker runs.
+	ID             string                                                   `json:"id,omitempty"`             // ID of the MQTT Broker.
+	Name           string                                                   `json:"name,omitempty"`           // Name of the MQTT Broker.
+	Port           *int                                                     `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
+	Security       *ResponseItemNetworksGetNetworkMqttBrokersSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
 }
 type ResponseItemNetworksGetNetworkMqttBrokersAuthentication struct {
-	Username string `json:"username,omitempty"` //
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
 }
 type ResponseItemNetworksGetNetworkMqttBrokersSecurity struct {
-	Mode string                                                `json:"mode,omitempty"` //
-	Tls  *ResponseItemNetworksGetNetworkMqttBrokersSecurityTls `json:"tls,omitempty"`  //
+	Mode string                                                `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *ResponseItemNetworksGetNetworkMqttBrokersSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
 }
 type ResponseItemNetworksGetNetworkMqttBrokersSecurityTls struct {
-	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` //
-	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  //
+	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` // Indicates whether the CA certificate is set
+	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  // Whether the TLS hostname verification is enabled for the MQTT broker.
 }
-type ResponseNetworksCreateNetworkMqttBroker interface{}
+type ResponseNetworksCreateNetworkMqttBroker struct {
+	Authentication *ResponseNetworksCreateNetworkMqttBrokerAuthentication `json:"authentication,omitempty"` // Authentication settings of the MQTT broker
+	Host           string                                                 `json:"host,omitempty"`           // Host name/IP address where the MQTT broker runs.
+	ID             string                                                 `json:"id,omitempty"`             // ID of the MQTT Broker.
+	Name           string                                                 `json:"name,omitempty"`           // Name of the MQTT Broker.
+	Port           *int                                                   `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
+	Security       *ResponseNetworksCreateNetworkMqttBrokerSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
+}
+type ResponseNetworksCreateNetworkMqttBrokerAuthentication struct {
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
+}
+type ResponseNetworksCreateNetworkMqttBrokerSecurity struct {
+	Mode string                                              `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *ResponseNetworksCreateNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
+}
+type ResponseNetworksCreateNetworkMqttBrokerSecurityTls struct {
+	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` // Indicates whether the CA certificate is set
+	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  // Whether the TLS hostname verification is enabled for the MQTT broker.
+}
 type ResponseNetworksGetNetworkMqttBroker struct {
-	Authentication *ResponseNetworksGetNetworkMqttBrokerAuthentication `json:"authentication,omitempty"` //
-	Host           string                                              `json:"host,omitempty"`           //
-	ID             string                                              `json:"id,omitempty"`             //
-	Name           string                                              `json:"name,omitempty"`           //
-	Port           *int                                                `json:"port,omitempty"`           //
-	Security       *ResponseNetworksGetNetworkMqttBrokerSecurity       `json:"security,omitempty"`       //
+	Authentication *ResponseNetworksGetNetworkMqttBrokerAuthentication `json:"authentication,omitempty"` // Authentication settings of the MQTT broker
+	Host           string                                              `json:"host,omitempty"`           // Host name/IP address where the MQTT broker runs.
+	ID             string                                              `json:"id,omitempty"`             // ID of the MQTT Broker.
+	Name           string                                              `json:"name,omitempty"`           // Name of the MQTT Broker.
+	Port           *int                                                `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
+	Security       *ResponseNetworksGetNetworkMqttBrokerSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
 }
 type ResponseNetworksGetNetworkMqttBrokerAuthentication struct {
-	Username string `json:"username,omitempty"` //
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
 }
 type ResponseNetworksGetNetworkMqttBrokerSecurity struct {
-	Mode string                                           `json:"mode,omitempty"` //
-	Tls  *ResponseNetworksGetNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  //
+	Mode string                                           `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *ResponseNetworksGetNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
 }
 type ResponseNetworksGetNetworkMqttBrokerSecurityTls struct {
-	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` //
-	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  //
+	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` // Indicates whether the CA certificate is set
+	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  // Whether the TLS hostname verification is enabled for the MQTT broker.
 }
-type ResponseNetworksUpdateNetworkMqttBroker interface{}
+type ResponseNetworksUpdateNetworkMqttBroker struct {
+	Authentication *ResponseNetworksUpdateNetworkMqttBrokerAuthentication `json:"authentication,omitempty"` // Authentication settings of the MQTT broker
+	Host           string                                                 `json:"host,omitempty"`           // Host name/IP address where the MQTT broker runs.
+	ID             string                                                 `json:"id,omitempty"`             // ID of the MQTT Broker.
+	Name           string                                                 `json:"name,omitempty"`           // Name of the MQTT Broker.
+	Port           *int                                                   `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
+	Security       *ResponseNetworksUpdateNetworkMqttBrokerSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
+}
+type ResponseNetworksUpdateNetworkMqttBrokerAuthentication struct {
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
+}
+type ResponseNetworksUpdateNetworkMqttBrokerSecurity struct {
+	Mode string                                              `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *ResponseNetworksUpdateNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
+}
+type ResponseNetworksUpdateNetworkMqttBrokerSecurityTls struct {
+	HasCaCertificate *bool `json:"hasCaCertificate,omitempty"` // Indicates whether the CA certificate is set
+	VerifyHostnames  *bool `json:"verifyHostnames,omitempty"`  // Whether the TLS hostname verification is enabled for the MQTT broker.
+}
 type ResponseNetworksGetNetworkNetflow struct {
-	CollectorIP      string `json:"collectorIp,omitempty"`      //
-	CollectorPort    *int   `json:"collectorPort,omitempty"`    //
-	EtaDstPort       *int   `json:"etaDstPort,omitempty"`       //
-	EtaEnabled       *bool  `json:"etaEnabled,omitempty"`       //
-	ReportingEnabled *bool  `json:"reportingEnabled,omitempty"` //
+	CollectorIP      string `json:"collectorIp,omitempty"`      // The IPv4 address of the NetFlow collector.
+	CollectorPort    *int   `json:"collectorPort,omitempty"`    // The port that the NetFlow collector will be listening on.
+	EtaDstPort       *int   `json:"etaDstPort,omitempty"`       // The port that the Encrypted Traffic Analytics collector will be listening on.
+	EtaEnabled       *bool  `json:"etaEnabled,omitempty"`       // Boolean indicating whether Encrypted Traffic Analytics is enabled (true) or disabled (false).
+	ReportingEnabled *bool  `json:"reportingEnabled,omitempty"` // Boolean indicating whether NetFlow traffic reporting is enabled (true) or disabled (false).
 }
-type ResponseNetworksUpdateNetworkNetflow interface{}
+type ResponseNetworksUpdateNetworkNetflow struct {
+	CollectorIP      string `json:"collectorIp,omitempty"`      // The IPv4 address of the NetFlow collector.
+	CollectorPort    *int   `json:"collectorPort,omitempty"`    // The port that the NetFlow collector will be listening on.
+	EtaDstPort       *int   `json:"etaDstPort,omitempty"`       // The port that the Encrypted Traffic Analytics collector will be listening on.
+	EtaEnabled       *bool  `json:"etaEnabled,omitempty"`       // Boolean indicating whether Encrypted Traffic Analytics is enabled (true) or disabled (false).
+	ReportingEnabled *bool  `json:"reportingEnabled,omitempty"` // Boolean indicating whether NetFlow traffic reporting is enabled (true) or disabled (false).
+}
 type ResponseNetworksGetNetworkNetworkHealthChannelUtilization []ResponseItemNetworksGetNetworkNetworkHealthChannelUtilization // Array of ResponseNetworksGetNetworkNetworkHealthChannelUtilization
 type ResponseItemNetworksGetNetworkNetworkHealthChannelUtilization struct {
-	Model  string                                                                `json:"model,omitempty"`  //
-	Serial string                                                                `json:"serial,omitempty"` //
-	Tags   string                                                                `json:"tags,omitempty"`   //
-	Wifi0  *[]ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi0 `json:"wifi0,omitempty"`  //
-	Wifi1  *[]ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi1 `json:"wifi1,omitempty"`  //
+	Model  string                                                                `json:"model,omitempty"`  // Device model.
+	Serial string                                                                `json:"serial,omitempty"` // Device serial
+	Tags   string                                                                `json:"tags,omitempty"`   // Device tags.
+	Wifi0  *[]ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi0 `json:"wifi0,omitempty"`  // Channel utilization for first wifi radio of device.
+	Wifi1  *[]ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi1 `json:"wifi1,omitempty"`  // Channel utilization for second wifi radio of device.
 }
 type ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi0 struct {
-	EndTime             string   `json:"endTime,omitempty"`             //
-	StartTime           string   `json:"startTime,omitempty"`           //
-	Utilization80211    *int     `json:"utilization80211,omitempty"`    //
-	UtilizationNon80211 *float64 `json:"utilizationNon80211,omitempty"` //
-	UtilizationTotal    *float64 `json:"utilizationTotal,omitempty"`    //
+	EndTime             string   `json:"endTime,omitempty"`             // The end time of the channel utilization interval.
+	StartTime           string   `json:"startTime,omitempty"`           // The start time of the channel utilization interval.
+	Utilization80211    *float64 `json:"utilization80211,omitempty"`    // Percentage of wifi channel utiliation for the given radio.
+	UtilizationNon80211 *float64 `json:"utilizationNon80211,omitempty"` // Percentage of non-wifi channel utiliation for the given radio.
+	UtilizationTotal    *float64 `json:"utilizationTotal,omitempty"`    // Percentage of total channel utiliation for the given radio.
 }
 type ResponseItemNetworksGetNetworkNetworkHealthChannelUtilizationWifi1 struct {
-	EndTime             string   `json:"endTime,omitempty"`             //
-	StartTime           string   `json:"startTime,omitempty"`           //
-	Utilization80211    *int     `json:"utilization80211,omitempty"`    //
-	UtilizationNon80211 *float64 `json:"utilizationNon80211,omitempty"` //
-	UtilizationTotal    *float64 `json:"utilizationTotal,omitempty"`    //
+	EndTime             string   `json:"endTime,omitempty"`             // The end time of the channel utilization interval.
+	StartTime           string   `json:"startTime,omitempty"`           // The start time of the channel utilization interval.
+	Utilization80211    *float64 `json:"utilization80211,omitempty"`    // Percentage of wifi channel utiliation for the given radio.
+	UtilizationNon80211 *float64 `json:"utilizationNon80211,omitempty"` // Percentage of non-wifi channel utiliation for the given radio.
+	UtilizationTotal    *float64 `json:"utilizationTotal,omitempty"`    // Percentage of total channel utiliation for the given radio.
 }
 type ResponseNetworksGetNetworkPiiPiiKeys struct {
 	N1234 *ResponseNetworksGetNetworkPiiPiiKeysN1234 `json:"N_1234,omitempty"` //
@@ -1943,27 +2511,37 @@ type ResponseNetworksGetNetworkPiiPiiKeysN1234 struct {
 }
 type ResponseNetworksGetNetworkPiiRequests []ResponseItemNetworksGetNetworkPiiRequests // Array of ResponseNetworksGetNetworkPiiRequests
 type ResponseItemNetworksGetNetworkPiiRequests struct {
-	CompletedAt      *int   `json:"completedAt,omitempty"`      //
-	CreatedAt        *int   `json:"createdAt,omitempty"`        //
-	Datasets         string `json:"datasets,omitempty"`         //
-	ID               string `json:"id,omitempty"`               //
-	Mac              string `json:"mac,omitempty"`              //
-	NetworkID        string `json:"networkId,omitempty"`        //
-	OrganizationWide *bool  `json:"organizationWide,omitempty"` //
-	Status           string `json:"status,omitempty"`           //
-	Type             string `json:"type,omitempty"`             //
+	CompletedAt      *int   `json:"completedAt,omitempty"`      // The request's completion time
+	CreatedAt        *int   `json:"createdAt,omitempty"`        // The request's creation time
+	Datasets         string `json:"datasets,omitempty"`         // The stringified array of datasets related to the provided key that should be deleted.
+	ID               string `json:"id,omitempty"`               // The network or organization identifier
+	Mac              string `json:"mac,omitempty"`              // The MAC address of the PII request
+	NetworkID        string `json:"networkId,omitempty"`        // The network identifier
+	OrganizationWide *bool  `json:"organizationWide,omitempty"` // If the data returned is organization-wide. False indicates the data is network-wide.
+	Status           string `json:"status,omitempty"`           // The status of the PII request
+	Type             string `json:"type,omitempty"`             // The type of PII request
 }
-type ResponseNetworksCreateNetworkPiiRequest interface{}
+type ResponseNetworksCreateNetworkPiiRequest struct {
+	CompletedAt      *int   `json:"completedAt,omitempty"`      // The request's completion time
+	CreatedAt        *int   `json:"createdAt,omitempty"`        // The request's creation time
+	Datasets         string `json:"datasets,omitempty"`         // The stringified array of datasets related to the provided key that should be deleted.
+	ID               string `json:"id,omitempty"`               // The network or organization identifier
+	Mac              string `json:"mac,omitempty"`              // The MAC address of the PII request
+	NetworkID        string `json:"networkId,omitempty"`        // The network identifier
+	OrganizationWide *bool  `json:"organizationWide,omitempty"` // If the data returned is organization-wide. False indicates the data is network-wide.
+	Status           string `json:"status,omitempty"`           // The status of the PII request
+	Type             string `json:"type,omitempty"`             // The type of PII request
+}
 type ResponseNetworksGetNetworkPiiRequest struct {
-	CompletedAt      *int   `json:"completedAt,omitempty"`      //
-	CreatedAt        *int   `json:"createdAt,omitempty"`        //
-	Datasets         string `json:"datasets,omitempty"`         //
-	ID               string `json:"id,omitempty"`               //
-	Mac              string `json:"mac,omitempty"`              //
-	NetworkID        string `json:"networkId,omitempty"`        //
-	OrganizationWide *bool  `json:"organizationWide,omitempty"` //
-	Status           string `json:"status,omitempty"`           //
-	Type             string `json:"type,omitempty"`             //
+	CompletedAt      *int   `json:"completedAt,omitempty"`      // The request's completion time
+	CreatedAt        *int   `json:"createdAt,omitempty"`        // The request's creation time
+	Datasets         string `json:"datasets,omitempty"`         // The stringified array of datasets related to the provided key that should be deleted.
+	ID               string `json:"id,omitempty"`               // The network or organization identifier
+	Mac              string `json:"mac,omitempty"`              // The MAC address of the PII request
+	NetworkID        string `json:"networkId,omitempty"`        // The network identifier
+	OrganizationWide *bool  `json:"organizationWide,omitempty"` // If the data returned is organization-wide. False indicates the data is network-wide.
+	Status           string `json:"status,omitempty"`           // The status of the PII request
+	Type             string `json:"type,omitempty"`             // The type of PII request
 }
 type ResponseNetworksGetNetworkPiiSmDevicesForKey struct {
 	N1234 []string `json:"N_1234,omitempty"` //
@@ -1987,17 +2565,12 @@ type ResponseItemNetworksGetNetworkPoliciesByClientAssignedSSID struct {
 	SSIDNumber *int `json:"ssidNumber,omitempty"` // number of ssid
 }
 type ResponseNetworksGetNetworkSettings struct {
-	ClientPrivacy           *ResponseNetworksGetNetworkSettingsClientPrivacy   `json:"clientPrivacy,omitempty"`           // Privacy settings
 	Fips                    *ResponseNetworksGetNetworkSettingsFips            `json:"fips,omitempty"`                    // A hash of FIPS options applied to the Network
 	LocalStatusPage         *ResponseNetworksGetNetworkSettingsLocalStatusPage `json:"localStatusPage,omitempty"`         // A hash of Local Status page(s)' authentication options applied to the Network.
 	LocalStatusPageEnabled  *bool                                              `json:"localStatusPageEnabled,omitempty"`  // Enables / disables the local device status pages (<a target='_blank' href='http://my.meraki.com/'>my.meraki.com, </a><a target='_blank' href='http://ap.meraki.com/'>ap.meraki.com, </a><a target='_blank' href='http://switch.meraki.com/'>switch.meraki.com, </a><a target='_blank' href='http://wired.meraki.com/'>wired.meraki.com</a>). Optional (defaults to false)
 	NamedVLANs              *ResponseNetworksGetNetworkSettingsNamedVLANs      `json:"namedVlans,omitempty"`              // A hash of Named VLANs options applied to the Network.
 	RemoteStatusPageEnabled *bool                                              `json:"remoteStatusPageEnabled,omitempty"` // Enables / disables access to the device status page (<a target='_blank'>http://[device's LAN IP])</a>. Optional. Can only be set if localStatusPageEnabled is set to true
 	SecurePort              *ResponseNetworksGetNetworkSettingsSecurePort      `json:"securePort,omitempty"`              // A hash of SecureConnect options applied to the Network.
-}
-type ResponseNetworksGetNetworkSettingsClientPrivacy struct {
-	ExpireDataBefore    string `json:"expireDataBefore,omitempty"`    // The date to expire the data before
-	ExpireDataOlderThan *int   `json:"expireDataOlderThan,omitempty"` // The number of days, weeks, or months in Epoch time to expire the data before
 }
 type ResponseNetworksGetNetworkSettingsFips struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enables / disables FIPS on the network.
@@ -2016,17 +2589,12 @@ type ResponseNetworksGetNetworkSettingsSecurePort struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enables / disables SecureConnect on the network. Optional.
 }
 type ResponseNetworksUpdateNetworkSettings struct {
-	ClientPrivacy           *ResponseNetworksUpdateNetworkSettingsClientPrivacy   `json:"clientPrivacy,omitempty"`           // Privacy settings
 	Fips                    *ResponseNetworksUpdateNetworkSettingsFips            `json:"fips,omitempty"`                    // A hash of FIPS options applied to the Network
 	LocalStatusPage         *ResponseNetworksUpdateNetworkSettingsLocalStatusPage `json:"localStatusPage,omitempty"`         // A hash of Local Status page(s)' authentication options applied to the Network.
 	LocalStatusPageEnabled  *bool                                                 `json:"localStatusPageEnabled,omitempty"`  // Enables / disables the local device status pages (<a target='_blank' href='http://my.meraki.com/'>my.meraki.com, </a><a target='_blank' href='http://ap.meraki.com/'>ap.meraki.com, </a><a target='_blank' href='http://switch.meraki.com/'>switch.meraki.com, </a><a target='_blank' href='http://wired.meraki.com/'>wired.meraki.com</a>). Optional (defaults to false)
 	NamedVLANs              *ResponseNetworksUpdateNetworkSettingsNamedVLANs      `json:"namedVlans,omitempty"`              // A hash of Named VLANs options applied to the Network.
 	RemoteStatusPageEnabled *bool                                                 `json:"remoteStatusPageEnabled,omitempty"` // Enables / disables access to the device status page (<a target='_blank'>http://[device's LAN IP])</a>. Optional. Can only be set if localStatusPageEnabled is set to true
 	SecurePort              *ResponseNetworksUpdateNetworkSettingsSecurePort      `json:"securePort,omitempty"`              // A hash of SecureConnect options applied to the Network.
-}
-type ResponseNetworksUpdateNetworkSettingsClientPrivacy struct {
-	ExpireDataBefore    string `json:"expireDataBefore,omitempty"`    // The date to expire the data before
-	ExpireDataOlderThan *int   `json:"expireDataOlderThan,omitempty"` // The number of days, weeks, or months in Epoch time to expire the data before
 }
 type ResponseNetworksUpdateNetworkSettingsFips struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enables / disables FIPS on the network.
@@ -2045,24 +2613,33 @@ type ResponseNetworksUpdateNetworkSettingsSecurePort struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enables / disables SecureConnect on the network. Optional.
 }
 type ResponseNetworksGetNetworkSNMP struct {
-	Access string                                 `json:"access,omitempty"` //
-	Users  *[]ResponseNetworksGetNetworkSNMPUsers `json:"users,omitempty"`  //
+	Access          string                                 `json:"access,omitempty"`          // The type of SNMP access. Can be one of 'none' (disabled), 'community' (V1/V2c), or 'users' (V3).
+	CommunityString string                                 `json:"communityString,omitempty"` // SNMP community string if access is 'community'.
+	Users           *[]ResponseNetworksGetNetworkSNMPUsers `json:"users,omitempty"`           // SNMP settings if access is 'users'.
 }
 type ResponseNetworksGetNetworkSNMPUsers struct {
-	Passphrase string `json:"passphrase,omitempty"` //
-	Username   string `json:"username,omitempty"`   //
+	Passphrase string `json:"passphrase,omitempty"` // The passphrase for the SNMP user.
+	Username   string `json:"username,omitempty"`   // The username for the SNMP user.
 }
-type ResponseNetworksUpdateNetworkSNMP interface{}
+type ResponseNetworksUpdateNetworkSNMP struct {
+	Access          string                                    `json:"access,omitempty"`          // The type of SNMP access. Can be one of 'none' (disabled), 'community' (V1/V2c), or 'users' (V3).
+	CommunityString string                                    `json:"communityString,omitempty"` // SNMP community string if access is 'community'.
+	Users           *[]ResponseNetworksUpdateNetworkSNMPUsers `json:"users,omitempty"`           // SNMP settings if access is 'users'.
+}
+type ResponseNetworksUpdateNetworkSNMPUsers struct {
+	Passphrase string `json:"passphrase,omitempty"` // The passphrase for the SNMP user.
+	Username   string `json:"username,omitempty"`   // The username for the SNMP user.
+}
 type ResponseNetworksGetNetworkSplashLoginAttempts []ResponseItemNetworksGetNetworkSplashLoginAttempts // Array of ResponseNetworksGetNetworkSplashLoginAttempts
 type ResponseItemNetworksGetNetworkSplashLoginAttempts struct {
-	Authorization    string `json:"authorization,omitempty"`    //
-	ClientID         string `json:"clientId,omitempty"`         //
-	ClientMac        string `json:"clientMac,omitempty"`        //
-	GatewayDeviceMac string `json:"gatewayDeviceMac,omitempty"` //
-	Login            string `json:"login,omitempty"`            //
-	LoginAt          string `json:"loginAt,omitempty"`          //
-	Name             string `json:"name,omitempty"`             //
-	SSID             string `json:"ssid,omitempty"`             //
+	Authorization    string `json:"authorization,omitempty"`    // Authorization status
+	ClientID         string `json:"clientId,omitempty"`         // Client ID
+	ClientMac        string `json:"clientMac,omitempty"`        // Client mac address
+	GatewayDeviceMac string `json:"gatewayDeviceMac,omitempty"` // Gateway device mac address
+	Login            string `json:"login,omitempty"`            // User login identifier
+	LoginAt          string `json:"loginAt,omitempty"`          // Login timestamp
+	Name             string `json:"name,omitempty"`             // User name
+	SSID             string `json:"ssid,omitempty"`             // SSID name
 }
 type ResponseNetworksSplitNetwork struct {
 	ResultingNetworks *[]ResponseNetworksSplitNetworkResultingNetworks `json:"resultingNetworks,omitempty"` // Networks after the split
@@ -2084,7 +2661,7 @@ type ResponseNetworksGetNetworkSyslogServers struct {
 }
 type ResponseNetworksGetNetworkSyslogServersServers struct {
 	Host  string   `json:"host,omitempty"`  // The IP address of the syslog server
-	Port  string   `json:"port,omitempty"`  // The port of the syslog server
+	Port  *int     `json:"port,omitempty"`  // The port of the syslog server
 	Roles []string `json:"roles,omitempty"` // A list of roles for the syslog server. Options (case-insensitive): 'Wireless event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
 }
 type ResponseNetworksUpdateNetworkSyslogServers struct {
@@ -2092,7 +2669,7 @@ type ResponseNetworksUpdateNetworkSyslogServers struct {
 }
 type ResponseNetworksUpdateNetworkSyslogServersServers struct {
 	Host  string   `json:"host,omitempty"`  // The IP address of the syslog server
-	Port  string   `json:"port,omitempty"`  // The port of the syslog server
+	Port  *int     `json:"port,omitempty"`  // The port of the syslog server
 	Roles []string `json:"roles,omitempty"` // A list of roles for the syslog server. Options (case-insensitive): 'Wireless event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
 }
 type ResponseNetworksGetNetworkTopologyLinkLayer struct {
@@ -2149,25 +2726,34 @@ type ResponseNetworksGetNetworkTopologyLinkLayerNodesDiscoveredLldp struct {
 }
 type ResponseNetworksGetNetworkTraffic []ResponseItemNetworksGetNetworkTraffic // Array of ResponseNetworksGetNetworkTraffic
 type ResponseItemNetworksGetNetworkTraffic struct {
-	ActiveTime  *int   `json:"activeTime,omitempty"`  //
-	Application string `json:"application,omitempty"` //
-	Flows       *int   `json:"flows,omitempty"`       //
-	NumClients  *int   `json:"numClients,omitempty"`  //
-	Port        *int   `json:"port,omitempty"`        //
-	Protocol    string `json:"protocol,omitempty"`    //
-	Recv        *int   `json:"recv,omitempty"`        //
-	Sent        *int   `json:"sent,omitempty"`        //
+	ActiveTime  *int     `json:"activeTime,omitempty"`  //
+	Application string   `json:"application,omitempty"` //
+	Destination string   `json:"destination,omitempty"` //
+	Flows       *int     `json:"flows,omitempty"`       //
+	NumClients  *int     `json:"numClients,omitempty"`  //
+	Port        *int     `json:"port,omitempty"`        //
+	Protocol    string   `json:"protocol,omitempty"`    //
+	Recv        *float64 `json:"recv,omitempty"`        //
+	Sent        *float64 `json:"sent,omitempty"`        //
 }
 type ResponseNetworksGetNetworkTrafficAnalysis struct {
-	CustomPieChartItems *[]ResponseNetworksGetNetworkTrafficAnalysisCustomPieChartItems `json:"customPieChartItems,omitempty"` //
-	Mode                string                                                          `json:"mode,omitempty"`                //
+	CustomPieChartItems *[]ResponseNetworksGetNetworkTrafficAnalysisCustomPieChartItems `json:"customPieChartItems,omitempty"` // The list of items that make up the custom pie chart for traffic reporting.
+	Mode                string                                                          `json:"mode,omitempty"`                //     The traffic analysis mode for the network. Can be one of 'disabled' (do not collect traffic types),     'basic' (collect generic traffic categories), or 'detailed' (collect destination hostnames).
 }
 type ResponseNetworksGetNetworkTrafficAnalysisCustomPieChartItems struct {
-	Name  string `json:"name,omitempty"`  //
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Name  string `json:"name,omitempty"`  // The name of the custom pie chart item.
+	Type  string `json:"type,omitempty"`  //     The signature type for the custom pie chart item. Can be one of 'host', 'port' or 'ipRange'.
+	Value string `json:"value,omitempty"` //     The value of the custom pie chart item. Valid syntax depends on the signature type of the chart item     (see sample request/response for more details).
 }
-type ResponseNetworksUpdateNetworkTrafficAnalysis interface{}
+type ResponseNetworksUpdateNetworkTrafficAnalysis struct {
+	CustomPieChartItems *[]ResponseNetworksUpdateNetworkTrafficAnalysisCustomPieChartItems `json:"customPieChartItems,omitempty"` // The list of items that make up the custom pie chart for traffic reporting.
+	Mode                string                                                             `json:"mode,omitempty"`                //     The traffic analysis mode for the network. Can be one of 'disabled' (do not collect traffic types),     'basic' (collect generic traffic categories), or 'detailed' (collect destination hostnames).
+}
+type ResponseNetworksUpdateNetworkTrafficAnalysisCustomPieChartItems struct {
+	Name  string `json:"name,omitempty"`  // The name of the custom pie chart item.
+	Type  string `json:"type,omitempty"`  //     The signature type for the custom pie chart item. Can be one of 'host', 'port' or 'ipRange'.
+	Value string `json:"value,omitempty"` //     The value of the custom pie chart item. Valid syntax depends on the signature type of the chart item     (see sample request/response for more details).
+}
 type ResponseNetworksGetNetworkTrafficShapingApplicationCategories struct {
 	ApplicationCategories *[]ResponseNetworksGetNetworkTrafficShapingApplicationCategoriesApplicationCategories `json:"applicationCategories,omitempty"` //
 }
@@ -2196,6 +2782,113 @@ type ResponseNetworksUnbindNetwork struct {
 	Tags                    []string `json:"tags,omitempty"`                    // Network tags
 	TimeZone                string   `json:"timeZone,omitempty"`                // Timezone of the network
 	URL                     string   `json:"url,omitempty"`                     // URL to the network Dashboard UI
+}
+type ResponseNetworksGetNetworkVLANProfiles []ResponseItemNetworksGetNetworkVLANProfiles // Array of ResponseNetworksGetNetworkVlanProfiles
+type ResponseItemNetworksGetNetworkVLANProfiles struct {
+	Iname      string                                                  `json:"iname,omitempty"`      // IName of the VLAN profile
+	IsDefault  *bool                                                   `json:"isDefault,omitempty"`  // Boolean indicating the default VLAN Profile for any device that does not have a profile explicitly assigned
+	Name       string                                                  `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]ResponseItemNetworksGetNetworkVLANProfilesVLANGroups `json:"vlanGroups,omitempty"` // An array of named VLANs
+	VLANNames  *[]ResponseItemNetworksGetNetworkVLANProfilesVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type ResponseItemNetworksGetNetworkVLANProfilesVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type ResponseItemNetworksGetNetworkVLANProfilesVLANNames struct {
+	AdaptivePolicyGroup *ResponseItemNetworksGetNetworkVLANProfilesVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                                  `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                                  `json:"vlanId,omitempty"`              // VLAN ID
+}
+type ResponseItemNetworksGetNetworkVLANProfilesVLANNamesAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // Adaptive Policy Group ID
+	Name string `json:"name,omitempty"` // Adaptive Policy Group name
+}
+type ResponseNetworksCreateNetworkVLANProfile struct {
+	Iname      string                                                `json:"iname,omitempty"`      // IName of the VLAN profile
+	IsDefault  *bool                                                 `json:"isDefault,omitempty"`  // Boolean indicating the default VLAN Profile for any device that does not have a profile explicitly assigned
+	Name       string                                                `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]ResponseNetworksCreateNetworkVLANProfileVLANGroups `json:"vlanGroups,omitempty"` // An array of named VLANs
+	VLANNames  *[]ResponseNetworksCreateNetworkVLANProfileVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type ResponseNetworksCreateNetworkVLANProfileVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type ResponseNetworksCreateNetworkVLANProfileVLANNames struct {
+	AdaptivePolicyGroup *ResponseNetworksCreateNetworkVLANProfileVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                                `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                                `json:"vlanId,omitempty"`              // VLAN ID
+}
+type ResponseNetworksCreateNetworkVLANProfileVLANNamesAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // Adaptive Policy Group ID
+	Name string `json:"name,omitempty"` // Adaptive Policy Group name
+}
+type ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice []ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDevice // Array of ResponseNetworksGetNetworkVlanProfilesAssignmentsByDevice
+type ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDevice struct {
+	Mac         string                                                                    `json:"mac,omitempty"`         // MAC address of the device
+	Name        string                                                                    `json:"name,omitempty"`        // Name of the Device
+	ProductType string                                                                    `json:"productType,omitempty"` // The product type
+	Serial      string                                                                    `json:"serial,omitempty"`      // Serial of the Device
+	Stack       *ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDeviceStack       `json:"stack,omitempty"`       // The Switch Stack the device belongs to
+	VLANProfile *ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDeviceVLANProfile `json:"vlanProfile,omitempty"` // The VLAN Profile
+}
+type ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDeviceStack struct {
+	ID string `json:"id,omitempty"` // ID of the Switch Stack
+}
+type ResponseItemNetworksGetNetworkVLANProfilesAssignmentsByDeviceVLANProfile struct {
+	Iname     string `json:"iname,omitempty"`     // IName of the VLAN Profile
+	IsDefault *bool  `json:"isDefault,omitempty"` // Is this VLAN profile the default for the network?
+	Name      string `json:"name,omitempty"`      // Name of the VLAN Profile
+}
+type ResponseNetworksReassignNetworkVLANProfilesAssignments struct {
+	Serials     []string                                                           `json:"serials,omitempty"`     // Array of Device Serials
+	StackIDs    []string                                                           `json:"stackIds,omitempty"`    // Array of Switch Stack IDs
+	VLANProfile *ResponseNetworksReassignNetworkVLANProfilesAssignmentsVLANProfile `json:"vlanProfile,omitempty"` // The VLAN Profile
+}
+type ResponseNetworksReassignNetworkVLANProfilesAssignmentsVLANProfile struct {
+	Iname string `json:"iname,omitempty"` // IName of the VLAN Profile
+	Name  string `json:"name,omitempty"`  // Name of the VLAN Profile
+}
+type ResponseNetworksGetNetworkVLANProfile struct {
+	Iname      string                                             `json:"iname,omitempty"`      // IName of the VLAN profile
+	IsDefault  *bool                                              `json:"isDefault,omitempty"`  // Boolean indicating the default VLAN Profile for any device that does not have a profile explicitly assigned
+	Name       string                                             `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]ResponseNetworksGetNetworkVLANProfileVLANGroups `json:"vlanGroups,omitempty"` // An array of named VLANs
+	VLANNames  *[]ResponseNetworksGetNetworkVLANProfileVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type ResponseNetworksGetNetworkVLANProfileVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type ResponseNetworksGetNetworkVLANProfileVLANNames struct {
+	AdaptivePolicyGroup *ResponseNetworksGetNetworkVLANProfileVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                             `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                             `json:"vlanId,omitempty"`              // VLAN ID
+}
+type ResponseNetworksGetNetworkVLANProfileVLANNamesAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // Adaptive Policy Group ID
+	Name string `json:"name,omitempty"` // Adaptive Policy Group name
+}
+type ResponseNetworksUpdateNetworkVLANProfile struct {
+	Iname      string                                                `json:"iname,omitempty"`      // IName of the VLAN profile
+	IsDefault  *bool                                                 `json:"isDefault,omitempty"`  // Boolean indicating the default VLAN Profile for any device that does not have a profile explicitly assigned
+	Name       string                                                `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]ResponseNetworksUpdateNetworkVLANProfileVLANGroups `json:"vlanGroups,omitempty"` // An array of named VLANs
+	VLANNames  *[]ResponseNetworksUpdateNetworkVLANProfileVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type ResponseNetworksUpdateNetworkVLANProfileVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type ResponseNetworksUpdateNetworkVLANProfileVLANNames struct {
+	AdaptivePolicyGroup *ResponseNetworksUpdateNetworkVLANProfileVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                                `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                                `json:"vlanId,omitempty"`              // VLAN ID
+}
+type ResponseNetworksUpdateNetworkVLANProfileVLANNamesAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // Adaptive Policy Group ID
+	Name string `json:"name,omitempty"` // Adaptive Policy Group name
 }
 type ResponseNetworksGetNetworkWebhooksHTTPServers []ResponseItemNetworksGetNetworkWebhooksHTTPServers // Array of ResponseNetworksGetNetworkWebhooksHttpServers
 type ResponseItemNetworksGetNetworkWebhooksHTTPServers struct {
@@ -2350,6 +3043,7 @@ type RequestNetworksUpdateNetwork struct {
 type RequestNetworksUpdateNetworkAlertsSettings struct {
 	Alerts              *[]RequestNetworksUpdateNetworkAlertsSettingsAlerts            `json:"alerts,omitempty"`              // Alert-specific configuration for each type. Only alerts that pertain to the network can be updated.
 	DefaultDestinations *RequestNetworksUpdateNetworkAlertsSettingsDefaultDestinations `json:"defaultDestinations,omitempty"` // The network-wide destinations for all alerts on the network.
+	Muting              *RequestNetworksUpdateNetworkAlertsSettingsMuting              `json:"muting,omitempty"`              // Mute alerts under certain conditions
 }
 type RequestNetworksUpdateNetworkAlertsSettingsAlerts struct {
 	AlertDestinations *RequestNetworksUpdateNetworkAlertsSettingsAlertsAlertDestinations `json:"alertDestinations,omitempty"` // A hash of destinations for this specific alert
@@ -2370,9 +3064,15 @@ type RequestNetworksUpdateNetworkAlertsSettingsAlertsFilters struct {
 }
 type RequestNetworksUpdateNetworkAlertsSettingsDefaultDestinations struct {
 	AllAdmins     *bool    `json:"allAdmins,omitempty"`     // If true, then all network admins will receive emails.
-	Emails        []string `json:"emails,omitempty"`        // A list of emails that will recieve the alert(s).
+	Emails        []string `json:"emails,omitempty"`        // A list of emails that will receive the alert(s).
 	HTTPServerIDs []string `json:"httpServerIds,omitempty"` // A list of HTTP server IDs to send a Webhook to
 	SNMP          *bool    `json:"snmp,omitempty"`          // If true, then an SNMP trap will be sent if there is an SNMP trap server configured for this network.
+}
+type RequestNetworksUpdateNetworkAlertsSettingsMuting struct {
+	ByPortSchedules *RequestNetworksUpdateNetworkAlertsSettingsMutingByPortSchedules `json:"byPortSchedules,omitempty"` // Mute wireless unreachable alerts based on switch port schedules
+}
+type RequestNetworksUpdateNetworkAlertsSettingsMutingByPortSchedules struct {
+	Enabled *bool `json:"enabled,omitempty"` // If true, then wireless unreachable alerts will be muted when caused by a port schedule
 }
 type RequestNetworksBindNetwork struct {
 	AutoBind         *bool  `json:"autoBind,omitempty"`         // Optional boolean indicating whether the network's switches should automatically bind to profiles of the same model. Defaults to false if left unspecified. This option only affects switch networks and switch templates. Auto-bind is not valid unless the switch template has at least one profile and has at most one profile per switch model.
@@ -2471,7 +3171,7 @@ type RequestNetworksProvisionNetworkClientsPoliciesBySSID9 struct {
 }
 type RequestNetworksUpdateNetworkClientPolicy struct {
 	DevicePolicy  string `json:"devicePolicy,omitempty"`  // The policy to assign. Can be 'Whitelisted', 'Blocked', 'Normal' or 'Group policy'. Required.
-	GroupPolicyID string `json:"groupPolicyId,omitempty"` // [optional] If 'devicePolicy' is set to 'Group policy' this param is used to specify the group policy ID.
+	GroupPolicyID string `json:"groupPolicyId,omitempty"` // [Optional] If 'devicePolicy' is set to 'Group policy' this param is used to specify the group policy ID.
 }
 type RequestNetworksUpdateNetworkClientSplashAuthorizationStatus struct {
 	SSIDs *RequestNetworksUpdateNetworkClientSplashAuthorizationStatusSSIDs `json:"ssids,omitempty"` // The target SSIDs. Each SSID must be enabled and must have Click-through splash enabled. For each SSID where isAuthorized is true, the expiration time will automatically be set according to the SSID's splash frequency. Not all networks support configuring all SSIDs
@@ -2542,7 +3242,7 @@ type RequestNetworksClaimNetworkDevices struct {
 	Serials []string `json:"serials"` // A list of serials of devices to claim
 }
 type RequestNetworksVmxNetworkDevicesClaim struct {
-	Size string `json:"size,omitempty"` // The size of the vMX you claim. It can be one of: small, medium, large, 100
+	Size string `json:"size,omitempty"` // The size of the vMX you claim. It can be one of: small, medium, large, xlarge, 100
 }
 type RequestNetworksRemoveNetworkDevices struct {
 	Serial string `json:"serial,omitempty"` // The serial of a device
@@ -2558,6 +3258,7 @@ type RequestNetworksUpdateNetworkFirmwareUpgradesProducts struct {
 	CellularGateway *RequestNetworksUpdateNetworkFirmwareUpgradesProductsCellularGateway `json:"cellularGateway,omitempty"` // The network device to be updated
 	Sensor          *RequestNetworksUpdateNetworkFirmwareUpgradesProductsSensor          `json:"sensor,omitempty"`          // The network device to be updated
 	Switch          *RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitch          `json:"switch,omitempty"`          // The network device to be updated
+	SwitchCatalyst  *RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalyst  `json:"switchCatalyst,omitempty"`  // The network device to be updated
 	Wireless        *RequestNetworksUpdateNetworkFirmwareUpgradesProductsWireless        `json:"wireless,omitempty"`        // The network device to be updated
 }
 type RequestNetworksUpdateNetworkFirmwareUpgradesProductsAppliance struct {
@@ -2615,6 +3316,17 @@ type RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchNextUpgrade struc
 type RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchNextUpgradeToVersion struct {
 	ID string `json:"id,omitempty"` // The version ID
 }
+type RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalyst struct {
+	NextUpgrade                  *RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalystNextUpgrade `json:"nextUpgrade,omitempty"`                  // The pending firmware upgrade if it exists
+	ParticipateInNextBetaRelease *bool                                                                          `json:"participateInNextBetaRelease,omitempty"` // Whether or not the network wants beta firmware
+}
+type RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalystNextUpgrade struct {
+	Time      string                                                                                  `json:"time,omitempty"`      // The time of the last successful upgrade
+	ToVersion *RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalystNextUpgradeToVersion `json:"toVersion,omitempty"` // The version to be updated to
+}
+type RequestNetworksUpdateNetworkFirmwareUpgradesProductsSwitchCatalystNextUpgradeToVersion struct {
+	ID string `json:"id,omitempty"` // The version ID
+}
 type RequestNetworksUpdateNetworkFirmwareUpgradesProductsWireless struct {
 	NextUpgrade                  *RequestNetworksUpdateNetworkFirmwareUpgradesProductsWirelessNextUpgrade `json:"nextUpgrade,omitempty"`                  // The pending firmware upgrade if it exists
 	ParticipateInNextBetaRelease *bool                                                                    `json:"participateInNextBetaRelease,omitempty"` // Whether or not the network wants beta firmware
@@ -2648,7 +3360,8 @@ type RequestNetworksCreateNetworkFirmwareUpgradesStagedEvent struct {
 	Stages   *[]RequestNetworksCreateNetworkFirmwareUpgradesStagedEventStages `json:"stages,omitempty"`   // All firmware upgrade stages in the network with their start time.
 }
 type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProducts struct {
-	Switch *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitch `json:"switch,omitempty"` // Version information for the switch network being upgraded
+	Switch         *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitch         `json:"switch,omitempty"`         // Version information for the switch network being upgraded
+	SwitchCatalyst *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalyst `json:"switchCatalyst,omitempty"` // Version information for the switch network being upgraded
 }
 type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitch struct {
 	NextUpgrade *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchNextUpgrade `json:"nextUpgrade,omitempty"` // The next upgrade version for the switch network
@@ -2657,6 +3370,15 @@ type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchNextUp
 	ToVersion *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchNextUpgradeToVersion `json:"toVersion,omitempty"` // The version to be updated to for switch devices
 }
 type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchNextUpgradeToVersion struct {
+	ID string `json:"id,omitempty"` // The version ID
+}
+type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalyst struct {
+	NextUpgrade *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalystNextUpgrade `json:"nextUpgrade,omitempty"` // The next upgrade version for the switch network
+}
+type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalystNextUpgrade struct {
+	ToVersion *RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalystNextUpgradeToVersion `json:"toVersion,omitempty"` // The version to be updated to for switch Catalyst devices
+}
+type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventProductsSwitchCatalystNextUpgradeToVersion struct {
 	ID string `json:"id,omitempty"` // The version ID
 }
 type RequestNetworksCreateNetworkFirmwareUpgradesStagedEventStages struct {
@@ -3064,7 +3786,7 @@ type RequestNetworksUpdateNetworkGroupPolicyVLANTagging struct {
 	VLANID   string `json:"vlanId,omitempty"`   // The ID of the vlan you want to tag. This only applies if 'settings' is set to 'custom'.
 }
 type RequestNetworksCreateNetworkMerakiAuthUser struct {
-	AccountType         string                                                      `json:"accountType,omitempty"`         // Authorization type for user. Can be 'Guest' or '802.1X' for wireless networks, or 'Client VPN' for wired networks. Defaults to '802.1X'.
+	AccountType         string                                                      `json:"accountType,omitempty"`         // Authorization type for user. Can be 'Guest' or '802.1X' for wireless networks, or 'Client VPN' for MX networks. Defaults to '802.1X'.
 	Authorizations      *[]RequestNetworksCreateNetworkMerakiAuthUserAuthorizations `json:"authorizations,omitempty"`      // Authorization zones and expiration dates for the user.
 	Email               string                                                      `json:"email,omitempty"`               // Email address of the user
 	EmailPasswordToUser *bool                                                       `json:"emailPasswordToUser,omitempty"` // Whether or not Meraki should email the password to user. Default is false.
@@ -3093,12 +3815,15 @@ type RequestNetworksCreateNetworkMqttBroker struct {
 	Port           *int                                                  `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
 	Security       *RequestNetworksCreateNetworkMqttBrokerSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
 }
-type RequestNetworksCreateNetworkMqttBrokerAuthentication interface{}
-type RequestNetworksCreateNetworkMqttBrokerSecurity struct {
-	Mode     string                                                  `json:"mode,omitempty"`     // Security protocol of the MQTT broker.
-	Security *RequestNetworksCreateNetworkMqttBrokerSecuritySecurity `json:"security,omitempty"` // TLS settings of the MQTT broker.
+type RequestNetworksCreateNetworkMqttBrokerAuthentication struct {
+	Password string `json:"password,omitempty"` // Password for the MQTT broker.
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
 }
-type RequestNetworksCreateNetworkMqttBrokerSecuritySecurity struct {
+type RequestNetworksCreateNetworkMqttBrokerSecurity struct {
+	Mode string                                             `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *RequestNetworksCreateNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
+}
+type RequestNetworksCreateNetworkMqttBrokerSecurityTls struct {
 	CaCertificate   string `json:"caCertificate,omitempty"`   // CA Certificate of the MQTT broker.
 	VerifyHostnames *bool  `json:"verifyHostnames,omitempty"` // Whether the TLS hostname verification is enabled for the MQTT broker.
 }
@@ -3109,12 +3834,15 @@ type RequestNetworksUpdateNetworkMqttBroker struct {
 	Port           *int                                                  `json:"port,omitempty"`           // Host port though which the MQTT broker can be reached.
 	Security       *RequestNetworksUpdateNetworkMqttBrokerSecurity       `json:"security,omitempty"`       // Security settings of the MQTT broker.
 }
-type RequestNetworksUpdateNetworkMqttBrokerAuthentication interface{}
-type RequestNetworksUpdateNetworkMqttBrokerSecurity struct {
-	Mode     string                                                  `json:"mode,omitempty"`     // Security protocol of the MQTT broker.
-	Security *RequestNetworksUpdateNetworkMqttBrokerSecuritySecurity `json:"security,omitempty"` // TLS settings of the MQTT broker.
+type RequestNetworksUpdateNetworkMqttBrokerAuthentication struct {
+	Password string `json:"password,omitempty"` // Password for the MQTT broker.
+	Username string `json:"username,omitempty"` // Username for the MQTT broker.
 }
-type RequestNetworksUpdateNetworkMqttBrokerSecuritySecurity struct {
+type RequestNetworksUpdateNetworkMqttBrokerSecurity struct {
+	Mode string                                             `json:"mode,omitempty"` // Security protocol of the MQTT broker.
+	Tls  *RequestNetworksUpdateNetworkMqttBrokerSecurityTls `json:"tls,omitempty"`  // TLS settings of the MQTT broker.
+}
+type RequestNetworksUpdateNetworkMqttBrokerSecurityTls struct {
 	CaCertificate   string `json:"caCertificate,omitempty"`   // CA Certificate of the MQTT broker.
 	VerifyHostnames *bool  `json:"verifyHostnames,omitempty"` // Whether the TLS hostname verification is enabled for the MQTT broker.
 }
@@ -3137,6 +3865,7 @@ type RequestNetworksCreateNetworkPiiRequest struct {
 type RequestNetworksUpdateNetworkSettings struct {
 	LocalStatusPage         *RequestNetworksUpdateNetworkSettingsLocalStatusPage `json:"localStatusPage,omitempty"`         // A hash of Local Status page(s)' authentication options applied to the Network.
 	LocalStatusPageEnabled  *bool                                                `json:"localStatusPageEnabled,omitempty"`  // Enables / disables the local device status pages (<a target='_blank' href='http://my.meraki.com/'>my.meraki.com, </a><a target='_blank' href='http://ap.meraki.com/'>ap.meraki.com, </a><a target='_blank' href='http://switch.meraki.com/'>switch.meraki.com, </a><a target='_blank' href='http://wired.meraki.com/'>wired.meraki.com</a>). Optional (defaults to false)
+	NamedVLANs              *RequestNetworksUpdateNetworkSettingsNamedVLANs      `json:"namedVlans,omitempty"`              // A hash of Named VLANs options applied to the Network.
 	RemoteStatusPageEnabled *bool                                                `json:"remoteStatusPageEnabled,omitempty"` // Enables / disables access to the device status page (<a target='_blank'>http://[device's LAN IP])</a>. Optional. Can only be set if localStatusPageEnabled is set to true
 	SecurePort              *RequestNetworksUpdateNetworkSettingsSecurePort      `json:"securePort,omitempty"`              // A hash of SecureConnect options applied to the Network.
 }
@@ -3146,6 +3875,9 @@ type RequestNetworksUpdateNetworkSettingsLocalStatusPage struct {
 type RequestNetworksUpdateNetworkSettingsLocalStatusPageAuthentication struct {
 	Enabled  *bool  `json:"enabled,omitempty"`  // Enables / disables the authentication on Local Status page(s).
 	Password string `json:"password,omitempty"` // The password used for Local Status Page(s). Set this to null to clear the password.
+}
+type RequestNetworksUpdateNetworkSettingsNamedVLANs struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enables / disables Named VLANs on the Network.
 }
 type RequestNetworksUpdateNetworkSettingsSecurePort struct {
 	Enabled *bool `json:"enabled,omitempty"` // Enables / disables SecureConnect on the network. Optional.
@@ -3164,7 +3896,7 @@ type RequestNetworksUpdateNetworkSyslogServers struct {
 }
 type RequestNetworksUpdateNetworkSyslogServersServers struct {
 	Host  string   `json:"host,omitempty"`  // The IP address of the syslog server
-	Port  string   `json:"port,omitempty"`  // The port of the syslog server
+	Port  *int     `json:"port,omitempty"`  // The port of the syslog server
 	Roles []string `json:"roles,omitempty"` // A list of roles for the syslog server. Options (case-insensitive): 'Wireless event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
 }
 type RequestNetworksUpdateNetworkTrafficAnalysis struct {
@@ -3178,6 +3910,49 @@ type RequestNetworksUpdateNetworkTrafficAnalysisCustomPieChartItems struct {
 }
 type RequestNetworksUnbindNetwork struct {
 	RetainConfigs *bool `json:"retainConfigs,omitempty"` // Optional boolean to retain all the current configs given by the template.
+}
+type RequestNetworksCreateNetworkVLANProfile struct {
+	Iname      string                                               `json:"iname,omitempty"`      // IName of the profile
+	Name       string                                               `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]RequestNetworksCreateNetworkVLANProfileVLANGroups `json:"vlanGroups,omitempty"` // An array of VLAN groups
+	VLANNames  *[]RequestNetworksCreateNetworkVLANProfileVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type RequestNetworksCreateNetworkVLANProfileVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type RequestNetworksCreateNetworkVLANProfileVLANNames struct {
+	AdaptivePolicyGroup *RequestNetworksCreateNetworkVLANProfileVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                               `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                               `json:"vlanId,omitempty"`              // VLAN ID
+}
+type RequestNetworksCreateNetworkVLANProfileVLANNamesAdaptivePolicyGroup struct {
+	ID string `json:"id,omitempty"` // Adaptive Policy Group ID
+}
+type RequestNetworksReassignNetworkVLANProfilesAssignments struct {
+	Serials     []string                                                          `json:"serials,omitempty"`     // Array of Device Serials
+	StackIDs    []string                                                          `json:"stackIds,omitempty"`    // Array of Switch Stack IDs
+	VLANProfile *RequestNetworksReassignNetworkVLANProfilesAssignmentsVLANProfile `json:"vlanProfile,omitempty"` // The VLAN Profile
+}
+type RequestNetworksReassignNetworkVLANProfilesAssignmentsVLANProfile struct {
+	Iname string `json:"iname,omitempty"` // IName of the VLAN Profile
+}
+type RequestNetworksUpdateNetworkVLANProfile struct {
+	Name       string                                               `json:"name,omitempty"`       // Name of the profile, string length must be from 1 to 255 characters
+	VLANGroups *[]RequestNetworksUpdateNetworkVLANProfileVLANGroups `json:"vlanGroups,omitempty"` // An array of VLAN groups
+	VLANNames  *[]RequestNetworksUpdateNetworkVLANProfileVLANNames  `json:"vlanNames,omitempty"`  // An array of named VLANs
+}
+type RequestNetworksUpdateNetworkVLANProfileVLANGroups struct {
+	Name    string `json:"name,omitempty"`    // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANIDs string `json:"vlanIds,omitempty"` // Comma-separated VLAN IDs or ID ranges
+}
+type RequestNetworksUpdateNetworkVLANProfileVLANNames struct {
+	AdaptivePolicyGroup *RequestNetworksUpdateNetworkVLANProfileVLANNamesAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"` // Adaptive Policy Group assigned to Vlan ID
+	Name                string                                                               `json:"name,omitempty"`                // Name of the VLAN, string length must be from 1 to 32 characters
+	VLANID              string                                                               `json:"vlanId,omitempty"`              // VLAN ID
+}
+type RequestNetworksUpdateNetworkVLANProfileVLANNamesAdaptivePolicyGroup struct {
+	ID string `json:"id,omitempty"` // Adaptive Policy Group ID
 }
 type RequestNetworksCreateNetworkWebhooksHTTPServer struct {
 	Name            string                                                         `json:"name,omitempty"`            // A name for easy reference to the HTTP server
@@ -3198,8 +3973,8 @@ type RequestNetworksUpdateNetworkWebhooksHTTPServerPayloadTemplate struct {
 	PayloadTemplateID string `json:"payloadTemplateId,omitempty"` // The ID of the payload template. Defaults to 'wpt_00001' for the Meraki template. For Meraki-included templates: for the Webex (included) template use 'wpt_00002'; for the Slack (included) template use 'wpt_00003'; for the Microsoft Teams (included) template use 'wpt_00004'; for the ServiceNow (included) template use 'wpt_00006'
 }
 type RequestNetworksCreateNetworkWebhooksPayloadTemplate struct {
-	Body        string                                                        `json:"body,omitempty"`        // The liquid template used for the body of the webhook message. Either *body* or *bodyFile* must be specified.
-	BodyFile    string                                                        `json:"bodyFile,omitempty"`    // A file containing liquid template used for the body of the webhook message. Either *body* or *bodyFile* must be specified.
+	Body        string                                                        `json:"body,omitempty"`        // The liquid template used for the body of the webhook message. Either `body` or `bodyFile` must be specified.
+	BodyFile    string                                                        `json:"bodyFile,omitempty"`    // A file containing liquid template used for the body of the webhook message. Either `body` or `bodyFile` must be specified.
 	Headers     *[]RequestNetworksCreateNetworkWebhooksPayloadTemplateHeaders `json:"headers,omitempty"`     // The liquid template used with the webhook headers.
 	HeadersFile string                                                        `json:"headersFile,omitempty"` // A file containing the liquid template used with the webhook headers.
 	Name        string                                                        `json:"name,omitempty"`        // The name of the new template
@@ -3409,14 +4184,14 @@ func (s *NetworksService) GetNetworkBluetoothClient(networkID string, bluetoothC
 }
 
 //GetNetworkClients List the clients that have used this network in the timespan
-/* List the clients that have used this network in the timespan
+/* List the clients that have used this network in the timespan. The data is updated at most once every five minutes.
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkClientsQueryParams Filtering parameter
 
 
 */
-func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQueryParams *GetNetworkClientsQueryParams) (*[]ResponseNetworksGetNetworkClients, *resty.Response, error) {
+func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQueryParams *GetNetworkClientsQueryParams) (*ResponseNetworksGetNetworkClients, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3426,7 +4201,7 @@ func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQ
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).SetResult(&[]ResponseNetworksGetNetworkClients{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseNetworksGetNetworkClients{}).
 		SetError(&Error).
 		Get(path)
 
@@ -3439,7 +4214,7 @@ func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQ
 		return nil, response, fmt.Errorf("error with operation GetNetworkClients")
 	}
 
-	result := response.Result().(*[]ResponseNetworksGetNetworkClients)
+	result := response.Result().(*ResponseNetworksGetNetworkClients)
 	return result, response, err
 
 }
@@ -4204,8 +4979,8 @@ func (s *NetworksService) GetNetworkHealthAlerts(networkID string) (*ResponseNet
 
 }
 
-//GetNetworkMerakiAuthUsers List the users configured under Meraki Authentication for a network (splash guest or RADIUS users for a wireless network, or client VPN users for a wired network)
-/* List the users configured under Meraki Authentication for a network (splash guest or RADIUS users for a wireless network, or client VPN users for a wired network)
+//GetNetworkMerakiAuthUsers List the users configured under Meraki Authentication for a network (splash guest or RADIUS users for a wireless network, or client VPN users for a MX network)
+/* List the users configured under Meraki Authentication for a network (splash guest or RADIUS users for a wireless network, or client VPN users for a MX network)
 
 @param networkID networkId path parameter. Network ID
 
@@ -4414,9 +5189,9 @@ func (s *NetworksService) GetNetworkNetworkHealthChannelUtilization(networkID st
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/piiKeys
-***
+```
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiPiiKeysQueryParams Filtering parameter
@@ -4456,9 +5231,9 @@ func (s *NetworksService) GetNetworkPiiPiiKeys(networkID string, getNetworkPiiPi
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/requests
-***
+```
 
 @param networkID networkId path parameter. Network ID
 
@@ -4495,9 +5270,9 @@ func (s *NetworksService) GetNetworkPiiRequests(networkID string) (*ResponseNetw
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/requests/{requestId}
-***
+```
 
 @param networkID networkId path parameter. Network ID
 @param requestID requestId path parameter. Request ID
@@ -4536,9 +5311,9 @@ func (s *NetworksService) GetNetworkPiiRequest(networkID string, requestID strin
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/smDevicesForKey
-***
+```
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiSmDevicesForKeyQueryParams Filtering parameter
@@ -4578,9 +5353,9 @@ func (s *NetworksService) GetNetworkPiiSmDevicesForKey(networkID string, getNetw
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/smOwnersForKey
-***
+```
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiSmOwnersForKeyQueryParams Filtering parameter
@@ -4786,8 +5561,8 @@ func (s *NetworksService) GetNetworkSyslogServers(networkID string) (*ResponseNe
 
 }
 
-//GetNetworkTopologyLinkLayer List the LLDP and CDP information for all discovered devices and connections in a network.
-/* List the LLDP and CDP information for all discovered devices and connections in a network.
+//GetNetworkTopologyLinkLayer List the LLDP and CDP information for all discovered devices and connections in a network
+/* List the LLDP and CDP information for all discovered devices and connections in a network. At least one MX or MS device must be in the network in order to build the topology.
 
 @param networkID networkId path parameter. Network ID
 
@@ -4888,8 +5663,8 @@ func (s *NetworksService) GetNetworkTrafficAnalysis(networkID string) (*Response
 
 }
 
-//GetNetworkTrafficShapingApplicationCategories Returns the application categories for traffic shaping rules.
-/* Returns the application categories for traffic shaping rules.
+//GetNetworkTrafficShapingApplicationCategories Returns the application categories for traffic shaping rules
+/* Returns the application categories for traffic shaping rules. Only applicable on networks with a security applicance.
 
 @param networkID networkId path parameter. Network ID
 
@@ -4950,6 +5725,110 @@ func (s *NetworksService) GetNetworkTrafficShapingDscpTaggingOptions(networkID s
 	}
 
 	result := response.Result().(*ResponseNetworksGetNetworkTrafficShapingDscpTaggingOptions)
+	return result, response, err
+
+}
+
+//GetNetworkVLANProfiles List VLAN profiles for a network
+/* List VLAN profiles for a network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+func (s *NetworksService) GetNetworkVLANProfiles(networkID string) (*ResponseNetworksGetNetworkVLANProfiles, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseNetworksGetNetworkVLANProfiles{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkVlanProfiles")
+	}
+
+	result := response.Result().(*ResponseNetworksGetNetworkVLANProfiles)
+	return result, response, err
+
+}
+
+//GetNetworkVLANProfilesAssignmentsByDevice Get the assigned VLAN Profiles for devices in a network
+/* Get the assigned VLAN Profiles for devices in a network
+
+@param networkID networkId path parameter. Network ID
+@param getNetworkVlanProfilesAssignmentsByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *NetworksService) GetNetworkVLANProfilesAssignmentsByDevice(networkID string, getNetworkVlanProfilesAssignmentsByDeviceQueryParams *GetNetworkVLANProfilesAssignmentsByDeviceQueryParams) (*ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles/assignments/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	queryString, _ := query.Values(getNetworkVlanProfilesAssignmentsByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkVlanProfilesAssignmentsByDevice")
+	}
+
+	result := response.Result().(*ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice)
+	return result, response, err
+
+}
+
+//GetNetworkVLANProfile Get an existing VLAN profile of a network
+/* Get an existing VLAN profile of a network
+
+@param networkID networkId path parameter. Network ID
+@param iname iname path parameter.
+
+
+*/
+func (s *NetworksService) GetNetworkVLANProfile(networkID string, iname string) (*ResponseNetworksGetNetworkVLANProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles/{iname}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{iname}", fmt.Sprintf("%v", iname), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseNetworksGetNetworkVLANProfile{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkVlanProfile")
+	}
+
+	result := response.Result().(*ResponseNetworksGetNetworkVLANProfile)
 	return result, response, err
 
 }
@@ -5125,6 +6004,41 @@ func (s *NetworksService) GetNetworkWebhooksWebhookTest(networkID string, webhoo
 
 }
 
+//GetOrganizationSummaryTopNetworksByStatus List the client and status overview information for the networks in an organization
+/* List the client and status overview information for the networks in an organization. Usage is measured in kilobytes and from the last seven days.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSummaryTopNetworksByStatusQueryParams Filtering parameter
+
+
+*/
+func (s *NetworksService) GetOrganizationSummaryTopNetworksByStatus(organizationID string, getOrganizationSummaryTopNetworksByStatusQueryParams *GetOrganizationSummaryTopNetworksByStatusQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/summary/top/networks/byStatus"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSummaryTopNetworksByStatusQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationSummaryTopNetworksByStatus")
+	}
+
+	return response, err
+
+}
+
 //BindNetwork Bind a network to a template.
 /* Bind a network to a template.
 
@@ -5133,7 +6047,7 @@ func (s *NetworksService) GetNetworkWebhooksWebhookTest(networkID string, webhoo
 
 */
 
-func (s *NetworksService) BindNetwork(networkID string, requestNetworksBindNetwork *RequestNetworksBindNetwork) (*resty.Response, error) {
+func (s *NetworksService) BindNetwork(networkID string, requestNetworksBindNetwork *RequestNetworksBindNetwork) (*ResponseNetworksBindNetwork, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/bind"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5142,20 +6056,21 @@ func (s *NetworksService) BindNetwork(networkID string, requestNetworksBindNetwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksBindNetwork).
-		// SetResult(&ResponseNetworksBindNetwork{}).
+		SetResult(&ResponseNetworksBindNetwork{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation BindNetwork")
+		return nil, response, fmt.Errorf("error with operation BindNetwork")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksBindNetwork)
+	return result, response, err
 
 }
 
@@ -5167,7 +6082,7 @@ func (s *NetworksService) BindNetwork(networkID string, requestNetworksBindNetwo
 
 */
 
-func (s *NetworksService) ProvisionNetworkClients(networkID string, requestNetworksProvisionNetworkClients *RequestNetworksProvisionNetworkClients) (*resty.Response, error) {
+func (s *NetworksService) ProvisionNetworkClients(networkID string, requestNetworksProvisionNetworkClients *RequestNetworksProvisionNetworkClients) (*ResponseNetworksProvisionNetworkClients, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/provision"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5176,32 +6091,33 @@ func (s *NetworksService) ProvisionNetworkClients(networkID string, requestNetwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksProvisionNetworkClients).
-		// SetResult(&ResponseNetworksProvisionNetworkClients{}).
+		SetResult(&ResponseNetworksProvisionNetworkClients{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ProvisionNetworkClients")
+		return nil, response, fmt.Errorf("error with operation ProvisionNetworkClients")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksProvisionNetworkClients)
+	return result, response, err
 
 }
 
-//ClaimNetworkDevices Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requsts against that device to succeed)
-/* Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requsts against that device to succeed)
+//ClaimNetworkDevices Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requests against that device to succeed)
+/* Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requests against that device to succeed). This operation can be used up to ten times within a single five minute window.
 
 @param networkID networkId path parameter. Network ID
 
 
 */
 
-func (s *NetworksService) ClaimNetworkDevices(networkID string, requestNetworksClaimNetworkDevices *RequestNetworksClaimNetworkDevices) (*resty.Response, error) {
+func (s *NetworksService) ClaimNetworkDevices(networkID string, requestNetworksClaimNetworkDevices *RequestNetworksClaimNetworkDevices) (*ResponseNetworksClaimNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices/claim"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5210,19 +6126,21 @@ func (s *NetworksService) ClaimNetworkDevices(networkID string, requestNetworksC
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksClaimNetworkDevices).
+		SetResult(&ResponseNetworksClaimNetworkDevices{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ClaimNetworkDevices")
+		return nil, response, fmt.Errorf("error with operation ClaimNetworkDevices")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksClaimNetworkDevices)
+	return result, response, err
 
 }
 
@@ -5234,7 +6152,7 @@ func (s *NetworksService) ClaimNetworkDevices(networkID string, requestNetworksC
 
 */
 
-func (s *NetworksService) VmxNetworkDevicesClaim(networkID string, requestNetworksVmxNetworkDevicesClaim *RequestNetworksVmxNetworkDevicesClaim) (*resty.Response, error) {
+func (s *NetworksService) VmxNetworkDevicesClaim(networkID string, requestNetworksVmxNetworkDevicesClaim *RequestNetworksVmxNetworkDevicesClaim) (*ResponseNetworksVmxNetworkDevicesClaim, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices/claim/vmx"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5243,20 +6161,21 @@ func (s *NetworksService) VmxNetworkDevicesClaim(networkID string, requestNetwor
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksVmxNetworkDevicesClaim).
-		// SetResult(&ResponseNetworksVmxNetworkDevicesClaim{}).
+		SetResult(&ResponseNetworksVmxNetworkDevicesClaim{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation VmxNetworkDevicesClaim")
+		return nil, response, fmt.Errorf("error with operation VmxNetworkDevicesClaim")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksVmxNetworkDevicesClaim)
+	return result, response, err
 
 }
 
@@ -5440,7 +6359,7 @@ func (s *NetworksService) RollbacksNetworkFirmwareUpgradesStagedEvents(networkID
 
 */
 
-func (s *NetworksService) CreateNetworkFirmwareUpgradesStagedGroup(networkID string, requestNetworksCreateNetworkFirmwareUpgradesStagedGroup *RequestNetworksCreateNetworkFirmwareUpgradesStagedGroup) (*resty.Response, error) {
+func (s *NetworksService) CreateNetworkFirmwareUpgradesStagedGroup(networkID string, requestNetworksCreateNetworkFirmwareUpgradesStagedGroup *RequestNetworksCreateNetworkFirmwareUpgradesStagedGroup) (*ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/groups"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5449,20 +6368,21 @@ func (s *NetworksService) CreateNetworkFirmwareUpgradesStagedGroup(networkID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksCreateNetworkFirmwareUpgradesStagedGroup).
-		// SetResult(&ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup{}).
+		SetResult(&ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkFirmwareUpgradesStagedGroup")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkFirmwareUpgradesStagedGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksCreateNetworkFirmwareUpgradesStagedGroup)
+	return result, response, err
 
 }
 
@@ -5474,7 +6394,7 @@ func (s *NetworksService) CreateNetworkFirmwareUpgradesStagedGroup(networkID str
 
 */
 
-func (s *NetworksService) CreateNetworkFloorPlan(networkID string, requestNetworksCreateNetworkFloorPlan *RequestNetworksCreateNetworkFloorPlan) (*resty.Response, error) {
+func (s *NetworksService) CreateNetworkFloorPlan(networkID string, requestNetworksCreateNetworkFloorPlan *RequestNetworksCreateNetworkFloorPlan) (*ResponseNetworksCreateNetworkFloorPlan, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/floorPlans"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5483,20 +6403,21 @@ func (s *NetworksService) CreateNetworkFloorPlan(networkID string, requestNetwor
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksCreateNetworkFloorPlan).
-		// SetResult(&ResponseNetworksCreateNetworkFloorPlan{}).
+		SetResult(&ResponseNetworksCreateNetworkFloorPlan{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkFloorPlan")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkFloorPlan")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksCreateNetworkFloorPlan)
+	return result, response, err
 
 }
 
@@ -5508,7 +6429,7 @@ func (s *NetworksService) CreateNetworkFloorPlan(networkID string, requestNetwor
 
 */
 
-func (s *NetworksService) CreateNetworkGroupPolicy(networkID string, requestNetworksCreateNetworkGroupPolicy *RequestNetworksCreateNetworkGroupPolicy) (*resty.Response, error) {
+func (s *NetworksService) CreateNetworkGroupPolicy(networkID string, requestNetworksCreateNetworkGroupPolicy *RequestNetworksCreateNetworkGroupPolicy) (*ResponseNetworksCreateNetworkGroupPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/groupPolicies"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5517,20 +6438,21 @@ func (s *NetworksService) CreateNetworkGroupPolicy(networkID string, requestNetw
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksCreateNetworkGroupPolicy).
-		// SetResult(&ResponseNetworksCreateNetworkGroupPolicy{}).
+		SetResult(&ResponseNetworksCreateNetworkGroupPolicy{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkGroupPolicy")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkGroupPolicy")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksCreateNetworkGroupPolicy)
+	return result, response, err
 
 }
 
@@ -5577,7 +6499,7 @@ func (s *NetworksService) CreateNetworkMerakiAuthUser(networkID string, requestN
 
 */
 
-func (s *NetworksService) CreateNetworkMqttBroker(networkID string, requestNetworksCreateNetworkMqttBroker *RequestNetworksCreateNetworkMqttBroker) (*resty.Response, error) {
+func (s *NetworksService) CreateNetworkMqttBroker(networkID string, requestNetworksCreateNetworkMqttBroker *RequestNetworksCreateNetworkMqttBroker) (*ResponseNetworksCreateNetworkMqttBroker, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/mqttBrokers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5586,20 +6508,21 @@ func (s *NetworksService) CreateNetworkMqttBroker(networkID string, requestNetwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksCreateNetworkMqttBroker).
-		// SetResult(&ResponseNetworksCreateNetworkMqttBroker{}).
+		SetResult(&ResponseNetworksCreateNetworkMqttBroker{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkMqttBroker")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkMqttBroker")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksCreateNetworkMqttBroker)
+	return result, response, err
 
 }
 
@@ -5608,16 +6531,16 @@ func (s *NetworksService) CreateNetworkMqttBroker(networkID string, requestNetwo
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/requests
-***
+```
 
 @param networkID networkId path parameter. Network ID
 
 
 */
 
-func (s *NetworksService) CreateNetworkPiiRequest(networkID string, requestNetworksCreateNetworkPiiRequest *RequestNetworksCreateNetworkPiiRequest) (*resty.Response, error) {
+func (s *NetworksService) CreateNetworkPiiRequest(networkID string, requestNetworksCreateNetworkPiiRequest *RequestNetworksCreateNetworkPiiRequest) (*ResponseNetworksCreateNetworkPiiRequest, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/requests"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5626,20 +6549,21 @@ func (s *NetworksService) CreateNetworkPiiRequest(networkID string, requestNetwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksCreateNetworkPiiRequest).
-		// SetResult(&ResponseNetworksCreateNetworkPiiRequest{}).
+		SetResult(&ResponseNetworksCreateNetworkPiiRequest{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkPiiRequest")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkPiiRequest")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksCreateNetworkPiiRequest)
+	return result, response, err
 
 }
 
@@ -5708,6 +6632,76 @@ func (s *NetworksService) UnbindNetwork(networkID string, requestNetworksUnbindN
 	}
 
 	result := response.Result().(*ResponseNetworksUnbindNetwork)
+	return result, response, err
+
+}
+
+//CreateNetworkVLANProfile Create a VLAN profile for a network
+/* Create a VLAN profile for a network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *NetworksService) CreateNetworkVLANProfile(networkID string, requestNetworksCreateNetworkVlanProfile *RequestNetworksCreateNetworkVLANProfile) (*ResponseNetworksCreateNetworkVLANProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestNetworksCreateNetworkVlanProfile).
+		SetResult(&ResponseNetworksCreateNetworkVLANProfile{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateNetworkVlanProfile")
+	}
+
+	result := response.Result().(*ResponseNetworksCreateNetworkVLANProfile)
+	return result, response, err
+
+}
+
+//ReassignNetworkVLANProfilesAssignments Update the assigned VLAN Profile for devices in a network
+/* Update the assigned VLAN Profile for devices in a network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *NetworksService) ReassignNetworkVLANProfilesAssignments(networkID string, requestNetworksReassignNetworkVlanProfilesAssignments *RequestNetworksReassignNetworkVLANProfilesAssignments) (*ResponseNetworksReassignNetworkVLANProfilesAssignments, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles/assignments/reassign"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestNetworksReassignNetworkVlanProfilesAssignments).
+		SetResult(&ResponseNetworksReassignNetworkVLANProfilesAssignments{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation ReassignNetworkVlanProfilesAssignments")
+	}
+
+	result := response.Result().(*ResponseNetworksReassignNetworkVLANProfilesAssignments)
 	return result, response, err
 
 }
@@ -5824,7 +6818,8 @@ func (s *NetworksService) CreateNetworkWebhooksWebhookTest(networkID string, req
 
 
 */
-func (s *NetworksService) CombineOrganizationNetworks(organizationID string, requestNetworksCombineOrganizationNetworks *RequestNetworksCombineOrganizationNetworks) (*ResponseNetworksCombineOrganizationNetworks, *resty.Response, error) {
+
+func (s *NetworksService) CombineOrganizationNetworks(organizationID string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/networks/combine"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5832,22 +6827,19 @@ func (s *NetworksService) CombineOrganizationNetworks(organizationID string, req
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBody(requestNetworksCombineOrganizationNetworks).
-		SetResult(&ResponseNetworksCombineOrganizationNetworks{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation CombineOrganizationNetworks")
+		return response, fmt.Errorf("error with operation CombineOrganizationNetworks")
 	}
 
-	result := response.Result().(*ResponseNetworksCombineOrganizationNetworks)
-	return result, response, err
+	return response, err
 
 }
 
@@ -5919,7 +6911,7 @@ func (s *NetworksService) UpdateNetworkAlertsSettings(networkID string, requestN
 @param networkID networkId path parameter. Network ID
 @param clientID clientId path parameter. Client ID
 */
-func (s *NetworksService) UpdateNetworkClientPolicy(networkID string, clientID string, requestNetworksUpdateNetworkClientPolicy *RequestNetworksUpdateNetworkClientPolicy) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkClientPolicy(networkID string, clientID string, requestNetworksUpdateNetworkClientPolicy *RequestNetworksUpdateNetworkClientPolicy) (*ResponseNetworksUpdateNetworkClientPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}/policy"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5929,19 +6921,21 @@ func (s *NetworksService) UpdateNetworkClientPolicy(networkID string, clientID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkClientPolicy).
+		SetResult(&ResponseNetworksUpdateNetworkClientPolicy{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkClientPolicy")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkClientPolicy")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkClientPolicy)
+	return result, response, err
 
 }
 
@@ -6047,7 +7041,7 @@ func (s *NetworksService) UpdateNetworkFirmwareUpgradesStagedEvents(networkID st
 @param networkID networkId path parameter. Network ID
 @param groupID groupId path parameter. Group ID
 */
-func (s *NetworksService) UpdateNetworkFirmwareUpgradesStagedGroup(networkID string, groupID string, requestNetworksUpdateNetworkFirmwareUpgradesStagedGroup *RequestNetworksUpdateNetworkFirmwareUpgradesStagedGroup) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkFirmwareUpgradesStagedGroup(networkID string, groupID string, requestNetworksUpdateNetworkFirmwareUpgradesStagedGroup *RequestNetworksUpdateNetworkFirmwareUpgradesStagedGroup) (*ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/groups/{groupId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6057,19 +7051,21 @@ func (s *NetworksService) UpdateNetworkFirmwareUpgradesStagedGroup(networkID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkFirmwareUpgradesStagedGroup).
+		SetResult(&ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroup{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkFirmwareUpgradesStagedGroup")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkFirmwareUpgradesStagedGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkFirmwareUpgradesStagedGroup)
+	return result, response, err
 
 }
 
@@ -6111,7 +7107,7 @@ func (s *NetworksService) UpdateNetworkFirmwareUpgradesStagedStages(networkID st
 @param networkID networkId path parameter. Network ID
 @param floorPlanID floorPlanId path parameter. Floor plan ID
 */
-func (s *NetworksService) UpdateNetworkFloorPlan(networkID string, floorPlanID string, requestNetworksUpdateNetworkFloorPlan *RequestNetworksUpdateNetworkFloorPlan) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkFloorPlan(networkID string, floorPlanID string, requestNetworksUpdateNetworkFloorPlan *RequestNetworksUpdateNetworkFloorPlan) (*ResponseNetworksUpdateNetworkFloorPlan, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/floorPlans/{floorPlanId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6121,19 +7117,21 @@ func (s *NetworksService) UpdateNetworkFloorPlan(networkID string, floorPlanID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkFloorPlan).
+		SetResult(&ResponseNetworksUpdateNetworkFloorPlan{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkFloorPlan")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkFloorPlan")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkFloorPlan)
+	return result, response, err
 
 }
 
@@ -6143,7 +7141,7 @@ func (s *NetworksService) UpdateNetworkFloorPlan(networkID string, floorPlanID s
 @param networkID networkId path parameter. Network ID
 @param groupPolicyID groupPolicyId path parameter. Group policy ID
 */
-func (s *NetworksService) UpdateNetworkGroupPolicy(networkID string, groupPolicyID string, requestNetworksUpdateNetworkGroupPolicy *RequestNetworksUpdateNetworkGroupPolicy) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkGroupPolicy(networkID string, groupPolicyID string, requestNetworksUpdateNetworkGroupPolicy *RequestNetworksUpdateNetworkGroupPolicy) (*ResponseNetworksUpdateNetworkGroupPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/groupPolicies/{groupPolicyId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6153,19 +7151,21 @@ func (s *NetworksService) UpdateNetworkGroupPolicy(networkID string, groupPolicy
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkGroupPolicy).
+		SetResult(&ResponseNetworksUpdateNetworkGroupPolicy{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkGroupPolicy")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkGroupPolicy")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkGroupPolicy)
+	return result, response, err
 
 }
 
@@ -6209,7 +7209,7 @@ func (s *NetworksService) UpdateNetworkMerakiAuthUser(networkID string, merakiAu
 @param networkID networkId path parameter. Network ID
 @param mqttBrokerID mqttBrokerId path parameter. Mqtt broker ID
 */
-func (s *NetworksService) UpdateNetworkMqttBroker(networkID string, mqttBrokerID string, requestNetworksUpdateNetworkMqttBroker *RequestNetworksUpdateNetworkMqttBroker) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkMqttBroker(networkID string, mqttBrokerID string, requestNetworksUpdateNetworkMqttBroker *RequestNetworksUpdateNetworkMqttBroker) (*ResponseNetworksUpdateNetworkMqttBroker, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/mqttBrokers/{mqttBrokerId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6219,19 +7219,21 @@ func (s *NetworksService) UpdateNetworkMqttBroker(networkID string, mqttBrokerID
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkMqttBroker).
+		SetResult(&ResponseNetworksUpdateNetworkMqttBroker{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkMqttBroker")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkMqttBroker")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkMqttBroker)
+	return result, response, err
 
 }
 
@@ -6240,7 +7242,7 @@ func (s *NetworksService) UpdateNetworkMqttBroker(networkID string, mqttBrokerID
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *NetworksService) UpdateNetworkNetflow(networkID string, requestNetworksUpdateNetworkNetflow *RequestNetworksUpdateNetworkNetflow) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkNetflow(networkID string, requestNetworksUpdateNetworkNetflow *RequestNetworksUpdateNetworkNetflow) (*ResponseNetworksUpdateNetworkNetflow, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/netflow"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6249,19 +7251,21 @@ func (s *NetworksService) UpdateNetworkNetflow(networkID string, requestNetworks
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkNetflow).
+		SetResult(&ResponseNetworksUpdateNetworkNetflow{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkNetflow")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkNetflow")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkNetflow)
+	return result, response, err
 
 }
 
@@ -6302,7 +7306,7 @@ func (s *NetworksService) UpdateNetworkSettings(networkID string, requestNetwork
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *NetworksService) UpdateNetworkSNMP(networkID string, requestNetworksUpdateNetworkSnmp *RequestNetworksUpdateNetworkSNMP) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkSNMP(networkID string, requestNetworksUpdateNetworkSnmp *RequestNetworksUpdateNetworkSNMP) (*ResponseNetworksUpdateNetworkSNMP, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/snmp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6311,19 +7315,21 @@ func (s *NetworksService) UpdateNetworkSNMP(networkID string, requestNetworksUpd
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkSnmp).
+		SetResult(&ResponseNetworksUpdateNetworkSNMP{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSnmp")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSnmp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkSNMP)
+	return result, response, err
 
 }
 
@@ -6364,7 +7370,7 @@ func (s *NetworksService) UpdateNetworkSyslogServers(networkID string, requestNe
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *NetworksService) UpdateNetworkTrafficAnalysis(networkID string, requestNetworksUpdateNetworkTrafficAnalysis *RequestNetworksUpdateNetworkTrafficAnalysis) (*resty.Response, error) {
+func (s *NetworksService) UpdateNetworkTrafficAnalysis(networkID string, requestNetworksUpdateNetworkTrafficAnalysis *RequestNetworksUpdateNetworkTrafficAnalysis) (*ResponseNetworksUpdateNetworkTrafficAnalysis, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/trafficAnalysis"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6373,19 +7379,55 @@ func (s *NetworksService) UpdateNetworkTrafficAnalysis(networkID string, request
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestNetworksUpdateNetworkTrafficAnalysis).
+		SetResult(&ResponseNetworksUpdateNetworkTrafficAnalysis{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkTrafficAnalysis")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkTrafficAnalysis")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksUpdateNetworkTrafficAnalysis)
+	return result, response, err
+
+}
+
+//UpdateNetworkVLANProfile Update an existing VLAN profile of a network
+/* Update an existing VLAN profile of a network
+
+@param networkID networkId path parameter. Network ID
+@param iname iname path parameter.
+*/
+func (s *NetworksService) UpdateNetworkVLANProfile(networkID string, iname string, requestNetworksUpdateNetworkVlanProfile *RequestNetworksUpdateNetworkVLANProfile) (*ResponseNetworksUpdateNetworkVLANProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/vlanProfiles/{iname}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{iname}", fmt.Sprintf("%v", iname), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestNetworksUpdateNetworkVlanProfile).
+		SetResult(&ResponseNetworksUpdateNetworkVLANProfile{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkVlanProfile")
+	}
+
+	result := response.Result().(*ResponseNetworksUpdateNetworkVLANProfile)
+	return result, response, err
 
 }
 
@@ -6531,7 +7573,7 @@ func (s *NetworksService) DeleteNetworkFirmwareUpgradesStagedGroup(networkID str
 
 
 */
-func (s *NetworksService) DeleteNetworkFloorPlan(networkID string, floorPlanID string) (*resty.Response, error) {
+func (s *NetworksService) DeleteNetworkFloorPlan(networkID string, floorPlanID string) (*ResponseNetworksDeleteNetworkFloorPlan, *resty.Response, error) {
 	//networkID string,floorPlanID string
 	path := "/api/v1/networks/{networkId}/floorPlans/{floorPlanId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6541,19 +7583,21 @@ func (s *NetworksService) DeleteNetworkFloorPlan(networkID string, floorPlanID s
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetResult(&ResponseNetworksDeleteNetworkFloorPlan{}).
 		SetError(&Error).
 		Delete(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation DeleteNetworkFloorPlan")
+		return nil, response, fmt.Errorf("error with operation DeleteNetworkFloorPlan")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseNetworksDeleteNetworkFloorPlan)
+	return result, response, err
 
 }
 
@@ -6591,24 +7635,28 @@ func (s *NetworksService) DeleteNetworkGroupPolicy(networkID string, groupPolicy
 
 }
 
-//DeleteNetworkMerakiAuthUser Deauthorize a user
-/* Deauthorize a user. To reauthorize a user after deauthorizing them, POST to this endpoint. (Currently, 802.1X RADIUS, splash guest, and client VPN users can be deauthorized.)
+//DeleteNetworkMerakiAuthUser Delete an 802.1X RADIUS user, or deauthorize and optionally delete a splash guest or client VPN user.
+/* Delete an 802.1X RADIUS user, or deauthorize and optionally delete a splash guest or client VPN user.
 
 @param networkID networkId path parameter. Network ID
 @param merakiAuthUserID merakiAuthUserId path parameter. Meraki auth user ID
+@param deleteNetworkMerakiAuthUserQueryParams Filtering parameter
 
 
 */
-func (s *NetworksService) DeleteNetworkMerakiAuthUser(networkID string, merakiAuthUserID string) (*resty.Response, error) {
-	//networkID string,merakiAuthUserID string
+func (s *NetworksService) DeleteNetworkMerakiAuthUser(networkID string, merakiAuthUserID string, deleteNetworkMerakiAuthUserQueryParams *DeleteNetworkMerakiAuthUserQueryParams) (*resty.Response, error) {
+	//networkID string,merakiAuthUserID string,deleteNetworkMerakiAuthUserQueryParams *DeleteNetworkMerakiAuthUserQueryParams
 	path := "/api/v1/networks/{networkId}/merakiAuthUsers/{merakiAuthUserId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{merakiAuthUserId}", fmt.Sprintf("%v", merakiAuthUserID), -1)
 
+	queryString, _ := query.Values(deleteNetworkMerakiAuthUserQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
 		SetError(&Error).
 		Delete(path)
 
@@ -6664,9 +7712,9 @@ func (s *NetworksService) DeleteNetworkMqttBroker(networkID string, mqttBrokerID
 
 ## ALTERNATE PATH
 
-***
+```
 /organizations/{organizationId}/pii/requests/{requestId}
-***
+```
 
 @param networkID networkId path parameter. Network ID
 @param requestID requestId path parameter. Request ID
@@ -6693,6 +7741,40 @@ func (s *NetworksService) DeleteNetworkPiiRequest(networkID string, requestID st
 
 	if response.IsError() {
 		return response, fmt.Errorf("error with operation DeleteNetworkPiiRequest")
+	}
+
+	return response, err
+
+}
+
+//DeleteNetworkVLANProfile Delete a VLAN profile of a network
+/* Delete a VLAN profile of a network
+
+@param networkID networkId path parameter. Network ID
+@param iname iname path parameter.
+
+
+*/
+func (s *NetworksService) DeleteNetworkVLANProfile(networkID string, iname string) (*resty.Response, error) {
+	//networkID string,iname string
+	path := "/api/v1/networks/{networkId}/vlanProfiles/{iname}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{iname}", fmt.Sprintf("%v", iname), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteNetworkVlanProfile")
 	}
 
 	return response, err

--- a/sdk/organizations.go
+++ b/sdk/organizations.go
@@ -10,6 +10,11 @@ import (
 
 type OrganizationsService service
 
+type GetOrganizationsQueryParams struct {
+	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 9000. Default is 9000.
+	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
 type GetOrganizationActionBatchesQueryParams struct {
 	Status string `url:"status,omitempty"` //Filter batches by status. Valid types are pending, completed, and failed.
 }
@@ -100,6 +105,29 @@ type GetOrganizationDevicesAvailabilitiesQueryParams struct {
 	Tags           []string `url:"tags[],omitempty"`         //An optional parameter to filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below). This filter uses multiple exact matches.
 	TagsFilterType string   `url:"tagsFilterType,omitempty"` //An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return devices which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.
 }
+type GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`             //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`             //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`       //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Serials       []string `url:"serials[],omitempty"`      //Optional parameter to filter device availabilities history by device serial numbers
+	ProductTypes  []string `url:"productTypes[],omitempty"` //Optional parameter to filter device availabilities history by device product types
+	NetworkIDs    []string `url:"networkIds[],omitempty"`   //Optional parameter to filter device availabilities history by network IDs
+	Statuses      []string `url:"statuses[],omitempty"`     //Optional parameter to filter device availabilities history by device statuses
+}
+type GetOrganizationDevicesBootsHistoryQueryParams struct {
+	T0                  string   `url:"t0,omitempty"`                  //The beginning of the timespan for the data.
+	T1                  string   `url:"t1,omitempty"`                  //The end of the timespan for the data. t1 can be a maximum of 730 days after t0.
+	Timespan            float64  `url:"timespan,omitempty"`            //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 730 days.
+	Serials             []string `url:"serials[],omitempty"`           //Optional parameter to filter device by device serial numbers. This filter uses multiple exact matches.
+	MostRecentPerDevice bool     `url:"mostRecentPerDevice,omitempty"` //If true, only the most recent boot for each device is returned.
+	PerPage             int      `url:"perPage,omitempty"`             //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter       string   `url:"startingAfter,omitempty"`       //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore        string   `url:"endingBefore,omitempty"`        //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder           string   `url:"sortOrder,omitempty"`           //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'descending'.
+}
 type GetOrganizationDevicesPowerModulesStatusesByDeviceQueryParams struct {
 	PerPage        int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter  string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -151,22 +179,25 @@ type GetOrganizationDevicesUplinksLossAndLatencyQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data. The maximum lookback period is 60 days from today.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 5 minutes after t0. The latest possible time that t1 can be is 2 minutes into the past.
 	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 5 minutes. The default is 5 minutes.
-	Uplink   string  `url:"uplink,omitempty"`   //Optional filter for a specific WAN uplink. Valid uplinks are wan1, wan2, cellular. Default will return all uplinks.
+	Uplink   string  `url:"uplink,omitempty"`   //Optional filter for a specific WAN uplink. Valid uplinks are wan1, wan2, wan3, cellular. Default will return all uplinks.
 	IP       string  `url:"ip,omitempty"`       //Optional filter for a specific destination IP. Default will return all destination IPs.
 }
 type GetOrganizationFirmwareUpgradesQueryParams struct {
-	Status      []string `url:"status[],omitempty"`      //The status of an upgrade
-	ProductType []string `url:"productType[],omitempty"` //The product type in a given upgrade ID
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	Status        []string `url:"status[],omitempty"`       //Optional parameter to filter the upgrade by status.
+	ProductTypes  []string `url:"productTypes[],omitempty"` //Optional parameter to filter the upgrade by product type.
 }
 type GetOrganizationFirmwareUpgradesByDeviceQueryParams struct {
-	PerPage                 int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 50. Default is 50.
+	PerPage                 int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 50.
 	StartingAfter           string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore            string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	NetworkIDs              []string `url:"networkIds[],omitempty"`              //Optional parameter to filter by network
 	Serials                 []string `url:"serials[],omitempty"`                 //Optional parameter to filter by serial number.  All returned devices will have a serial number that is an exact match.
 	Macs                    []string `url:"macs[],omitempty"`                    //Optional parameter to filter by one or more MAC addresses belonging to devices. All devices returned belong to MAC addresses that are an exact match.
-	FirmwareUpgradeIDs      []string `url:"firmwareUpgradeIds[],omitempty"`      //Optional parameter to filter by firmware upgrade ids.
 	FirmwareUpgradeBatchIDs []string `url:"firmwareUpgradeBatchIds[],omitempty"` //Optional parameter to filter by firmware upgrade batch ids.
+	Upgradestatuses         []string `url:"upgradeStatuses[],omitempty"`         //Optional parameter to filter by firmware upgrade statuses.
 }
 type GetOrganizationInventoryDevicesQueryParams struct {
 	PerPage        int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -175,7 +206,7 @@ type GetOrganizationInventoryDevicesQueryParams struct {
 	UsedState      string   `url:"usedState,omitempty"`      //Filter results by used or unused inventory. Accepted values are 'used' or 'unused'.
 	Search         string   `url:"search,omitempty"`         //Search for devices in inventory based on serial number, mac address, or model.
 	Macs           []string `url:"macs[],omitempty"`         //Search for devices in inventory based on mac addresses.
-	NetworkIDs     []string `url:"networkIds[],omitempty"`   //Search for devices in inventory based on network ids.
+	NetworkIDs     []string `url:"networkIds[],omitempty"`   //Search for devices in inventory based on network ids. Use explicit 'null' value to get available devices only.
 	Serials        []string `url:"serials[],omitempty"`      //Search for devices in inventory based on serials.
 	Models         []string `url:"models[],omitempty"`       //Search for devices in inventory based on model.
 	OrderNumbers   []string `url:"orderNumbers[],omitempty"` //Search for devices in inventory based on order numbers.
@@ -188,6 +219,7 @@ type GetOrganizationInventoryOnboardingCloudMonitoringImportsQueryParams struct 
 }
 type GetOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams struct {
 	DeviceType    string `url:"deviceType,omitempty"`    //Device Type switch or wireless controller
+	Search        string `url:"search,omitempty"`        //Optional parameter to search on network name
 	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 100000. Default is 1000.
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -209,6 +241,9 @@ type GetOrganizationNetworksQueryParams struct {
 	StartingAfter           string   `url:"startingAfter,omitempty"`           //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore            string   `url:"endingBefore,omitempty"`            //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
+type GetOrganizationOpenapiSpecQueryParams struct {
+	Version int `url:"version,omitempty"` //OpenAPI Specification version to return. Default is 2
+}
 type GetOrganizationPolicyObjectsQueryParams struct {
 	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 10 - 5000. Default is 5000.
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -222,12 +257,12 @@ type GetOrganizationPolicyObjectsGroupsQueryParams struct {
 type GetOrganizationSummaryTopAppliancesByUtilizationQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopClientsByUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopClientsManufacturersByUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
@@ -237,22 +272,27 @@ type GetOrganizationSummaryTopClientsManufacturersByUsageQueryParams struct {
 type GetOrganizationSummaryTopDevicesByUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopDevicesModelsByUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
+}
+type GetOrganizationSummaryTopNetworksByStatusQueryParams struct {
+	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 5000.
+	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
 type GetOrganizationSummaryTopSSIDsByUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopSwitchesByEnergyUsageQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
 	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationUplinksStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -298,7 +338,7 @@ type ResponseItemOrganizationsGetOrganizationsLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseItemOrganizationsGetOrganizationsManagement struct {
-	Details *[]ResponseItemOrganizationsGetOrganizationsManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty
+	Details *[]ResponseItemOrganizationsGetOrganizationsManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseItemOrganizationsGetOrganizationsManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -326,7 +366,7 @@ type ResponseOrganizationsCreateOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsCreateOrganizationManagement struct {
-	Details *[]ResponseOrganizationsCreateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty
+	Details *[]ResponseOrganizationsCreateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsCreateOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -354,7 +394,7 @@ type ResponseOrganizationsGetOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsGetOrganizationManagement struct {
-	Details *[]ResponseOrganizationsGetOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty
+	Details *[]ResponseOrganizationsGetOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsGetOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -382,7 +422,7 @@ type ResponseOrganizationsUpdateOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsUpdateOrganizationManagement struct {
-	Details *[]ResponseOrganizationsUpdateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty
+	Details *[]ResponseOrganizationsUpdateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsUpdateOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -390,33 +430,32 @@ type ResponseOrganizationsUpdateOrganizationManagementDetails struct {
 }
 type ResponseOrganizationsGetOrganizationActionBatches []ResponseItemOrganizationsGetOrganizationActionBatches // Array of ResponseOrganizationsGetOrganizationActionBatches
 type ResponseItemOrganizationsGetOrganizationActionBatches struct {
-	Actions        *[]ResponseItemOrganizationsGetOrganizationActionBatchesActions `json:"actions,omitempty"`        //
-	Confirmed      *bool                                                           `json:"confirmed,omitempty"`      //
-	ID             string                                                          `json:"id,omitempty"`             //
-	OrganizationID string                                                          `json:"organizationId,omitempty"` //
-	Status         *ResponseItemOrganizationsGetOrganizationActionBatchesStatus    `json:"status,omitempty"`         //
-	Synchronous    *bool                                                           `json:"synchronous,omitempty"`    //
+	Actions        *[]ResponseItemOrganizationsGetOrganizationActionBatchesActions `json:"actions,omitempty"`        // A set of changes made as part of this action (<a href='https://developer.cisco.com/meraki/api/#/rest/guides/action-batches/'>more details</a>)
+	Confirmed      *bool                                                           `json:"confirmed,omitempty"`      // Flag describing whether the action should be previewed before executing or not
+	ID             string                                                          `json:"id,omitempty"`             // ID of the action batch. Can be used to check the status of the action batch at /organizations/{organizationId}/actionBatches/{actionBatchId}
+	OrganizationID string                                                          `json:"organizationId,omitempty"` // ID of the organization this action batch belongs to
+	Status         *ResponseItemOrganizationsGetOrganizationActionBatchesStatus    `json:"status,omitempty"`         // Status of action batch
+	Synchronous    *bool                                                           `json:"synchronous,omitempty"`    // Flag describing whether actions should run synchronously or asynchronously
 }
 type ResponseItemOrganizationsGetOrganizationActionBatchesActions struct {
-	Body      *ResponseItemOrganizationsGetOrganizationActionBatchesActionsBody `json:"body,omitempty"`      //
-	Operation string                                                            `json:"operation,omitempty"` //
-	Resource  string                                                            `json:"resource,omitempty"`  //
+	Body      *ResponseItemOrganizationsGetOrganizationActionBatchesActionsBody `json:"body,omitempty"`      // Data provided in the body of the Action. Contents depend on the Action type
+	Operation string                                                            `json:"operation,omitempty"` // The operation to be used by this action
+	Resource  string                                                            `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
 }
-type ResponseItemOrganizationsGetOrganizationActionBatchesActionsBody struct {
-	Enabled *bool `json:"enabled,omitempty"` //
-}
+type ResponseItemOrganizationsGetOrganizationActionBatchesActionsBody interface{}
 type ResponseItemOrganizationsGetOrganizationActionBatchesStatus struct {
-	Completed        *bool                                                                          `json:"completed,omitempty"`        //
-	CreatedResources *[]ResponseItemOrganizationsGetOrganizationActionBatchesStatusCreatedResources `json:"createdResources,omitempty"` //
-	Errors           []string                                                                       `json:"errors,omitempty"`           //
-	Failed           *bool                                                                          `json:"failed,omitempty"`           //
+	Completed        *bool                                                                          `json:"completed,omitempty"`        // Flag describing whether all actions in the action batch have completed
+	CreatedResources *[]ResponseItemOrganizationsGetOrganizationActionBatchesStatusCreatedResources `json:"createdResources,omitempty"` // Resources created as a result of this action batch
+	Errors           []string                                                                       `json:"errors,omitempty"`           // List of errors encountered when running actions in the action batch
+	Failed           *bool                                                                          `json:"failed,omitempty"`           // Flag describing whether any actions in the action batch failed
 }
 type ResponseItemOrganizationsGetOrganizationActionBatchesStatusCreatedResources struct {
-	ID  *int   `json:"id,omitempty"`  //
-	URI string `json:"uri,omitempty"` //
+	ID  string `json:"id,omitempty"`  // ID of the created resource
+	URI string `json:"uri,omitempty"` // URI, not including base, of the created resource
 }
 type ResponseOrganizationsCreateOrganizationActionBatch struct {
 	Actions        *[]ResponseOrganizationsCreateOrganizationActionBatchActions `json:"actions,omitempty"`        // A set of changes made as part of this action (<a href='https://developer.cisco.com/meraki/api/#/rest/guides/action-batches/'>more details</a>)
+	Callback       *ResponseOrganizationsCreateOrganizationActionBatchCallback  `json:"callback,omitempty"`       // Information for callback used to send back results
 	Confirmed      *bool                                                        `json:"confirmed,omitempty"`      // Flag describing whether the action should be previewed before executing or not
 	ID             string                                                       `json:"id,omitempty"`             // ID of the action batch. Can be used to check the status of the action batch at /organizations/{organizationId}/actionBatches/{actionBatchId}
 	OrganizationID string                                                       `json:"organizationId,omitempty"` // ID of the organization this action batch belongs to
@@ -424,8 +463,15 @@ type ResponseOrganizationsCreateOrganizationActionBatch struct {
 	Synchronous    *bool                                                        `json:"synchronous,omitempty"`    // Flag describing whether actions should run synchronously or asynchronously
 }
 type ResponseOrganizationsCreateOrganizationActionBatchActions struct {
-	Operation string `json:"operation,omitempty"` // The operation to be used by this action
-	Resource  string `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
+	Body      *ResponseOrganizationsCreateOrganizationActionBatchActionsBody `json:"body,omitempty"`      // Data provided in the body of the Action. Contents depend on the Action type
+	Operation string                                                         `json:"operation,omitempty"` // The operation to be used by this action
+	Resource  string                                                         `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
+}
+type ResponseOrganizationsCreateOrganizationActionBatchActionsBody interface{}
+type ResponseOrganizationsCreateOrganizationActionBatchCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseOrganizationsCreateOrganizationActionBatchStatus struct {
 	Completed        *bool                                                                       `json:"completed,omitempty"`        // Flag describing whether all actions in the action batch have completed
@@ -439,6 +485,7 @@ type ResponseOrganizationsCreateOrganizationActionBatchStatusCreatedResources st
 }
 type ResponseOrganizationsGetOrganizationActionBatch struct {
 	Actions        *[]ResponseOrganizationsGetOrganizationActionBatchActions `json:"actions,omitempty"`        // A set of changes made as part of this action (<a href='https://developer.cisco.com/meraki/api/#/rest/guides/action-batches/'>more details</a>)
+	Callback       *ResponseOrganizationsGetOrganizationActionBatchCallback  `json:"callback,omitempty"`       // Information for callback used to send back results
 	Confirmed      *bool                                                     `json:"confirmed,omitempty"`      // Flag describing whether the action should be previewed before executing or not
 	ID             string                                                    `json:"id,omitempty"`             // ID of the action batch. Can be used to check the status of the action batch at /organizations/{organizationId}/actionBatches/{actionBatchId}
 	OrganizationID string                                                    `json:"organizationId,omitempty"` // ID of the organization this action batch belongs to
@@ -446,8 +493,15 @@ type ResponseOrganizationsGetOrganizationActionBatch struct {
 	Synchronous    *bool                                                     `json:"synchronous,omitempty"`    // Flag describing whether actions should run synchronously or asynchronously
 }
 type ResponseOrganizationsGetOrganizationActionBatchActions struct {
-	Operation string `json:"operation,omitempty"` // The operation to be used by this action
-	Resource  string `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
+	Body      *ResponseOrganizationsGetOrganizationActionBatchActionsBody `json:"body,omitempty"`      // Data provided in the body of the Action. Contents depend on the Action type
+	Operation string                                                      `json:"operation,omitempty"` // The operation to be used by this action
+	Resource  string                                                      `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
+}
+type ResponseOrganizationsGetOrganizationActionBatchActionsBody interface{}
+type ResponseOrganizationsGetOrganizationActionBatchCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseOrganizationsGetOrganizationActionBatchStatus struct {
 	Completed        *bool                                                                    `json:"completed,omitempty"`        // Flag describing whether all actions in the action batch have completed
@@ -459,7 +513,30 @@ type ResponseOrganizationsGetOrganizationActionBatchStatusCreatedResources struc
 	ID  string `json:"id,omitempty"`  // ID of the created resource
 	URI string `json:"uri,omitempty"` // URI, not including base, of the created resource
 }
-type ResponseOrganizationsUpdateOrganizationActionBatch interface{}
+type ResponseOrganizationsUpdateOrganizationActionBatch struct {
+	Actions        *[]ResponseOrganizationsUpdateOrganizationActionBatchActions `json:"actions,omitempty"`        // A set of changes made as part of this action (<a href='https://developer.cisco.com/meraki/api/#/rest/guides/action-batches/'>more details</a>)
+	Confirmed      *bool                                                        `json:"confirmed,omitempty"`      // Flag describing whether the action should be previewed before executing or not
+	ID             string                                                       `json:"id,omitempty"`             // ID of the action batch. Can be used to check the status of the action batch at /organizations/{organizationId}/actionBatches/{actionBatchId}
+	OrganizationID string                                                       `json:"organizationId,omitempty"` // ID of the organization this action batch belongs to
+	Status         *ResponseOrganizationsUpdateOrganizationActionBatchStatus    `json:"status,omitempty"`         // Status of action batch
+	Synchronous    *bool                                                        `json:"synchronous,omitempty"`    // Flag describing whether actions should run synchronously or asynchronously
+}
+type ResponseOrganizationsUpdateOrganizationActionBatchActions struct {
+	Body      *ResponseOrganizationsUpdateOrganizationActionBatchActionsBody `json:"body,omitempty"`      // Data provided in the body of the Action. Contents depend on the Action type
+	Operation string                                                         `json:"operation,omitempty"` // The operation to be used by this action
+	Resource  string                                                         `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
+}
+type ResponseOrganizationsUpdateOrganizationActionBatchActionsBody interface{}
+type ResponseOrganizationsUpdateOrganizationActionBatchStatus struct {
+	Completed        *bool                                                                       `json:"completed,omitempty"`        // Flag describing whether all actions in the action batch have completed
+	CreatedResources *[]ResponseOrganizationsUpdateOrganizationActionBatchStatusCreatedResources `json:"createdResources,omitempty"` // Resources created as a result of this action batch
+	Errors           []string                                                                    `json:"errors,omitempty"`           // List of errors encountered when running actions in the action batch
+	Failed           *bool                                                                       `json:"failed,omitempty"`           // Flag describing whether any actions in the action batch failed
+}
+type ResponseOrganizationsUpdateOrganizationActionBatchStatusCreatedResources struct {
+	ID  string `json:"id,omitempty"`  // ID of the created resource
+	URI string `json:"uri,omitempty"` // URI, not including base, of the created resource
+}
 type ResponseOrganizationsGetOrganizationAdaptivePolicyACLs []ResponseItemOrganizationsGetOrganizationAdaptivePolicyACLs // Array of ResponseOrganizationsGetOrganizationAdaptivePolicyAcls
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyACLs struct {
 	ACLID       string                                                             `json:"aclId,omitempty"`       // ID of the adaptive policy ACL
@@ -714,44 +791,62 @@ type ResponseOrganizationsUpdateOrganizationAdminTags struct {
 }
 type ResponseOrganizationsGetOrganizationAlertsProfiles []ResponseItemOrganizationsGetOrganizationAlertsProfiles // Array of ResponseOrganizationsGetOrganizationAlertsProfiles
 type ResponseItemOrganizationsGetOrganizationAlertsProfiles struct {
-	AlertCondition *ResponseItemOrganizationsGetOrganizationAlertsProfilesAlertCondition `json:"alertCondition,omitempty"` //
-	Description    string                                                                `json:"description,omitempty"`    //
-	Enabled        *bool                                                                 `json:"enabled,omitempty"`        //
-	ID             string                                                                `json:"id,omitempty"`             //
-	NetworkTags    []string                                                              `json:"networkTags,omitempty"`    //
-	Recipients     *ResponseItemOrganizationsGetOrganizationAlertsProfilesRecipients     `json:"recipients,omitempty"`     //
-	Type           string                                                                `json:"type,omitempty"`           //
+	AlertCondition *ResponseItemOrganizationsGetOrganizationAlertsProfilesAlertCondition `json:"alertCondition,omitempty"` // The conditions that determine if the alert triggers
+	Description    string                                                                `json:"description,omitempty"`    // User supplied description of the alert
+	Enabled        *bool                                                                 `json:"enabled,omitempty"`        // Is the alert config enabled
+	ID             string                                                                `json:"id,omitempty"`             // The alert config ID
+	NetworkTags    []string                                                              `json:"networkTags,omitempty"`    // Networks with these tags will be monitored for the alert
+	Recipients     *ResponseItemOrganizationsGetOrganizationAlertsProfilesRecipients     `json:"recipients,omitempty"`     // List of recipients that will recieve the alert.
+	Type           string                                                                `json:"type,omitempty"`           // The alert type
 }
 type ResponseItemOrganizationsGetOrganizationAlertsProfilesAlertCondition struct {
-	BitRateBps *int   `json:"bit_rate_bps,omitempty"` //
-	Duration   *int   `json:"duration,omitempty"`     //
-	Interface  string `json:"interface,omitempty"`    //
-	Window     *int   `json:"window,omitempty"`       //
+	BitRateBps *int   `json:"bit_rate_bps,omitempty"` // The threshold the metric must cross to be valid for alerting. Used only for WAN Utilization alerts.
+	Duration   *int   `json:"duration,omitempty"`     // The total duration in seconds that the threshold should be crossed before alerting
+	Interface  string `json:"interface,omitempty"`    // The uplink observed for the alert
+	Window     *int   `json:"window,omitempty"`       // The look back period in seconds for sensing the alert
 }
 type ResponseItemOrganizationsGetOrganizationAlertsProfilesRecipients struct {
-	Emails        []string `json:"emails,omitempty"`        //
-	HTTPServerIDs []string `json:"httpServerIds,omitempty"` //
+	Emails        []string `json:"emails,omitempty"`        // A list of emails that will receive information about the alert
+	HTTPServerIDs []string `json:"httpServerIds,omitempty"` // A list base64 encoded urls of webhook endpoints that will receive information about the alert
 }
 type ResponseOrganizationsCreateOrganizationAlertsProfile struct {
-	AlertCondition *ResponseOrganizationsCreateOrganizationAlertsProfileAlertCondition `json:"alertCondition,omitempty"` //
-	Description    string                                                              `json:"description,omitempty"`    //
-	Enabled        *bool                                                               `json:"enabled,omitempty"`        //
-	ID             string                                                              `json:"id,omitempty"`             //
-	NetworkTags    []string                                                            `json:"networkTags,omitempty"`    //
-	Recipients     *ResponseOrganizationsCreateOrganizationAlertsProfileRecipients     `json:"recipients,omitempty"`     //
-	Type           string                                                              `json:"type,omitempty"`           //
+	AlertCondition *ResponseOrganizationsCreateOrganizationAlertsProfileAlertCondition `json:"alertCondition,omitempty"` // The conditions that determine if the alert triggers
+	Description    string                                                              `json:"description,omitempty"`    // User supplied description of the alert
+	Enabled        *bool                                                               `json:"enabled,omitempty"`        // Is the alert config enabled
+	ID             string                                                              `json:"id,omitempty"`             // The alert config ID
+	NetworkTags    []string                                                            `json:"networkTags,omitempty"`    // Networks with these tags will be monitored for the alert
+	Recipients     *ResponseOrganizationsCreateOrganizationAlertsProfileRecipients     `json:"recipients,omitempty"`     // List of recipients that will recieve the alert.
+	Type           string                                                              `json:"type,omitempty"`           // The alert type
 }
 type ResponseOrganizationsCreateOrganizationAlertsProfileAlertCondition struct {
-	BitRateBps *int   `json:"bit_rate_bps,omitempty"` //
-	Duration   *int   `json:"duration,omitempty"`     //
-	Interface  string `json:"interface,omitempty"`    //
-	Window     *int   `json:"window,omitempty"`       //
+	BitRateBps *int   `json:"bit_rate_bps,omitempty"` // The threshold the metric must cross to be valid for alerting. Used only for WAN Utilization alerts.
+	Duration   *int   `json:"duration,omitempty"`     // The total duration in seconds that the threshold should be crossed before alerting
+	Interface  string `json:"interface,omitempty"`    // The uplink observed for the alert
+	Window     *int   `json:"window,omitempty"`       // The look back period in seconds for sensing the alert
 }
 type ResponseOrganizationsCreateOrganizationAlertsProfileRecipients struct {
-	Emails        []string `json:"emails,omitempty"`        //
-	HTTPServerIDs []string `json:"httpServerIds,omitempty"` //
+	Emails        []string `json:"emails,omitempty"`        // A list of emails that will receive information about the alert
+	HTTPServerIDs []string `json:"httpServerIds,omitempty"` // A list base64 encoded urls of webhook endpoints that will receive information about the alert
 }
-type ResponseOrganizationsUpdateOrganizationAlertsProfile interface{}
+type ResponseOrganizationsUpdateOrganizationAlertsProfile struct {
+	AlertCondition *ResponseOrganizationsUpdateOrganizationAlertsProfileAlertCondition `json:"alertCondition,omitempty"` // The conditions that determine if the alert triggers
+	Description    string                                                              `json:"description,omitempty"`    // User supplied description of the alert
+	Enabled        *bool                                                               `json:"enabled,omitempty"`        // Is the alert config enabled
+	ID             string                                                              `json:"id,omitempty"`             // The alert config ID
+	NetworkTags    []string                                                            `json:"networkTags,omitempty"`    // Networks with these tags will be monitored for the alert
+	Recipients     *ResponseOrganizationsUpdateOrganizationAlertsProfileRecipients     `json:"recipients,omitempty"`     // List of recipients that will recieve the alert.
+	Type           string                                                              `json:"type,omitempty"`           // The alert type
+}
+type ResponseOrganizationsUpdateOrganizationAlertsProfileAlertCondition struct {
+	BitRateBps *int   `json:"bit_rate_bps,omitempty"` // The threshold the metric must cross to be valid for alerting. Used only for WAN Utilization alerts.
+	Duration   *int   `json:"duration,omitempty"`     // The total duration in seconds that the threshold should be crossed before alerting
+	Interface  string `json:"interface,omitempty"`    // The uplink observed for the alert
+	Window     *int   `json:"window,omitempty"`       // The look back period in seconds for sensing the alert
+}
+type ResponseOrganizationsUpdateOrganizationAlertsProfileRecipients struct {
+	Emails        []string `json:"emails,omitempty"`        // A list of emails that will receive information about the alert
+	HTTPServerIDs []string `json:"httpServerIds,omitempty"` // A list base64 encoded urls of webhook endpoints that will receive information about the alert
+}
 type ResponseOrganizationsGetOrganizationAPIRequests []ResponseItemOrganizationsGetOrganizationAPIRequests // Array of ResponseOrganizationsGetOrganizationApiRequests
 type ResponseItemOrganizationsGetOrganizationAPIRequests struct {
 	AdminID      string `json:"adminId,omitempty"`      // Database ID for the admin user who made the API request.
@@ -1003,7 +1098,15 @@ type ResponseOrganizationsUpdateOrganizationBrandingPolicyHelpSettings struct {
 	SupportContactInfo                 string `json:"supportContactInfo,omitempty"`                 //       The 'Contact Meraki Support' section of the 'Help -> Get Help' subtab. Can be one of 'default or inherit', 'hide', 'show', or a replacement custom HTML string.
 	UniversalSearchKnowledgeBaseSearch string `json:"universalSearchKnowledgeBaseSearch,omitempty"` //       The universal search box always visible on Dashboard will, by default, present results from the Meraki KB. This configures       whether these Meraki KB results should be returned. Can be one of 'default or inherit', 'hide' or 'show'.
 }
-type ResponseOrganizationsClaimIntoOrganization interface{}
+type ResponseOrganizationsClaimIntoOrganization struct {
+	Licenses *[]ResponseOrganizationsClaimIntoOrganizationLicenses `json:"licenses,omitempty"` // The licenses claimed
+	Orders   []string                                              `json:"orders,omitempty"`   // The numbers of the orders claimed
+	Serials  []string                                              `json:"serials,omitempty"`  // The serials of the devices claimed
+}
+type ResponseOrganizationsClaimIntoOrganizationLicenses struct {
+	Key  string `json:"key,omitempty"`  // The key of the license
+	Mode string `json:"mode,omitempty"` // The mode of the license
+}
 type ResponseOrganizationsGetOrganizationClientsBandwidthUsageHistory []ResponseItemOrganizationsGetOrganizationClientsBandwidthUsageHistory // Array of ResponseOrganizationsGetOrganizationClientsBandwidthUsageHistory
 type ResponseItemOrganizationsGetOrganizationClientsBandwidthUsageHistory struct {
 	Downstream *int   `json:"downstream,omitempty"` // Downloaded data, in mbps.
@@ -1034,6 +1137,7 @@ type ResponseOrganizationsGetOrganizationClientsSearch struct {
 	Records      *[]ResponseOrganizationsGetOrganizationClientsSearchRecords `json:"records,omitempty"`      //
 }
 type ResponseOrganizationsGetOrganizationClientsSearchRecords struct {
+	Cdp                  string                                                                          `json:"cdp,omitempty"`                  //
 	ClientVpnConnections *[]ResponseOrganizationsGetOrganizationClientsSearchRecordsClientVpnConnections `json:"clientVpnConnections,omitempty"` //
 	Description          string                                                                          `json:"description,omitempty"`          //
 	FirstSeen            *int                                                                            `json:"firstSeen,omitempty"`            //
@@ -1046,6 +1150,7 @@ type ResponseOrganizationsGetOrganizationClientsSearchRecords struct {
 	SmInstalled          *bool                                                                           `json:"smInstalled,omitempty"`          //
 	SSID                 string                                                                          `json:"ssid,omitempty"`                 //
 	Status               string                                                                          `json:"status,omitempty"`               //
+	Switchport           string                                                                          `json:"switchport,omitempty"`           //
 	User                 string                                                                          `json:"user,omitempty"`                 //
 	VLAN                 string                                                                          `json:"vlan,omitempty"`                 //
 	WirelessCapabilities string                                                                          `json:"wirelessCapabilities,omitempty"` //
@@ -1088,7 +1193,7 @@ type ResponseOrganizationsCloneOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsCloneOrganizationManagement struct {
-	Details *[]ResponseOrganizationsCloneOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty
+	Details *[]ResponseOrganizationsCloneOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsCloneOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -1096,45 +1201,66 @@ type ResponseOrganizationsCloneOrganizationManagementDetails struct {
 }
 type ResponseOrganizationsGetOrganizationConfigTemplates []ResponseItemOrganizationsGetOrganizationConfigTemplates // Array of ResponseOrganizationsGetOrganizationConfigTemplates
 type ResponseItemOrganizationsGetOrganizationConfigTemplates struct {
-	ID           string   `json:"id,omitempty"`           //
-	Name         string   `json:"name,omitempty"`         //
-	ProductTypes []string `json:"productTypes,omitempty"` //
-	TimeZone     string   `json:"timeZone,omitempty"`     //
+	ID           string   `json:"id,omitempty"`           // The ID of the network or config template to copy configuration from
+	Name         string   `json:"name,omitempty"`         // The name of the configuration template
+	ProductTypes []string `json:"productTypes,omitempty"` // The product types of the configuration template
+	TimeZone     string   `json:"timeZone,omitempty"`     // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
 }
-type ResponseOrganizationsCreateOrganizationConfigTemplate interface{}
+type ResponseOrganizationsCreateOrganizationConfigTemplate struct {
+	ID           string   `json:"id,omitempty"`           // The ID of the network or config template to copy configuration from
+	Name         string   `json:"name,omitempty"`         // The name of the configuration template
+	ProductTypes []string `json:"productTypes,omitempty"` // The product types of the configuration template
+	TimeZone     string   `json:"timeZone,omitempty"`     // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
+}
 type ResponseOrganizationsGetOrganizationConfigTemplate struct {
-	ID           string   `json:"id,omitempty"`           //
-	Name         string   `json:"name,omitempty"`         //
-	ProductTypes []string `json:"productTypes,omitempty"` //
-	TimeZone     string   `json:"timeZone,omitempty"`     //
+	ID           string   `json:"id,omitempty"`           // The ID of the network or config template to copy configuration from
+	Name         string   `json:"name,omitempty"`         // The name of the configuration template
+	ProductTypes []string `json:"productTypes,omitempty"` // The product types of the configuration template
+	TimeZone     string   `json:"timeZone,omitempty"`     // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
 }
-type ResponseOrganizationsUpdateOrganizationConfigTemplate interface{}
+type ResponseOrganizationsUpdateOrganizationConfigTemplate struct {
+	ID           string   `json:"id,omitempty"`           // The ID of the network or config template to copy configuration from
+	Name         string   `json:"name,omitempty"`         // The name of the configuration template
+	ProductTypes []string `json:"productTypes,omitempty"` // The product types of the configuration template
+	TimeZone     string   `json:"timeZone,omitempty"`     // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
+}
 type ResponseOrganizationsGetOrganizationConfigurationChanges []ResponseItemOrganizationsGetOrganizationConfigurationChanges // Array of ResponseOrganizationsGetOrganizationConfigurationChanges
 type ResponseItemOrganizationsGetOrganizationConfigurationChanges struct {
-	AdminEmail string `json:"adminEmail,omitempty"` //
-	AdminID    string `json:"adminId,omitempty"`    //
-	AdminName  string `json:"adminName,omitempty"`  //
-	Label      string `json:"label,omitempty"`      //
-	NewValue   string `json:"newValue,omitempty"`   //
-	OldValue   string `json:"oldValue,omitempty"`   //
-	Page       string `json:"page,omitempty"`       //
-	Ts         string `json:"ts,omitempty"`         //
+	AdminEmail  string `json:"adminEmail,omitempty"`  // The email address of the admin who made the configuration change. This attribute may be null.
+	AdminID     string `json:"adminId,omitempty"`     // The ID of the admin who made the configuration change. This attribute may be null.
+	AdminName   string `json:"adminName,omitempty"`   // The name of the admin who made the configuration change.
+	Label       string `json:"label,omitempty"`       // Description of the configuration change.
+	NetworkID   string `json:"networkId,omitempty"`   // The ID of the network that the configuration change was applied to. This attribute may be null.
+	NetworkName string `json:"networkName,omitempty"` // The name of the network that the configuration change was applied to. This attribute may be null.
+	NetworkURL  string `json:"networkUrl,omitempty"`  // The url of the network that the configuration change was applied to. This attribute may be null.
+	NewValue    string `json:"newValue,omitempty"`    // The value of the configuration, after the change was applied.
+	OldValue    string `json:"oldValue,omitempty"`    // The value of the configuration, before the change was applied.
+	Page        string `json:"page,omitempty"`        // The name of the Meraki Dashboard page on which the configuration change was made.
+	SSIDName    string `json:"ssidName,omitempty"`    // The name of the ssid that the configuration change was applied to, if applicable. This attribute may be null.
+	SSIDNumber  *int   `json:"ssidNumber,omitempty"`  // The ssid number that the configuration change was applied to, if applicable. This attribute may be null.
+	Ts          string `json:"ts,omitempty"`          // Time, in ISO8601 format, when the configuration change was made.
 }
 type ResponseOrganizationsGetOrganizationDevices []ResponseItemOrganizationsGetOrganizationDevices // Array of ResponseOrganizationsGetOrganizationDevices
 type ResponseItemOrganizationsGetOrganizationDevices struct {
-	Address     string   `json:"address,omitempty"`     // Physical address of the device
-	Firmware    string   `json:"firmware,omitempty"`    // Firmware version of the device
-	LanIP       string   `json:"lanIp,omitempty"`       // LAN IP address of the device
-	Lat         *float64 `json:"lat,omitempty"`         // Latitude of the device
-	Lng         *float64 `json:"lng,omitempty"`         // Longitude of the device
-	Mac         string   `json:"mac,omitempty"`         // MAC address of the device
-	Model       string   `json:"model,omitempty"`       // Model of the device
-	Name        string   `json:"name,omitempty"`        // Name of the device
-	NetworkID   string   `json:"networkId,omitempty"`   // ID of the network the device belongs to
-	Notes       string   `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
-	ProductType string   `json:"productType,omitempty"` // Product type of the device
-	Serial      string   `json:"serial,omitempty"`      // Serial number of the device
-	Tags        []string `json:"tags,omitempty"`        // List of tags assigned to the device
+	Address     string                                                    `json:"address,omitempty"`     // Physical address of the device
+	Details     *[]ResponseItemOrganizationsGetOrganizationDevicesDetails `json:"details,omitempty"`     // Additional device information
+	Firmware    string                                                    `json:"firmware,omitempty"`    // Firmware version of the device
+	Imei        string                                                    `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	LanIP       string                                                    `json:"lanIp,omitempty"`       // LAN IP address of the device
+	Lat         *float64                                                  `json:"lat,omitempty"`         // Latitude of the device
+	Lng         *float64                                                  `json:"lng,omitempty"`         // Longitude of the device
+	Mac         string                                                    `json:"mac,omitempty"`         // MAC address of the device
+	Model       string                                                    `json:"model,omitempty"`       // Model of the device
+	Name        string                                                    `json:"name,omitempty"`        // Name of the device
+	NetworkID   string                                                    `json:"networkId,omitempty"`   // ID of the network the device belongs to
+	Notes       string                                                    `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
+	ProductType string                                                    `json:"productType,omitempty"` // Product type of the device
+	Serial      string                                                    `json:"serial,omitempty"`      // Serial number of the device
+	Tags        []string                                                  `json:"tags,omitempty"`        // List of tags assigned to the device
+}
+type ResponseItemOrganizationsGetOrganizationDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseOrganizationsGetOrganizationDevicesAvailabilities []ResponseItemOrganizationsGetOrganizationDevicesAvailabilities // Array of ResponseOrganizationsGetOrganizationDevicesAvailabilities
 type ResponseItemOrganizationsGetOrganizationDevicesAvailabilities struct {
@@ -1148,6 +1274,49 @@ type ResponseItemOrganizationsGetOrganizationDevicesAvailabilities struct {
 }
 type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesNetwork struct {
 	ID string `json:"id,omitempty"` // ID for the network containing the device.
+}
+type ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory []ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory // Array of ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory struct {
+	Details *ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetails `json:"details,omitempty"` // Details about the status changes
+	Device  *ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDevice  `json:"device,omitempty"`  // Device information
+	Network *ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryNetwork `json:"network,omitempty"` // Network information
+	Ts      string                                                                             `json:"ts,omitempty"`      // Timestamp, in iso8601 format, at which the event happened
+}
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetails struct {
+	New *[]ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsNew `json:"new,omitempty"` // Details about the new status
+	Old *[]ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsOld `json:"old,omitempty"` // Details about the old status
+}
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsNew struct {
+	Name  string `json:"name,omitempty"`  // Name of the detail
+	Value string `json:"value,omitempty"` // Value of the detail
+}
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsOld struct {
+	Name  string `json:"name,omitempty"`  // Name of the detail
+	Value string `json:"value,omitempty"` // Value of the detail
+}
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryDevice struct {
+	Model       string `json:"model,omitempty"`       // Device model
+	Name        string `json:"name,omitempty"`        // Device name
+	ProductType string `json:"productType,omitempty"` // Device product type.
+	Serial      string `json:"serial,omitempty"`      // Device serial number
+}
+type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryNetwork struct {
+	ID   string   `json:"id,omitempty"`   // Network id
+	Name string   `json:"name,omitempty"` // Network name
+	Tags []string `json:"tags,omitempty"` // Network tags
+	URL  string   `json:"url,omitempty"`  // Network dashboard url
+}
+type ResponseOrganizationsGetOrganizationDevicesBootsHistory []ResponseItemOrganizationsGetOrganizationDevicesBootsHistory // Array of ResponseOrganizationsGetOrganizationDevicesBootsHistory
+type ResponseItemOrganizationsGetOrganizationDevicesBootsHistory struct {
+	Network *ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryNetwork `json:"network,omitempty"` // Device network
+	Serial  string                                                              `json:"serial,omitempty"`  // Device serial number
+	Start   *ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryStart   `json:"start,omitempty"`   // Device power up
+}
+type ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryNetwork struct {
+	ID string `json:"id,omitempty"` // API-formatted network ID
+}
+type ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryStart struct {
+	BootedAt string `json:"bootedAt,omitempty"` // Indicates when the device booted
 }
 type ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice []ResponseItemOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice // Array of ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice
 type ResponseItemOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice struct {
@@ -1181,26 +1350,38 @@ type ResponseItemOrganizationsGetOrganizationDevicesProvisioningStatuses struct 
 type ResponseItemOrganizationsGetOrganizationDevicesProvisioningStatusesNetwork struct {
 	ID string `json:"id,omitempty"` // ID for the network containing the device.
 }
-type ResponseOrganizationsGetOrganizationDevicesStatuses struct {
-	Components     *ResponseOrganizationsGetOrganizationDevicesStatusesComponents `json:"components,omitempty"`     // Components
-	Gateway        string                                                         `json:"gateway,omitempty"`        // IP Gateway
-	IPType         string                                                         `json:"ipType,omitempty"`         // IP Type
-	LanIP          string                                                         `json:"lanIp,omitempty"`          // LAN IP Address
-	LastReportedAt string                                                         `json:"lastReportedAt,omitempty"` // Device Last Reported Location
-	Mac            string                                                         `json:"mac,omitempty"`            // MAC Address
-	Model          string                                                         `json:"model,omitempty"`          // Model
-	Name           string                                                         `json:"name,omitempty"`           // Device Name
-	NetworkID      string                                                         `json:"networkId,omitempty"`      // Network ID
-	PrimaryDNS     string                                                         `json:"primaryDns,omitempty"`     // Primary DNS
-	ProductType    string                                                         `json:"productType,omitempty"`    // Product Type
-	PublicIP       string                                                         `json:"publicIp,omitempty"`       // Public IP Address
-	SecondaryDNS   string                                                         `json:"secondaryDns,omitempty"`   // Secondary DNS
-	Serial         string                                                         `json:"serial,omitempty"`         // Device Serial Number
-	Status         string                                                         `json:"status,omitempty"`         // Device Status
-	Tags           []string                                                       `json:"tags,omitempty"`           // Tags
+type ResponseOrganizationsGetOrganizationDevicesStatuses []ResponseItemOrganizationsGetOrganizationDevicesStatuses // Array of ResponseOrganizationsGetOrganizationDevicesStatuses
+type ResponseItemOrganizationsGetOrganizationDevicesStatuses struct {
+	Components     *ResponseItemOrganizationsGetOrganizationDevicesStatusesComponents `json:"components,omitempty"`     // Components
+	Gateway        string                                                             `json:"gateway,omitempty"`        // IP Gateway
+	IPType         string                                                             `json:"ipType,omitempty"`         // IP Type
+	LanIP          string                                                             `json:"lanIp,omitempty"`          // LAN IP Address
+	LastReportedAt string                                                             `json:"lastReportedAt,omitempty"` // Device Last Reported Location
+	Mac            string                                                             `json:"mac,omitempty"`            // MAC Address
+	Model          string                                                             `json:"model,omitempty"`          // Model
+	Name           string                                                             `json:"name,omitempty"`           // Device Name
+	NetworkID      string                                                             `json:"networkId,omitempty"`      // Network ID
+	PrimaryDNS     string                                                             `json:"primaryDns,omitempty"`     // Primary DNS
+	ProductType    string                                                             `json:"productType,omitempty"`    // Product Type
+	PublicIP       string                                                             `json:"publicIp,omitempty"`       // Public IP Address
+	SecondaryDNS   string                                                             `json:"secondaryDns,omitempty"`   // Secondary DNS
+	Serial         string                                                             `json:"serial,omitempty"`         // Device Serial Number
+	Status         string                                                             `json:"status,omitempty"`         // Device Status
+	Tags           []string                                                           `json:"tags,omitempty"`           // Tags
 }
-type ResponseOrganizationsGetOrganizationDevicesStatusesComponents struct {
-	PowerSupplies []string `json:"powerSupplies,omitempty"` // Power Supplies
+type ResponseItemOrganizationsGetOrganizationDevicesStatusesComponents struct {
+	PowerSupplies *[]ResponseItemOrganizationsGetOrganizationDevicesStatusesComponentsPowerSupplies `json:"powerSupplies,omitempty"` // Power Supplies
+}
+type ResponseItemOrganizationsGetOrganizationDevicesStatusesComponentsPowerSupplies struct {
+	Model  string                                                                             `json:"model,omitempty"`  // Model of the power supply
+	Poe    *ResponseItemOrganizationsGetOrganizationDevicesStatusesComponentsPowerSuppliesPoe `json:"poe,omitempty"`    // PoE info of the power supply
+	Serial string                                                                             `json:"serial,omitempty"` // Serial of the power supply
+	Slot   *int                                                                               `json:"slot,omitempty"`   // Slot the power supply is in
+	Status string                                                                             `json:"status,omitempty"` // Status of the power supply
+}
+type ResponseItemOrganizationsGetOrganizationDevicesStatusesComponentsPowerSuppliesPoe struct {
+	Maximum *int   `json:"maximum,omitempty"` // Maximum PoE this power supply can provide when connected to the current switch model
+	Unit    string `json:"unit,omitempty"`    // Unit of the PoE maximum
 }
 type ResponseOrganizationsGetOrganizationDevicesStatusesOverview struct {
 	Counts *ResponseOrganizationsGetOrganizationDevicesStatusesOverviewCounts `json:"counts,omitempty"` // counts
@@ -1268,44 +1449,52 @@ type ResponseItemOrganizationsGetOrganizationEarlyAccessFeaturesDescriptions str
 	Long  string `json:"long,omitempty"`  // Long description
 	Short string `json:"short,omitempty"` // Short description
 }
-type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIns []ResponseItemOrganizationsGetOrganizationEarlyAccessFeaturesOptIns // Array of ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIns
-type ResponseItemOrganizationsGetOrganizationEarlyAccessFeaturesOptIns struct {
-	CreatedAt            string                                                                                   `json:"createdAt,omitempty"`            //
-	ID                   string                                                                                   `json:"id,omitempty"`                   //
-	LimitScopeToNetworks *[]ResponseItemOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` //
-	ShortName            string                                                                                   `json:"shortName,omitempty"`            //
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIns struct {
+	CreatedAt            string                                                                               `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
+	ID                   string                                                                               `json:"id,omitempty"`                   // ID of Early Access Feature
+	LimitScopeToNetworks *[]ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	ShortName            string                                                                               `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
-type ResponseItemOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks struct {
+	ID   string `json:"id,omitempty"`   // ID of Network
+	Name string `json:"name,omitempty"` // Name of Network
 }
 type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptIn struct {
-	CreatedAt            string                                                                                 `json:"createdAt,omitempty"`            //
-	ID                   string                                                                                 `json:"id,omitempty"`                   //
-	LimitScopeToNetworks *[]ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` //
-	ShortName            string                                                                                 `json:"shortName,omitempty"`            //
+	CreatedAt            string                                                                                 `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
+	ID                   string                                                                                 `json:"id,omitempty"`                   // ID of Early Access Feature
+	LimitScopeToNetworks *[]ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	ShortName            string                                                                                 `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // ID of Network
+	Name string `json:"name,omitempty"` // Name of Network
 }
 type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIn struct {
-	CreatedAt            string                                                                              `json:"createdAt,omitempty"`            //
-	ID                   string                                                                              `json:"id,omitempty"`                   //
-	LimitScopeToNetworks *[]ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` //
-	ShortName            string                                                                              `json:"shortName,omitempty"`            //
+	CreatedAt            string                                                                              `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
+	ID                   string                                                                              `json:"id,omitempty"`                   // ID of Early Access Feature
+	LimitScopeToNetworks *[]ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	ShortName            string                                                                              `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // ID of Network
+	Name string `json:"name,omitempty"` // Name of Network
 }
-type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn interface{}
+type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn struct {
+	CreatedAt            string                                                                                 `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
+	ID                   string                                                                                 `json:"id,omitempty"`                   // ID of Early Access Feature
+	LimitScopeToNetworks *[]ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	ShortName            string                                                                                 `json:"shortName,omitempty"`            // Name of Early Access Feature
+}
+type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
+	ID   string `json:"id,omitempty"`   // ID of Network
+	Name string `json:"name,omitempty"` // Name of Network
+}
 type ResponseOrganizationsGetOrganizationFirmwareUpgrades []ResponseItemOrganizationsGetOrganizationFirmwareUpgrades // Array of ResponseOrganizationsGetOrganizationFirmwareUpgrades
 type ResponseItemOrganizationsGetOrganizationFirmwareUpgrades struct {
 	CompletedAt    string                                                               `json:"completedAt,omitempty"`    // Timestamp when upgrade completed. Null if status pending.
 	FromVersion    *ResponseItemOrganizationsGetOrganizationFirmwareUpgradesFromVersion `json:"fromVersion,omitempty"`    // ID of the upgrade's starting version
 	Network        *ResponseItemOrganizationsGetOrganizationFirmwareUpgradesNetwork     `json:"network,omitempty"`        // Network of the upgrade
-	ProductType    string                                                               `json:"productType,omitempty"`    // product upgraded [wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor]
+	ProductTypes   string                                                               `json:"productTypes,omitempty"`   // product upgraded [wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor]
 	Status         string                                                               `json:"status,omitempty"`         // Status of upgrade event: [Cancelled, Completed]
 	Time           string                                                               `json:"time,omitempty"`           // Scheduled start time
 	ToVersion      *ResponseItemOrganizationsGetOrganizationFirmwareUpgradesToVersion   `json:"toVersion,omitempty"`      // ID of the upgrade's target version
@@ -1313,6 +1502,7 @@ type ResponseItemOrganizationsGetOrganizationFirmwareUpgrades struct {
 	UpgradeID      string                                                               `json:"upgradeId,omitempty"`      // The upgrade
 }
 type ResponseItemOrganizationsGetOrganizationFirmwareUpgradesFromVersion struct {
+	Firmware    string `json:"firmware,omitempty"`    // Firmware name
 	ID          string `json:"id,omitempty"`          // Firmware version ID
 	ReleaseDate string `json:"releaseDate,omitempty"` // Release date of the firmware version
 	ReleaseType string `json:"releaseType,omitempty"` // Release type of the firmware version
@@ -1323,6 +1513,7 @@ type ResponseItemOrganizationsGetOrganizationFirmwareUpgradesNetwork struct {
 	Name string `json:"name,omitempty"` // The network
 }
 type ResponseItemOrganizationsGetOrganizationFirmwareUpgradesToVersion struct {
+	Firmware    string `json:"firmware,omitempty"`    // Firmware name
 	ID          string `json:"id,omitempty"`          // Firmware version ID
 	ReleaseDate string `json:"releaseDate,omitempty"` // Release date of the firmware version
 	ReleaseType string `json:"releaseType,omitempty"` // Release type of the firmware version
@@ -1362,31 +1553,109 @@ type ResponseItemOrganizationsGetOrganizationFirmwareUpgradesByDeviceUpgradeToVe
 	ReleaseType string `json:"releaseType,omitempty"` // Release type of the firmware version
 	ShortName   string `json:"shortName,omitempty"`   // Firmware version short name
 }
-type ResponseOrganizationsClaimIntoOrganizationInventory interface{}
+type ResponseOrganizationsClaimIntoOrganizationInventory struct {
+	Licenses *[]ResponseOrganizationsClaimIntoOrganizationInventoryLicenses `json:"licenses,omitempty"` // The licenses claimed
+	Orders   []string                                                       `json:"orders,omitempty"`   // The numbers of the orders claimed
+	Serials  []string                                                       `json:"serials,omitempty"`  // The serials of the devices claimed
+}
+type ResponseOrganizationsClaimIntoOrganizationInventoryLicenses struct {
+	Key  string `json:"key,omitempty"`  // The key of the license
+	Mode string `json:"mode,omitempty"` // The mode of the license
+}
 type ResponseOrganizationsGetOrganizationInventoryDevices []ResponseItemOrganizationsGetOrganizationInventoryDevices // Array of ResponseOrganizationsGetOrganizationInventoryDevices
 type ResponseItemOrganizationsGetOrganizationInventoryDevices struct {
-	ClaimedAt             string   `json:"claimedAt,omitempty"`             // Claimed time of the device
-	LicenseExpirationDate string   `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
-	Mac                   string   `json:"mac,omitempty"`                   // MAC address of the device
-	Model                 string   `json:"model,omitempty"`                 // Model type of the device
-	Name                  string   `json:"name,omitempty"`                  // Name of the device
-	NetworkID             string   `json:"networkId,omitempty"`             // Network Id of the device
-	OrderNumber           string   `json:"orderNumber,omitempty"`           // Order number of the device
-	ProductType           string   `json:"productType,omitempty"`           // Product type of the device
-	Serial                string   `json:"serial,omitempty"`                // Serial number of the device
-	Tags                  []string `json:"tags,omitempty"`                  // Device tags
+	ClaimedAt             string                                                             `json:"claimedAt,omitempty"`             // Claimed time of the device
+	CountryCode           string                                                             `json:"countryCode,omitempty"`           // Country/region code from device, network, or store order
+	Details               *[]ResponseItemOrganizationsGetOrganizationInventoryDevicesDetails `json:"details,omitempty"`               // Additional device information
+	LicenseExpirationDate string                                                             `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
+	Mac                   string                                                             `json:"mac,omitempty"`                   // MAC address of the device
+	Model                 string                                                             `json:"model,omitempty"`                 // Model type of the device
+	Name                  string                                                             `json:"name,omitempty"`                  // Name of the device
+	NetworkID             string                                                             `json:"networkId,omitempty"`             // Network Id of the device
+	OrderNumber           string                                                             `json:"orderNumber,omitempty"`           // Order number of the device
+	ProductType           string                                                             `json:"productType,omitempty"`           // Product type of the device
+	Serial                string                                                             `json:"serial,omitempty"`                // Serial number of the device
+	Tags                  []string                                                           `json:"tags,omitempty"`                  // Device tags
+}
+type ResponseItemOrganizationsGetOrganizationInventoryDevicesDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulk struct {
+	JobID string                                                                   `json:"jobId,omitempty"` // The ID of the job that was used to create all of the device swaps.
+	Swaps *[]ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // An array of recent swap requests and their statuses.
+}
+type ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                                        `json:"afterAction,omitempty"` // An action to perform on the devices.old object after swap is complete.
+	CompletedAt string                                                                        `json:"completedAt,omitempty"` // An iso8601 timestamp for when the swap completed or failed.
+	CreatedAt   string                                                                        `json:"createdAt,omitempty"`   // An iso8601 timestamp for the creation of the swap request.
+	Devices     *ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap
+	Errors      []string                                                                      `json:"errors,omitempty"`      // A list of error messages for why a swap failed.
+	ID          string                                                                        `json:"id,omitempty"`          // Swap Request ID
+	Status      string                                                                        `json:"status,omitempty"`      // The current status of the swap job.
+}
+type ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New *ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew `json:"new,omitempty"` // The device that will have settings cloned to
+	Old *ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld `json:"old,omitempty"` // The device that will be cloned
+}
+type ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulk struct {
+	JobID string                                                                `json:"jobId,omitempty"` // The ID of the job that was used to create all of the device swaps.
+	Swaps *[]ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // An array of recent swap requests and their statuses.
+}
+type ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                                     `json:"afterAction,omitempty"` // An action to perform on the devices.old object after swap is complete.
+	CompletedAt string                                                                     `json:"completedAt,omitempty"` // An iso8601 timestamp for when the swap completed or failed.
+	CreatedAt   string                                                                     `json:"createdAt,omitempty"`   // An iso8601 timestamp for the creation of the swap request.
+	Devices     *ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap
+	Errors      []string                                                                   `json:"errors,omitempty"`      // A list of error messages for why a swap failed.
+	ID          string                                                                     `json:"id,omitempty"`          // Swap Request ID
+	Status      string                                                                     `json:"status,omitempty"`      // The current status of the swap job.
+}
+type ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New *ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew `json:"new,omitempty"` // The device that will have settings cloned to
+	Old *ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld `json:"old,omitempty"` // The device that will be cloned
+}
+type ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
 }
 type ResponseOrganizationsGetOrganizationInventoryDevice struct {
-	ClaimedAt             string   `json:"claimedAt,omitempty"`             // Claimed time of the device
-	LicenseExpirationDate string   `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
-	Mac                   string   `json:"mac,omitempty"`                   // MAC address of the device
-	Model                 string   `json:"model,omitempty"`                 // Model type of the device
-	Name                  string   `json:"name,omitempty"`                  // Name of the device
-	NetworkID             string   `json:"networkId,omitempty"`             // Network Id of the device
-	OrderNumber           string   `json:"orderNumber,omitempty"`           // Order number of the device
-	ProductType           string   `json:"productType,omitempty"`           // Product type of the device
-	Serial                string   `json:"serial,omitempty"`                // Serial number of the device
-	Tags                  []string `json:"tags,omitempty"`                  // Device tags
+	ClaimedAt             string                                                        `json:"claimedAt,omitempty"`             // Claimed time of the device
+	CountryCode           string                                                        `json:"countryCode,omitempty"`           // Country/region code from device, network, or store order
+	Details               *[]ResponseOrganizationsGetOrganizationInventoryDeviceDetails `json:"details,omitempty"`               // Additional device information
+	LicenseExpirationDate string                                                        `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
+	Mac                   string                                                        `json:"mac,omitempty"`                   // MAC address of the device
+	Model                 string                                                        `json:"model,omitempty"`                 // Model type of the device
+	Name                  string                                                        `json:"name,omitempty"`                  // Name of the device
+	NetworkID             string                                                        `json:"networkId,omitempty"`             // Network Id of the device
+	OrderNumber           string                                                        `json:"orderNumber,omitempty"`           // Order number of the device
+	ProductType           string                                                        `json:"productType,omitempty"`           // Product type of the device
+	Serial                string                                                        `json:"serial,omitempty"`                // Serial number of the device
+	Tags                  []string                                                      `json:"tags,omitempty"`                  // Device tags
+}
+type ResponseOrganizationsGetOrganizationInventoryDeviceDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringExportEvent interface{}
 type ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringImports []ResponseItemOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringImports // Array of ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringImports
@@ -1450,7 +1719,9 @@ type ResponseItemOrganizationsCreateOrganizationInventoryOnboardingCloudMonitori
 type ResponseItemOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareConfigParamsUserSecret struct {
 	Hash string `json:"hash,omitempty"` // The hashed secret
 }
-type ResponseOrganizationsReleaseFromOrganizationInventory interface{}
+type ResponseOrganizationsReleaseFromOrganizationInventory struct {
+	Serials []string `json:"serials,omitempty"` // Serials of the devices that were released
+}
 type ResponseOrganizationsGetOrganizationLicenses []ResponseItemOrganizationsGetOrganizationLicenses // Array of ResponseOrganizationsGetOrganizationLicenses
 type ResponseItemOrganizationsGetOrganizationLicenses struct {
 	ActivationDate            string                                                                       `json:"activationDate,omitempty"`            // The date the license started burning
@@ -1466,7 +1737,7 @@ type ResponseItemOrganizationsGetOrganizationLicenses struct {
 	OrderNumber               string                                                                       `json:"orderNumber,omitempty"`               // Order number
 	PermanentlyQueuedLicenses *[]ResponseItemOrganizationsGetOrganizationLicensesPermanentlyQueuedLicenses `json:"permanentlyQueuedLicenses,omitempty"` // DEPRECATED List of permanently queued licenses attached to the license. Instead, use /organizations/{organizationId}/licenses?deviceSerial= to retrieved queued licenses for a given device.
 	SeatCount                 *int                                                                         `json:"seatCount,omitempty"`                 // The number of seats of the license. Only applicable to SM licenses.
-	State                     string                                                                       `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of *recentlyQueued*.
+	State                     string                                                                       `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of `recentlyQueued`.
 	TotalDurationInDays       *int                                                                         `json:"totalDurationInDays,omitempty"`       // The duration of the license plus all permanently queued licenses associated with it
 }
 type ResponseItemOrganizationsGetOrganizationLicensesPermanentlyQueuedLicenses struct {
@@ -1493,7 +1764,7 @@ type ResponseOrganizationsAssignOrganizationLicensesSeatsResultingLicenses struc
 	OrderNumber               string                                                                                            `json:"orderNumber,omitempty"`               // Order number
 	PermanentlyQueuedLicenses *[]ResponseOrganizationsAssignOrganizationLicensesSeatsResultingLicensesPermanentlyQueuedLicenses `json:"permanentlyQueuedLicenses,omitempty"` // DEPRECATED List of permanently queued licenses attached to the license. Instead, use /organizations/{organizationId}/licenses?deviceSerial= to retrieved queued licenses for a given device.
 	SeatCount                 *int                                                                                              `json:"seatCount,omitempty"`                 // The number of seats of the license. Only applicable to SM licenses.
-	State                     string                                                                                            `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of *recentlyQueued*.
+	State                     string                                                                                            `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of `recentlyQueued`.
 	TotalDurationInDays       *int                                                                                              `json:"totalDurationInDays,omitempty"`       // The duration of the license plus all permanently queued licenses associated with it
 }
 type ResponseOrganizationsAssignOrganizationLicensesSeatsResultingLicensesPermanentlyQueuedLicenses struct {
@@ -1513,12 +1784,76 @@ type ResponseOrganizationsMoveOrganizationLicensesSeats struct {
 	SeatCount          *int   `json:"seatCount,omitempty"`          // The number of seats to move to the new organization. Must be less than or equal to the total number of seats of the license
 }
 type ResponseOrganizationsGetOrganizationLicensesOverview struct {
-	ExpirationDate       string                                                                    `json:"expirationDate,omitempty"`       //
-	LicensedDeviceCounts *ResponseOrganizationsGetOrganizationLicensesOverviewLicensedDeviceCounts `json:"licensedDeviceCounts,omitempty"` //
-	Status               string                                                                    `json:"status,omitempty"`               //
+	ExpirationDate       string                                                                    `json:"expirationDate,omitempty"`       // License expiration date (Co-termination licensing only)
+	LicenseCount         *int                                                                      `json:"licenseCount,omitempty"`         // Total number of licenses (Per-device licensing only)
+	LicenseTypes         *[]ResponseOrganizationsGetOrganizationLicensesOverviewLicenseTypes       `json:"licenseTypes,omitempty"`         // Data by license type (Per-device licensing only)
+	LicensedDeviceCounts *ResponseOrganizationsGetOrganizationLicensesOverviewLicensedDeviceCounts `json:"licensedDeviceCounts,omitempty"` // License counts (Co-termination licensing only)
+	States               *ResponseOrganizationsGetOrganizationLicensesOverviewStates               `json:"states,omitempty"`               // Aggregated data for licenses by state (Per-device licensing only)
+	Status               string                                                                    `json:"status,omitempty"`               // License status (Co-termination licensing only)
+	SystemsManager       *ResponseOrganizationsGetOrganizationLicensesOverviewSystemsManager       `json:"systemsManager,omitempty"`       // Aggregated data for Systems Manager licenses (Per-device licensing only)
 }
-type ResponseOrganizationsGetOrganizationLicensesOverviewLicensedDeviceCounts struct {
-	MS *int `json:"MS,omitempty"` //
+type ResponseOrganizationsGetOrganizationLicensesOverviewLicenseTypes struct {
+	Counts      *ResponseOrganizationsGetOrganizationLicensesOverviewLicenseTypesCounts `json:"counts,omitempty"`      // Aggregated count data for the license type
+	LicenseType string                                                                  `json:"licenseType,omitempty"` // License type
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewLicenseTypesCounts struct {
+	Unassigned *int `json:"unassigned,omitempty"` // The number of unassigned licenses
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewLicensedDeviceCounts interface{}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStates struct {
+	Active         *ResponseOrganizationsGetOrganizationLicensesOverviewStatesActive         `json:"active,omitempty"`         // Data for active licenses
+	Expired        *ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpired        `json:"expired,omitempty"`        // Data for expired licenses
+	Expiring       *ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiring       `json:"expiring,omitempty"`       // Data for expiring licenses
+	RecentlyQueued *ResponseOrganizationsGetOrganizationLicensesOverviewStatesRecentlyQueued `json:"recentlyQueued,omitempty"` // Data for recently queued licenses
+	Unused         *ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnused         `json:"unused,omitempty"`         // Data for unused licenses
+	UnusedActive   *ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedActive   `json:"unusedActive,omitempty"`   // Data for unused, active licenses
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesActive struct {
+	Count *int `json:"count,omitempty"` // The number of active licenses
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpired struct {
+	Count *int `json:"count,omitempty"` // The number of expired licenses
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiring struct {
+	Count    *int                                                                        `json:"count,omitempty"`    // The number of expiring licenses
+	Critical *ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiringCritical `json:"critical,omitempty"` // Data for the critical threshold
+	Warning  *ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiringWarning  `json:"warning,omitempty"`  // Data for the warning threshold
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiringCritical struct {
+	ExpiringCount   *int `json:"expiringCount,omitempty"`   // The number of licenses that will expire in this window
+	ThresholdInDays *int `json:"thresholdInDays,omitempty"` // The number of days from now denoting the critical threshold for an expiring license
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesExpiringWarning struct {
+	ExpiringCount   *int `json:"expiringCount,omitempty"`   // The number of licenses that will expire in this window
+	ThresholdInDays *int `json:"thresholdInDays,omitempty"` // The number of days from now denoting the warning threshold for an expiring license
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesRecentlyQueued struct {
+	Count *int `json:"count,omitempty"` // The number of recently queued licenses
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnused struct {
+	Count             *int                                                                               `json:"count,omitempty"`             // The number of unused licenses
+	SoonestActivation *ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedSoonestActivation `json:"soonestActivation,omitempty"` // Information about the soonest forthcoming license activation
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedSoonestActivation struct {
+	ActivationDate  string `json:"activationDate,omitempty"`  // The soonest license activation date
+	ToActivateCount *int   `json:"toActivateCount,omitempty"` // The number of licenses that will activate on this date
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedActive struct {
+	Count            *int                                                                                    `json:"count,omitempty"`            // The number of unused, active licenses
+	OldestActivation *ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedActiveOldestActivation `json:"oldestActivation,omitempty"` // Information about the oldest historical license activation
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewStatesUnusedActiveOldestActivation struct {
+	ActivationDate string `json:"activationDate,omitempty"` // The oldest license activation date
+	ActiveCount    *int   `json:"activeCount,omitempty"`    // The number of licenses that activated on this date
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewSystemsManager struct {
+	Counts *ResponseOrganizationsGetOrganizationLicensesOverviewSystemsManagerCounts `json:"counts,omitempty"` // Aggregated license count data for Systems Manager
+}
+type ResponseOrganizationsGetOrganizationLicensesOverviewSystemsManagerCounts struct {
+	ActiveSeats            *int `json:"activeSeats,omitempty"`            // The number of Systems Manager seats in use
+	OrgwideEnrolledDevices *int `json:"orgwideEnrolledDevices,omitempty"` // The total number of enrolled Systems Manager devices
+	TotalSeats             *int `json:"totalSeats,omitempty"`             // The total number of Systems Manager seats
+	UnassignedSeats        *int `json:"unassignedSeats,omitempty"`        // The number of unused Systems Manager seats
 }
 type ResponseOrganizationsRenewOrganizationLicensesSeats struct {
 	ResultingLicenses *[]ResponseOrganizationsRenewOrganizationLicensesSeatsResultingLicenses `json:"resultingLicenses,omitempty"` // Resulting licenses from the move
@@ -1537,7 +1872,7 @@ type ResponseOrganizationsRenewOrganizationLicensesSeatsResultingLicenses struct
 	OrderNumber               string                                                                                           `json:"orderNumber,omitempty"`               // Order number
 	PermanentlyQueuedLicenses *[]ResponseOrganizationsRenewOrganizationLicensesSeatsResultingLicensesPermanentlyQueuedLicenses `json:"permanentlyQueuedLicenses,omitempty"` // DEPRECATED List of permanently queued licenses attached to the license. Instead, use /organizations/{organizationId}/licenses?deviceSerial= to retrieved queued licenses for a given device.
 	SeatCount                 *int                                                                                             `json:"seatCount,omitempty"`                 // The number of seats of the license. Only applicable to SM licenses.
-	State                     string                                                                                           `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of *recentlyQueued*.
+	State                     string                                                                                           `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of `recentlyQueued`.
 	TotalDurationInDays       *int                                                                                             `json:"totalDurationInDays,omitempty"`       // The duration of the license plus all permanently queued licenses associated with it
 }
 type ResponseOrganizationsRenewOrganizationLicensesSeatsResultingLicensesPermanentlyQueuedLicenses struct {
@@ -1561,7 +1896,7 @@ type ResponseOrganizationsGetOrganizationLicense struct {
 	OrderNumber               string                                                                  `json:"orderNumber,omitempty"`               // Order number
 	PermanentlyQueuedLicenses *[]ResponseOrganizationsGetOrganizationLicensePermanentlyQueuedLicenses `json:"permanentlyQueuedLicenses,omitempty"` // DEPRECATED List of permanently queued licenses attached to the license. Instead, use /organizations/{organizationId}/licenses?deviceSerial= to retrieved queued licenses for a given device.
 	SeatCount                 *int                                                                    `json:"seatCount,omitempty"`                 // The number of seats of the license. Only applicable to SM licenses.
-	State                     string                                                                  `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of *recentlyQueued*.
+	State                     string                                                                  `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of `recentlyQueued`.
 	TotalDurationInDays       *int                                                                    `json:"totalDurationInDays,omitempty"`       // The duration of the license plus all permanently queued licenses associated with it
 }
 type ResponseOrganizationsGetOrganizationLicensePermanentlyQueuedLicenses struct {
@@ -1585,7 +1920,7 @@ type ResponseOrganizationsUpdateOrganizationLicense struct {
 	OrderNumber               string                                                                     `json:"orderNumber,omitempty"`               // Order number
 	PermanentlyQueuedLicenses *[]ResponseOrganizationsUpdateOrganizationLicensePermanentlyQueuedLicenses `json:"permanentlyQueuedLicenses,omitempty"` // DEPRECATED List of permanently queued licenses attached to the license. Instead, use /organizations/{organizationId}/licenses?deviceSerial= to retrieved queued licenses for a given device.
 	SeatCount                 *int                                                                       `json:"seatCount,omitempty"`                 // The number of seats of the license. Only applicable to SM licenses.
-	State                     string                                                                     `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of *recentlyQueued*.
+	State                     string                                                                     `json:"state,omitempty"`                     // The state of the license. All queued licenses have a status of `recentlyQueued`.
 	TotalDurationInDays       *int                                                                       `json:"totalDurationInDays,omitempty"`       // The duration of the license plus all permanently queued licenses associated with it
 }
 type ResponseOrganizationsUpdateOrganizationLicensePermanentlyQueuedLicenses struct {
@@ -1716,50 +2051,85 @@ type ResponseOrganizationsGetOrganizationOpenapiSpecPathsOrganizationsGetRespons
 }
 type ResponseOrganizationsGetOrganizationPolicyObjects []ResponseItemOrganizationsGetOrganizationPolicyObjects // Array of ResponseOrganizationsGetOrganizationPolicyObjects
 type ResponseItemOrganizationsGetOrganizationPolicyObjects struct {
-	Category   string   `json:"category,omitempty"`   //
-	Cidr       string   `json:"cidr,omitempty"`       //
-	CreatedAt  string   `json:"created_at,omitempty"` //
-	GroupIDs   []string `json:"groupIds,omitempty"`   //
-	ID         string   `json:"id,omitempty"`         //
-	Name       string   `json:"name,omitempty"`       //
-	NetworkIDs []string `json:"networkIds,omitempty"` //
-	Type       string   `json:"type,omitempty"`       //
-	UpdatedAt  string   `json:"updated_at,omitempty"` //
+	Category   string   `json:"category,omitempty"`   // Category of a policy object (one of: adaptivePolicy, network)
+	Cidr       string   `json:"cidr,omitempty"`       // CIDR Value of a policy object
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	GroupIDs   []string `json:"groupIds,omitempty"`   // The IDs of policy object groups the policy object belongs to.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of policy object (alphanumeric, space, dash, or underscore characters only).
+	NetworkIDs []string `json:"networkIds,omitempty"` // The IDs of the networks that use the policy object.
+	Type       string   `json:"type,omitempty"`       // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
-type ResponseOrganizationsCreateOrganizationPolicyObject interface{}
-type ResponseOrganizationsGetOrganizationPolicyObjectsGroups []ResponseItemOrganizationsGetOrganizationPolicyObjectsGroups // Array of ResponseOrganizationsGetOrganizationPolicyObjectsGroups
-type ResponseItemOrganizationsGetOrganizationPolicyObjectsGroups struct {
-	Category   string   `json:"category,omitempty"`   //
-	CreatedAt  string   `json:"created_at,omitempty"` //
-	ID         string   `json:"id,omitempty"`         //
-	Name       string   `json:"name,omitempty"`       //
-	NetworkIDs []string `json:"networkIds,omitempty"` //
-	ObjectIDs  []string `json:"objectIds,omitempty"`  //
-	UpdatedAt  string   `json:"updated_at,omitempty"` //
+type ResponseOrganizationsCreateOrganizationPolicyObject struct {
+	Category   string   `json:"category,omitempty"`   // Category of a policy object (one of: adaptivePolicy, network)
+	Cidr       string   `json:"cidr,omitempty"`       // CIDR Value of a policy object
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	GroupIDs   []string `json:"groupIds,omitempty"`   // The IDs of policy object groups the policy object belongs to.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of policy object (alphanumeric, space, dash, or underscore characters only).
+	NetworkIDs []string `json:"networkIds,omitempty"` // The IDs of the networks that use the policy object.
+	Type       string   `json:"type,omitempty"`       // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
-type ResponseOrganizationsCreateOrganizationPolicyObjectsGroup interface{}
+type ResponseOrganizationsGetOrganizationPolicyObjectsGroups struct {
+	Category   string   `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of the Policy object group.
+	NetworkIDs []string `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
+	ObjectIDs  *[]int   `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
+}
+type ResponseOrganizationsCreateOrganizationPolicyObjectsGroup struct {
+	Category   string   `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of the Policy object group.
+	NetworkIDs []string `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
+	ObjectIDs  *[]int   `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
+}
 type ResponseOrganizationsGetOrganizationPolicyObjectsGroup struct {
-	Category   string   `json:"category,omitempty"`   //
-	CreatedAt  string   `json:"created_at,omitempty"` //
-	ID         string   `json:"id,omitempty"`         //
-	Name       string   `json:"name,omitempty"`       //
-	NetworkIDs []string `json:"networkIds,omitempty"` //
-	ObjectIDs  []string `json:"objectIds,omitempty"`  //
-	UpdatedAt  string   `json:"updated_at,omitempty"` //
+	Category   string   `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of the Policy object group.
+	NetworkIDs []string `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
+	ObjectIDs  *[]int   `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
-type ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup interface{}
+type ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup struct {
+	Category   string   `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of the Policy object group.
+	NetworkIDs []string `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
+	ObjectIDs  *[]int   `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
+}
 type ResponseOrganizationsGetOrganizationPolicyObject struct {
-	Category   string   `json:"category,omitempty"`   //
-	Cidr       string   `json:"cidr,omitempty"`       //
-	CreatedAt  string   `json:"created_at,omitempty"` //
-	GroupIDs   []string `json:"groupIds,omitempty"`   //
-	ID         string   `json:"id,omitempty"`         //
-	Name       string   `json:"name,omitempty"`       //
-	NetworkIDs []string `json:"networkIds,omitempty"` //
-	Type       string   `json:"type,omitempty"`       //
-	UpdatedAt  string   `json:"updated_at,omitempty"` //
+	Category   string   `json:"category,omitempty"`   // Category of a policy object (one of: adaptivePolicy, network)
+	Cidr       string   `json:"cidr,omitempty"`       // CIDR Value of a policy object
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	GroupIDs   []string `json:"groupIds,omitempty"`   // The IDs of policy object groups the policy object belongs to.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of policy object (alphanumeric, space, dash, or underscore characters only).
+	NetworkIDs []string `json:"networkIds,omitempty"` // The IDs of the networks that use the policy object.
+	Type       string   `json:"type,omitempty"`       // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
-type ResponseOrganizationsUpdateOrganizationPolicyObject interface{}
+type ResponseOrganizationsUpdateOrganizationPolicyObject struct {
+	Category   string   `json:"category,omitempty"`   // Category of a policy object (one of: adaptivePolicy, network)
+	Cidr       string   `json:"cidr,omitempty"`       // CIDR Value of a policy object
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	GroupIDs   []string `json:"groupIds,omitempty"`   // The IDs of policy object groups the policy object belongs to.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of policy object (alphanumeric, space, dash, or underscore characters only).
+	NetworkIDs []string `json:"networkIds,omitempty"` // The IDs of the networks that use the policy object.
+	Type       string   `json:"type,omitempty"`       // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
+}
 type ResponseOrganizationsGetOrganizationSaml struct {
 	Enabled *bool `json:"enabled,omitempty"` // Toggle depicting if SAML SSO settings are enabled
 }
@@ -1795,42 +2165,76 @@ type ResponseItemOrganizationsUpdateOrganizationSamlIDp struct {
 }
 type ResponseOrganizationsGetOrganizationSamlRoles []ResponseItemOrganizationsGetOrganizationSamlRoles // Array of ResponseOrganizationsGetOrganizationSamlRoles
 type ResponseItemOrganizationsGetOrganizationSamlRoles struct {
-	ID        string                                                       `json:"id,omitempty"`        //
-	Networks  *[]ResponseItemOrganizationsGetOrganizationSamlRolesNetworks `json:"networks,omitempty"`  //
-	OrgAccess string                                                       `json:"orgAccess,omitempty"` //
-	Role      string                                                       `json:"role,omitempty"`      //
-	Tags      *[]ResponseItemOrganizationsGetOrganizationSamlRolesTags     `json:"tags,omitempty"`      //
+	Camera    *[]ResponseItemOrganizationsGetOrganizationSamlRolesCamera   `json:"camera,omitempty"`    // The list of camera access privileges for SAML administrator
+	ID        string                                                       `json:"id,omitempty"`        // ID associated with the SAML role
+	Networks  *[]ResponseItemOrganizationsGetOrganizationSamlRolesNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
+	OrgAccess string                                                       `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization
+	Role      string                                                       `json:"role,omitempty"`      // The role of the SAML administrator
+	Tags      *[]ResponseItemOrganizationsGetOrganizationSamlRolesTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+}
+type ResponseItemOrganizationsGetOrganizationSamlRolesCamera struct {
+	Access  string `json:"access,omitempty"`  // Camera access ability
+	OrgWide *bool  `json:"orgWide,omitempty"` // Whether or not SAML administrator has org-wide access
 }
 type ResponseItemOrganizationsGetOrganizationSamlRolesNetworks struct {
-	Access string `json:"access,omitempty"` //
-	ID     string `json:"id,omitempty"`     //
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network
+	ID     string `json:"id,omitempty"`     // The network ID
 }
 type ResponseItemOrganizationsGetOrganizationSamlRolesTags struct {
-	Access string `json:"access,omitempty"` //
-	Tag    string `json:"tag,omitempty"`    //
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the tag
+	Tag    string `json:"tag,omitempty"`    // The name of the tag
 }
-type ResponseOrganizationsCreateOrganizationSamlRole interface{}
+type ResponseOrganizationsCreateOrganizationSamlRole struct {
+	Camera    *[]ResponseOrganizationsCreateOrganizationSamlRoleCamera   `json:"camera,omitempty"`    // The list of camera access privileges for SAML administrator
+	ID        string                                                     `json:"id,omitempty"`        // ID associated with the SAML role
+	Networks  *[]ResponseOrganizationsCreateOrganizationSamlRoleNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
+	OrgAccess string                                                     `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization
+	Role      string                                                     `json:"role,omitempty"`      // The role of the SAML administrator
+	Tags      *[]ResponseOrganizationsCreateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+}
+type ResponseOrganizationsCreateOrganizationSamlRoleCamera struct {
+	Access  string `json:"access,omitempty"`  // Camera access ability
+	OrgWide *bool  `json:"orgWide,omitempty"` // Whether or not SAML administrator has org-wide access
+}
+type ResponseOrganizationsCreateOrganizationSamlRoleNetworks struct {
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network
+	ID     string `json:"id,omitempty"`     // The network ID
+}
+type ResponseOrganizationsCreateOrganizationSamlRoleTags struct {
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the tag
+	Tag    string `json:"tag,omitempty"`    // The name of the tag
+}
 type ResponseOrganizationsGetOrganizationSamlRole struct {
-	ID        string                                                  `json:"id,omitempty"`        //
-	Networks  *[]ResponseOrganizationsGetOrganizationSamlRoleNetworks `json:"networks,omitempty"`  //
-	OrgAccess string                                                  `json:"orgAccess,omitempty"` //
-	Role      string                                                  `json:"role,omitempty"`      //
-	Tags      *[]ResponseOrganizationsGetOrganizationSamlRoleTags     `json:"tags,omitempty"`      //
+	Camera    *[]ResponseOrganizationsGetOrganizationSamlRoleCamera   `json:"camera,omitempty"`    // The list of camera access privileges for SAML administrator
+	ID        string                                                  `json:"id,omitempty"`        // ID associated with the SAML role
+	Networks  *[]ResponseOrganizationsGetOrganizationSamlRoleNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
+	OrgAccess string                                                  `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization
+	Role      string                                                  `json:"role,omitempty"`      // The role of the SAML administrator
+	Tags      *[]ResponseOrganizationsGetOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+}
+type ResponseOrganizationsGetOrganizationSamlRoleCamera struct {
+	Access  string `json:"access,omitempty"`  // Camera access ability
+	OrgWide *bool  `json:"orgWide,omitempty"` // Whether or not SAML administrator has org-wide access
 }
 type ResponseOrganizationsGetOrganizationSamlRoleNetworks struct {
-	Access string `json:"access,omitempty"` //
-	ID     string `json:"id,omitempty"`     //
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network
+	ID     string `json:"id,omitempty"`     // The network ID
 }
 type ResponseOrganizationsGetOrganizationSamlRoleTags struct {
-	Access string `json:"access,omitempty"` //
-	Tag    string `json:"tag,omitempty"`    //
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the tag
+	Tag    string `json:"tag,omitempty"`    // The name of the tag
 }
 type ResponseOrganizationsUpdateOrganizationSamlRole struct {
+	Camera    *[]ResponseOrganizationsUpdateOrganizationSamlRoleCamera   `json:"camera,omitempty"`    // The list of camera access privileges for SAML administrator
 	ID        string                                                     `json:"id,omitempty"`        // ID associated with the SAML role
 	Networks  *[]ResponseOrganizationsUpdateOrganizationSamlRoleNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
 	OrgAccess string                                                     `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization
 	Role      string                                                     `json:"role,omitempty"`      // The role of the SAML administrator
 	Tags      *[]ResponseOrganizationsUpdateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+}
+type ResponseOrganizationsUpdateOrganizationSamlRoleCamera struct {
+	Access  string `json:"access,omitempty"`  // Camera access ability
+	OrgWide *bool  `json:"orgWide,omitempty"` // Whether or not SAML administrator has org-wide access
 }
 type ResponseOrganizationsUpdateOrganizationSamlRoleNetworks struct {
 	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network
@@ -1841,15 +2245,27 @@ type ResponseOrganizationsUpdateOrganizationSamlRoleTags struct {
 	Tag    string `json:"tag,omitempty"`    // The name of the tag
 }
 type ResponseOrganizationsGetOrganizationSNMP struct {
-	Hostname   string   `json:"hostname,omitempty"`   //
-	PeerIPs    []string `json:"peerIps,omitempty"`    //
-	Port       *int     `json:"port,omitempty"`       //
-	V2CEnabled *bool    `json:"v2cEnabled,omitempty"` //
-	V3AuthMode string   `json:"v3AuthMode,omitempty"` //
-	V3Enabled  *bool    `json:"v3Enabled,omitempty"`  //
-	V3PrivMode string   `json:"v3PrivMode,omitempty"` //
+	Hostname          string   `json:"hostname,omitempty"`          // The hostname of the SNMP server.
+	PeerIPs           []string `json:"peerIps,omitempty"`           // The list of IPv4 addresses that are allowed to access the SNMP server.
+	Port              *int     `json:"port,omitempty"`              // The port of the SNMP server.
+	V2CommunityString string   `json:"v2CommunityString,omitempty"` // The community string for SNMP version 2c, if enabled.
+	V2CEnabled        *bool    `json:"v2cEnabled,omitempty"`        // Boolean indicating whether SNMP version 2c is enabled for the organization.
+	V3AuthMode        string   `json:"v3AuthMode,omitempty"`        // The SNMP version 3 authentication mode. Can be either 'MD5' or 'SHA'.
+	V3Enabled         *bool    `json:"v3Enabled,omitempty"`         // Boolean indicating whether SNMP version 3 is enabled for the organization.
+	V3PrivMode        string   `json:"v3PrivMode,omitempty"`        // The SNMP version 3 privacy mode. Can be either 'DES' or 'AES128'.
+	V3User            string   `json:"v3User,omitempty"`            // The user for SNMP version 3, if enabled.
 }
-type ResponseOrganizationsUpdateOrganizationSNMP interface{}
+type ResponseOrganizationsUpdateOrganizationSNMP struct {
+	Hostname          string   `json:"hostname,omitempty"`          // The hostname of the SNMP server.
+	PeerIPs           []string `json:"peerIps,omitempty"`           // The list of IPv4 addresses that are allowed to access the SNMP server.
+	Port              *int     `json:"port,omitempty"`              // The port of the SNMP server.
+	V2CommunityString string   `json:"v2CommunityString,omitempty"` // The community string for SNMP version 2c, if enabled.
+	V2CEnabled        *bool    `json:"v2cEnabled,omitempty"`        // Boolean indicating whether SNMP version 2c is enabled for the organization.
+	V3AuthMode        string   `json:"v3AuthMode,omitempty"`        // The SNMP version 3 authentication mode. Can be either 'MD5' or 'SHA'.
+	V3Enabled         *bool    `json:"v3Enabled,omitempty"`         // Boolean indicating whether SNMP version 3 is enabled for the organization.
+	V3PrivMode        string   `json:"v3PrivMode,omitempty"`        // The SNMP version 3 privacy mode. Can be either 'DES' or 'AES128'.
+	V3User            string   `json:"v3User,omitempty"`            // The user for SNMP version 3, if enabled.
+}
 type ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization []ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilization // Array of ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization
 type ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilization struct {
 	Mac         string                                                                                `json:"mac,omitempty"`         // Mac address of the appliance
@@ -1939,6 +2355,49 @@ type ResponseItemOrganizationsGetOrganizationSummaryTopDevicesModelsByUsageUsage
 	Average *float64 `json:"average,omitempty"` // Average usage in megabytes
 	Total   *float64 `json:"total,omitempty"`   // Total usage in megabytes
 }
+type ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus []ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatus // Array of ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatus struct {
+	Clients      *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClients  `json:"clients,omitempty"`      // Network clients data
+	Devices      *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusDevices  `json:"devices,omitempty"`      // Network device information
+	Name         string                                                                      `json:"name,omitempty"`         // Network name
+	NetworkID    string                                                                      `json:"networkId,omitempty"`    // Network identifier
+	ProductTypes []string                                                                    `json:"productTypes,omitempty"` // Product types in network
+	Statuses     *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatuses `json:"statuses,omitempty"`     // Network device statuses
+	Tags         []string                                                                    `json:"tags,omitempty"`         // Network tags
+	URL          string                                                                      `json:"url,omitempty"`          // Network clients list URL
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClients struct {
+	Counts *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClientsCounts `json:"counts,omitempty"` // Network client counts
+	Usage  *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClientsUsage  `json:"usage,omitempty"`  // Network client usage data
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClientsCounts struct {
+	Total *int `json:"total,omitempty"` // Total count of clients in network
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusClientsUsage struct {
+	Downstream *float64 `json:"downstream,omitempty"` // Total downstream usage in network, in KB
+	Upstream   *float64 `json:"upstream,omitempty"`   // Total upstream usage in network, in KB
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusDevices struct {
+	ByProductType *[]ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusDevicesByProductType `json:"byProductType,omitempty"` // URLs by product type
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusDevicesByProductType struct {
+	ProductType string `json:"productType,omitempty"` // Product type
+	URL         string `json:"url,omitempty"`         // URL to clients list for the relevant product type
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatuses struct {
+	ByProductType *[]ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatusesByProductType `json:"byProductType,omitempty"` // List of status counts by product type
+	Overall       string                                                                                     `json:"overall,omitempty"`       // Overall status of network
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatusesByProductType struct {
+	Counts      *ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatusesByProductTypeCounts `json:"counts,omitempty"`      // Counts of devices by status
+	ProductType string                                                                                         `json:"productType,omitempty"` // Product type
+}
+type ResponseItemOrganizationsGetOrganizationSummaryTopNetworksByStatusStatusesByProductTypeCounts struct {
+	Alerting *int `json:"alerting,omitempty"` // Count of alerting devices
+	Dormant  *int `json:"dormant,omitempty"`  // Count of dormant devices
+	Offline  *int `json:"offline,omitempty"`  // Count of offline devices
+	Online   *int `json:"online,omitempty"`   // Count of online devices
+}
 type ResponseOrganizationsGetOrganizationSummaryTopSSIDsByUsage []ResponseItemOrganizationsGetOrganizationSummaryTopSSIDsByUsage // Array of ResponseOrganizationsGetOrganizationSummaryTopSsidsByUsage
 type ResponseItemOrganizationsGetOrganizationSummaryTopSSIDsByUsage struct {
 	Clients *ResponseItemOrganizationsGetOrganizationSummaryTopSSIDsByUsageClients `json:"clients,omitempty"` // Clients info of the SSID
@@ -1974,11 +2433,16 @@ type ResponseItemOrganizationsGetOrganizationSummaryTopSwitchesByEnergyUsageUsag
 }
 type ResponseOrganizationsGetOrganizationUplinksStatuses []ResponseItemOrganizationsGetOrganizationUplinksStatuses // Array of ResponseOrganizationsGetOrganizationUplinksStatuses
 type ResponseItemOrganizationsGetOrganizationUplinksStatuses struct {
-	LastReportedAt string                                                            `json:"lastReportedAt,omitempty"` // Last reported time for the device
-	Model          string                                                            `json:"model,omitempty"`          // The uplink model
-	NetworkID      string                                                            `json:"networkId,omitempty"`      // Network identifier
-	Serial         string                                                            `json:"serial,omitempty"`         // The uplink serial
-	Uplinks        *[]ResponseItemOrganizationsGetOrganizationUplinksStatusesUplinks `json:"uplinks,omitempty"`        // Uplinks
+	HighAvailability *ResponseItemOrganizationsGetOrganizationUplinksStatusesHighAvailability `json:"highAvailability,omitempty"` // Device High Availability Capabilities
+	LastReportedAt   string                                                                   `json:"lastReportedAt,omitempty"`   // Last reported time for the device
+	Model            string                                                                   `json:"model,omitempty"`            // The uplink model
+	NetworkID        string                                                                   `json:"networkId,omitempty"`        // Network identifier
+	Serial           string                                                                   `json:"serial,omitempty"`           // The uplink serial
+	Uplinks          *[]ResponseItemOrganizationsGetOrganizationUplinksStatusesUplinks        `json:"uplinks,omitempty"`          // Uplinks
+}
+type ResponseItemOrganizationsGetOrganizationUplinksStatusesHighAvailability struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Indicates whether High Availability is enabled for the device. For devices that do not support HA, this will be 'false'
+	Role    string `json:"role,omitempty"`    // The HA role of the device on the network. For devices that do not support HA, this will be 'primary'
 }
 type ResponseItemOrganizationsGetOrganizationUplinksStatusesUplinks struct {
 	Apn            string                                                                    `json:"apn,omitempty"`            // Access Point Name
@@ -2002,34 +2466,59 @@ type ResponseItemOrganizationsGetOrganizationUplinksStatusesUplinksSignalStat st
 	Rsrp string `json:"rsrp,omitempty"` // Reference Signal Received Power
 	Rsrq string `json:"rsrq,omitempty"` // Reference Signal Received Quality
 }
-type ResponseOrganizationsGetOrganizationWebhooksAlertTypes []ResponseItemOrganizationsGetOrganizationWebhooksAlertTypes // Array of ResponseOrganizationsGetOrganizationWebhooksAlertTypes
-type ResponseItemOrganizationsGetOrganizationWebhooksAlertTypes struct {
-	AlertData        *ResponseItemOrganizationsGetOrganizationWebhooksAlertTypesAlertData `json:"alertData,omitempty"`        //
-	AlertID          string                                                               `json:"alertId,omitempty"`          //
-	AlertLevel       string                                                               `json:"alertLevel,omitempty"`       //
-	AlertType        string                                                               `json:"alertType,omitempty"`        //
-	AlertTypeID      string                                                               `json:"alertTypeId,omitempty"`      //
-	DeviceMac        string                                                               `json:"deviceMac,omitempty"`        //
-	DeviceModel      string                                                               `json:"deviceModel,omitempty"`      //
-	DeviceName       string                                                               `json:"deviceName,omitempty"`       //
-	DeviceSerial     string                                                               `json:"deviceSerial,omitempty"`     //
-	DeviceTags       []string                                                             `json:"deviceTags,omitempty"`       //
-	DeviceURL        string                                                               `json:"deviceUrl,omitempty"`        //
-	EnrollmentString string                                                               `json:"enrollmentString,omitempty"` //
-	NetworkID        string                                                               `json:"networkId,omitempty"`        //
-	NetworkName      string                                                               `json:"networkName,omitempty"`      //
-	NetworkURL       string                                                               `json:"networkUrl,omitempty"`       //
-	Notes            string                                                               `json:"notes,omitempty"`            //
-	OccurredAt       string                                                               `json:"occurredAt,omitempty"`       //
-	OrganizationID   string                                                               `json:"organizationId,omitempty"`   //
-	OrganizationName string                                                               `json:"organizationName,omitempty"` //
-	OrganizationURL  string                                                               `json:"organizationUrl,omitempty"`  //
-	ProductTypes     []string                                                             `json:"productTypes,omitempty"`     //
-	SentAt           string                                                               `json:"sentAt,omitempty"`           //
-	SharedSecret     string                                                               `json:"sharedSecret,omitempty"`     //
-	Version          string                                                               `json:"version,omitempty"`          //
+type ResponseOrganizationsGetOrganizationWebhooksAlertTypes struct {
+	AlertType   string                                                         `json:"alertType,omitempty"`   // The type of Meraki alert
+	AlertTypeID string                                                         `json:"alertTypeId,omitempty"` // The type ID of Meraki alert
+	Example     *ResponseOrganizationsGetOrganizationWebhooksAlertTypesExample `json:"example,omitempty"`     // Example alert type
 }
-type ResponseItemOrganizationsGetOrganizationWebhooksAlertTypesAlertData interface{}
+type ResponseOrganizationsGetOrganizationWebhooksAlertTypesExample struct {
+	AlertData        *ResponseOrganizationsGetOrganizationWebhooksAlertTypesExampleAlertData `json:"alertData,omitempty"`        // Data for the specific alert. Contents depend on the type of the alert
+	AlertID          string                                                                  `json:"alertId,omitempty"`          // ID for the alert instance
+	AlertLevel       string                                                                  `json:"alertLevel,omitempty"`       // Severity level of the alert
+	DeviceMac        string                                                                  `json:"deviceMac,omitempty"`        // Mac address for the device associated with the alert
+	DeviceModel      string                                                                  `json:"deviceModel,omitempty"`      // Model of the device associated with the alert
+	DeviceName       string                                                                  `json:"deviceName,omitempty"`       // Name of the device associated with the alert
+	DeviceSerial     string                                                                  `json:"deviceSerial,omitempty"`     // Serial for the device associated with the alert
+	DeviceTags       []string                                                                `json:"deviceTags,omitempty"`       // List of tags for the device associated with the alert
+	DeviceURL        string                                                                  `json:"deviceUrl,omitempty"`        // URL of the device associated with the alert
+	EncryptedID      string                                                                  `json:"encryptedId,omitempty"`      // Encrypted ID of the network associated with the alert
+	EnrollmentString string                                                                  `json:"enrollmentString,omitempty"` // Enrollment string of the network associated with the alert
+	NetworkID        string                                                                  `json:"networkId,omitempty"`        // ID of the network associated with the alert
+	NetworkName      string                                                                  `json:"networkName,omitempty"`      // Name of the network associated with the alert
+	NetworkURL       string                                                                  `json:"networkUrl,omitempty"`       // URL of the network associated with the alert
+	Notes            string                                                                  `json:"notes,omitempty"`            // Notes for the network associated with the alert
+	OccurredAt       string                                                                  `json:"occurredAt,omitempty"`       // When the alert occurred, in ISO8601 format
+	OrganizationID   string                                                                  `json:"organizationId,omitempty"`   // ID of the organization associated with the alert
+	OrganizationName string                                                                  `json:"organizationName,omitempty"` // Name of the organization associated with the alert
+	OrganizationURL  string                                                                  `json:"organizationUrl,omitempty"`  // URL of the organization associated with the alert
+	ProductTypes     []string                                                                `json:"productTypes,omitempty"`     // List of product types that are part of the network associated with the alert
+	SentAt           string                                                                  `json:"sentAt,omitempty"`           // When the alert notification was sent, in ISO8601 format
+	SharedSecret     string                                                                  `json:"sharedSecret,omitempty"`     // Shared secret for the alert
+	Version          string                                                                  `json:"version,omitempty"`          // Version of the alert
+}
+type ResponseOrganizationsGetOrganizationWebhooksAlertTypesExampleAlertData interface{}
+type ResponseOrganizationsGetOrganizationWebhooksCallbacksStatus struct {
+	CallbackID string                                                                `json:"callbackId,omitempty"` // The ID of the callback
+	CreatedBy  *ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusCreatedBy `json:"createdBy,omitempty"`  // Information around who initiated the callback
+	Errors     []string                                                              `json:"errors,omitempty"`     // The errors returned by the callback
+	Status     string                                                                `json:"status,omitempty"`     // The status of the callback
+	Webhook    *ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhook   `json:"webhook,omitempty"`    // The webhook receiver used by the callback to send results
+}
+type ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusCreatedBy struct {
+	AdminID string `json:"adminId,omitempty"` // The ID of the user who initiated the callback
+}
+type ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhook struct {
+	HTTPServer      *ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhookHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook
+	PayloadTemplate *ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhookPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SentAt          string                                                                             `json:"sentAt,omitempty"`          // The timestamp the callback was sent to the webhook receiver
+	URL             string                                                                             `json:"url,omitempty"`             // The webhook receiver URL where the callback will be sent
+}
+type ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhookHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information
+}
+type ResponseOrganizationsGetOrganizationWebhooksCallbacksStatusWebhookPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template
+}
 type ResponseOrganizationsGetOrganizationWebhooksLogs []ResponseItemOrganizationsGetOrganizationWebhooksLogs // Array of ResponseOrganizationsGetOrganizationWebhooksLogs
 type ResponseItemOrganizationsGetOrganizationWebhooksLogs struct {
 	AlertType        string `json:"alertType,omitempty"`        // Type of alert that the webhook is delivering
@@ -2069,6 +2558,7 @@ type RequestOrganizationsUpdateOrganizationManagementDetails struct {
 }
 type RequestOrganizationsCreateOrganizationActionBatch struct {
 	Actions     *[]RequestOrganizationsCreateOrganizationActionBatchActions `json:"actions,omitempty"`     // A set of changes to make as part of this action (<a href='https://developer.cisco.com/meraki/api/#/rest/guides/action-batches/'>more details</a>)
+	Callback    *RequestOrganizationsCreateOrganizationActionBatchCallback  `json:"callback,omitempty"`    // Details for the callback. Please include either an httpServerId OR url and sharedSecret
 	Confirmed   *bool                                                       `json:"confirmed,omitempty"`   // Set to true for immediate execution. Set to false if the action should be previewed before executing. This property cannot be unset once it is true. Defaults to false.
 	Synchronous *bool                                                       `json:"synchronous,omitempty"` // Set to true to force the batch to run synchronous. There can be at most 20 actions in synchronous batch. Defaults to false.
 }
@@ -2078,6 +2568,18 @@ type RequestOrganizationsCreateOrganizationActionBatchActions struct {
 	Resource  string                                                        `json:"resource,omitempty"`  // Unique identifier for the resource to be acted on
 }
 type RequestOrganizationsCreateOrganizationActionBatchActionsBody interface{}
+type RequestOrganizationsCreateOrganizationActionBatchCallback struct {
+	HTTPServer      *RequestOrganizationsCreateOrganizationActionBatchCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestOrganizationsCreateOrganizationActionBatchCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                                    `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                                    `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestOrganizationsCreateOrganizationActionBatchCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestOrganizationsCreateOrganizationActionBatchCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
 type RequestOrganizationsUpdateOrganizationActionBatch struct {
 	Confirmed   *bool `json:"confirmed,omitempty"`   // A boolean representing whether or not the batch has been confirmed. This property cannot be unset once it is true.
 	Synchronous *bool `json:"synchronous,omitempty"` // Set to true to force the batch to run synchronous. There can be at most 20 actions in synchronous batch.
@@ -2109,7 +2611,7 @@ type RequestOrganizationsUpdateOrganizationAdaptivePolicyACLRules struct {
 type RequestOrganizationsCreateOrganizationAdaptivePolicyGroup struct {
 	Description   string                                                                    `json:"description,omitempty"`   // Description of the group (default: "")
 	Name          string                                                                    `json:"name,omitempty"`          // Name of the group
-	PolicyObjects *[]RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"` // The policy objects that belong to this group; traffic from addresses specified by these policy objects will be tagged with this group's SGT value if no other tagging scheme is being used (each requires one unique attribute) (default: [])
+	PolicyObjects *[]RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"` // The policy objects that belong to this group; traffic from addresses specified by these policy objects will be tagged with this group's SGT value if no other tagging scheme is being used (each requires one unique attribute) ()
 	Sgt           *int                                                                      `json:"sgt,omitempty"`           // SGT value of the group
 }
 type RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects struct {
@@ -2127,7 +2629,7 @@ type RequestOrganizationsUpdateOrganizationAdaptivePolicyGroupPolicyObjects stru
 	Name string `json:"name,omitempty"` // The name of the policy object
 }
 type RequestOrganizationsCreateOrganizationAdaptivePolicyPolicy struct {
-	ACLs             *[]RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // An ordered array of adaptive policy ACLs (each requires one unique attribute) that apply to this policy (default: [])
+	ACLs             *[]RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // An ordered array of adaptive policy ACLs (each requires one unique attribute) that apply to this policy ()
 	DestinationGroup *RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` // The destination adaptive policy group (requires one unique attribute)
 	LastEntryRule    string                                                                      `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL (default: "default")
 	SourceGroup      *RequestOrganizationsCreateOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      // The source adaptive policy group (requires one unique attribute)
@@ -2209,7 +2711,7 @@ type RequestOrganizationsCreateOrganizationAlertsProfile struct {
 type RequestOrganizationsCreateOrganizationAlertsProfileAlertCondition struct {
 	BitRateBps *int     `json:"bit_rate_bps,omitempty"` // The threshold the metric must cross to be valid for alerting. Used only for WAN Utilization alerts.
 	Duration   *int     `json:"duration,omitempty"`     // The total duration in seconds that the threshold should be crossed before alerting
-	Interface  string   `json:"interface,omitempty"`    // The uplink observed for the alert.  interface must be one of the following: wan1, wan2, cellular
+	Interface  string   `json:"interface,omitempty"`    // The uplink observed for the alert.  interface must be one of the following: wan1, wan2, wan3, cellular
 	JitterMs   *int     `json:"jitter_ms,omitempty"`    // The threshold the metric must cross to be valid for alerting. Used only for VoIP Jitter alerts.
 	LatencyMs  *int     `json:"latency_ms,omitempty"`   // The threshold the metric must cross to be valid for alerting. Used only for WAN Latency alerts.
 	LossRatio  *float64 `json:"loss_ratio,omitempty"`   // The threshold the metric must cross to be valid for alerting. Used only for Packet Loss alerts.
@@ -2231,7 +2733,7 @@ type RequestOrganizationsUpdateOrganizationAlertsProfile struct {
 type RequestOrganizationsUpdateOrganizationAlertsProfileAlertCondition struct {
 	BitRateBps *int     `json:"bit_rate_bps,omitempty"` // The threshold the metric must cross to be valid for alerting. Used only for WAN Utilization alerts.
 	Duration   *int     `json:"duration,omitempty"`     // The total duration in seconds that the threshold should be crossed before alerting
-	Interface  string   `json:"interface,omitempty"`    // The uplink observed for the alert.  interface must be one of the following: wan1, wan2, cellular
+	Interface  string   `json:"interface,omitempty"`    // The uplink observed for the alert.  interface must be one of the following: wan1, wan2, wan3, cellular
 	JitterMs   *int     `json:"jitter_ms,omitempty"`    // The threshold the metric must cross to be valid for alerting. Used only for VoIP Jitter alerts.
 	LatencyMs  *int     `json:"latency_ms,omitempty"`   // The threshold the metric must cross to be valid for alerting. Used only for WAN Latency alerts.
 	LossRatio  *float64 `json:"loss_ratio,omitempty"`   // The threshold the metric must cross to be valid for alerting. Used only for Packet Loss alerts.
@@ -2330,8 +2832,9 @@ type RequestOrganizationsCloneOrganization struct {
 	Name string `json:"name,omitempty"` // The name of the new organization
 }
 type RequestOrganizationsCreateOrganizationConfigTemplate struct {
-	Name     string `json:"name,omitempty"`     // The name of the configuration template
-	TimeZone string `json:"timeZone,omitempty"` // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
+	CopyFromNetworkID string `json:"copyFromNetworkId,omitempty"` // The ID of the network or config template to copy configuration from
+	Name              string `json:"name,omitempty"`              // The name of the configuration template
+	TimeZone          string `json:"timeZone,omitempty"`          // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article</a>. Not applicable if copying from existing network or template
 }
 type RequestOrganizationsUpdateOrganizationConfigTemplate struct {
 	Name     string `json:"name,omitempty"`     // The name of the configuration template
@@ -2352,6 +2855,17 @@ type RequestOrganizationsClaimIntoOrganizationInventory struct {
 type RequestOrganizationsClaimIntoOrganizationInventoryLicenses struct {
 	Key  string `json:"key,omitempty"`  // The key of the license
 	Mode string `json:"mode,omitempty"` // Co-term licensing only: either 'renew' or 'addDevices'. 'addDevices' will increase the license limit, while 'renew' will extend the amount of time until expiration. Defaults to 'addDevices'. All licenses must be claimed with the same mode, and at most one renewal can be claimed at a time. Does not apply to organizations using per-device licensing model.
+}
+type RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulk struct {
+	Swaps *[]RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // List of replacments to perform
+}
+type RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                                       `json:"afterAction,omitempty"` // What action to perform on devices.old after the device cloning is complete. 'remove from network' will return the device to inventory, while 'release from organization inventory' will free up the license attached to the device.
+	Devices     *RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap.
+}
+type RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New string `json:"new,omitempty"` // The serial of the device that the old device's settings will be cloned to.
+	Old string `json:"old,omitempty"` // The serial of the device to be cloned.
 }
 type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringExportEvent struct {
 	LogEvent  string `json:"logEvent,omitempty"`  // The type of log event this is recording, e.g. download or opening a banner
@@ -2475,14 +2989,14 @@ type RequestOrganizationsCombineOrganizationNetworks struct {
 	NetworkIDs       []string `json:"networkIds,omitempty"`       // A list of the network IDs that will be combined. If an ID of a combined network is included in this list, the other networks in the list will be grouped into that network
 }
 type RequestOrganizationsCreateOrganizationPolicyObject struct {
-	Category string `json:"category,omitempty"` // Category of a policy object (one of: adaptivePolicy, network)
-	Cidr     string `json:"cidr,omitempty"`     // CIDR Value of a policy object (e.g. 10.11.12.1/24")
-	Fqdn     string `json:"fqdn,omitempty"`     // Fully qualified domain name of policy object (e.g. "example.com")
-	GroupIDs *[]int `json:"groupIds,omitempty"` // The IDs of policy object groups the policy object belongs to
-	IP       string `json:"ip,omitempty"`       // IP Address of a policy object (e.g. "1.2.3.4")
-	Mask     string `json:"mask,omitempty"`     // Mask of a policy object (e.g. "255.255.0.0")
-	Name     string `json:"name,omitempty"`     // Name of a policy object, unique within the organization (alphanumeric, space, dash, or underscore characters only)
-	Type     string `json:"type,omitempty"`     // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
+	Category string   `json:"category,omitempty"` // Category of a policy object (one of: adaptivePolicy, network)
+	Cidr     string   `json:"cidr,omitempty"`     // CIDR Value of a policy object (e.g. 10.11.12.1/24")
+	Fqdn     string   `json:"fqdn,omitempty"`     // Fully qualified domain name of policy object (e.g. "example.com")
+	GroupIDs []string `json:"groupIds,omitempty"` // The IDs of policy object groups the policy object belongs to
+	IP       string   `json:"ip,omitempty"`       // IP Address of a policy object (e.g. "1.2.3.4")
+	Mask     string   `json:"mask,omitempty"`     // Mask of a policy object (e.g. "255.255.0.0")
+	Name     string   `json:"name,omitempty"`     // Name of a policy object, unique within the organization (alphanumeric, space, dash, or underscore characters only)
+	Type     string   `json:"type,omitempty"`     // Type of a policy object (one of: adaptivePolicyIpv4Cidr, cidr, fqdn, ipAndMask)
 }
 type RequestOrganizationsCreateOrganizationPolicyObjectsGroup struct {
 	Category  string `json:"category,omitempty"`  // Category of a policy object group (one of: NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
@@ -2494,12 +3008,12 @@ type RequestOrganizationsUpdateOrganizationPolicyObjectsGroup struct {
 	ObjectIDs *[]int `json:"objectIds,omitempty"` // A list of Policy Object ID's that this NetworkObjectGroup should be associated to (note: these ID's will replace the existing associated Policy Objects)
 }
 type RequestOrganizationsUpdateOrganizationPolicyObject struct {
-	Cidr     string `json:"cidr,omitempty"`     // CIDR Value of a policy object (e.g. 10.11.12.1/24")
-	Fqdn     string `json:"fqdn,omitempty"`     // Fully qualified domain name of policy object (e.g. "example.com")
-	GroupIDs *[]int `json:"groupIds,omitempty"` // The IDs of policy object groups the policy object belongs to
-	IP       string `json:"ip,omitempty"`       // IP Address of a policy object (e.g. "1.2.3.4")
-	Mask     string `json:"mask,omitempty"`     // Mask of a policy object (e.g. "255.255.0.0")
-	Name     string `json:"name,omitempty"`     // Name of a policy object, unique within the organization (alphanumeric, space, dash, or underscore characters only)
+	Cidr     string   `json:"cidr,omitempty"`     // CIDR Value of a policy object (e.g. 10.11.12.1/24")
+	Fqdn     string   `json:"fqdn,omitempty"`     // Fully qualified domain name of policy object (e.g. "example.com")
+	GroupIDs []string `json:"groupIds,omitempty"` // The IDs of policy object groups the policy object belongs to
+	IP       string   `json:"ip,omitempty"`       // IP Address of a policy object (e.g. "1.2.3.4")
+	Mask     string   `json:"mask,omitempty"`     // Mask of a policy object (e.g. "255.255.0.0")
+	Name     string   `json:"name,omitempty"`     // Name of a policy object, unique within the organization (alphanumeric, space, dash, or underscore characters only)
 }
 type RequestOrganizationsUpdateOrganizationSaml struct {
 	Enabled *bool `json:"enabled,omitempty"` // Boolean for updating SAML SSO enabled settings.
@@ -2516,7 +3030,7 @@ type RequestOrganizationsCreateOrganizationSamlRole struct {
 	Networks  *[]RequestOrganizationsCreateOrganizationSamlRoleNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
 	OrgAccess string                                                    `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization. Can be one of 'none', 'read-only', 'full' or 'enterprise'
 	Role      string                                                    `json:"role,omitempty"`      // The role of the SAML administrator
-	Tags      *[]RequestOrganizationsCreateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+	Tags      *[]RequestOrganizationsCreateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privileges on
 }
 type RequestOrganizationsCreateOrganizationSamlRoleNetworks struct {
 	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only' or 'ssid-admin'
@@ -2530,7 +3044,7 @@ type RequestOrganizationsUpdateOrganizationSamlRole struct {
 	Networks  *[]RequestOrganizationsUpdateOrganizationSamlRoleNetworks `json:"networks,omitempty"`  // The list of networks that the SAML administrator has privileges on
 	OrgAccess string                                                    `json:"orgAccess,omitempty"` // The privilege of the SAML administrator on the organization. Can be one of 'none', 'read-only', 'full' or 'enterprise'
 	Role      string                                                    `json:"role,omitempty"`      // The role of the SAML administrator
-	Tags      *[]RequestOrganizationsUpdateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privleges on
+	Tags      *[]RequestOrganizationsUpdateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privileges on
 }
 type RequestOrganizationsUpdateOrganizationSamlRoleNetworks struct {
 	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only' or 'ssid-admin'
@@ -2553,17 +3067,20 @@ type RequestOrganizationsUpdateOrganizationSNMP struct {
 //GetOrganizations List the organizations that the user has privileges on
 /* List the organizations that the user has privileges on
 
+@param getOrganizationsQueryParams Filtering parameter
 
 
- */
-func (s *OrganizationsService) GetOrganizations() (*ResponseOrganizationsGetOrganizations, *resty.Response, error) {
+*/
+func (s *OrganizationsService) GetOrganizations(getOrganizationsQueryParams *GetOrganizationsQueryParams) (*ResponseOrganizationsGetOrganizations, *resty.Response, error) {
 	path := "/api/v1/organizations"
 	s.rateLimiterBucket.Wait(1)
+
+	queryString, _ := query.Values(getOrganizationsQueryParams)
 
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseOrganizationsGetOrganizations{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizations{}).
 		SetError(&Error).
 		Get(path)
 
@@ -3514,8 +4031,80 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilities(organization
 
 }
 
-//GetOrganizationDevicesPowerModulesStatusesByDevice List the power status information for devices in an organization
-/* List the power status information for devices in an organization. The data returned by this endpoint is updated every 5 minutes.
+//GetOrganizationDevicesAvailabilitiesChangeHistory List the availability history information for devices in an organization.
+/* List the availability history information for devices in an organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/availabilities/changeHistory"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesAvailabilitiesChangeHistory")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory)
+	return result, response, err
+
+}
+
+//GetOrganizationDevicesBootsHistory Returns the history of device boots in reverse chronological order (most recent first)
+/* Returns the history of device boots in reverse chronological order (most recent first). Currently supported for MS devices only.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationDevicesBootsHistoryQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationDevicesBootsHistory(organizationID string, getOrganizationDevicesBootsHistoryQueryParams *GetOrganizationDevicesBootsHistoryQueryParams) (*ResponseOrganizationsGetOrganizationDevicesBootsHistory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/boots/history"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationDevicesBootsHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationDevicesBootsHistory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesBootsHistory")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationDevicesBootsHistory)
+	return result, response, err
+
+}
+
+//GetOrganizationDevicesPowerModulesStatusesByDevice List the most recent status information for power modules in rackmount MX and MS devices that support them
+/* List the most recent status information for power modules in rackmount MX and MS devices that support them. The data returned by this endpoint is updated every 5 minutes.
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams Filtering parameter
@@ -3868,7 +4457,7 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgrades(organizationID st
 }
 
 //GetOrganizationFirmwareUpgradesByDevice Get firmware upgrade status for the filtered devices
-/* Get firmware upgrade status for the filtered devices
+/* Get firmware upgrade status for the filtered devices. This endpoint currently only supports Meraki switches.
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationFirmwareUpgradesByDeviceQueryParams Filtering parameter
@@ -3935,6 +4524,41 @@ func (s *OrganizationsService) GetOrganizationInventoryDevices(organizationID st
 	}
 
 	result := response.Result().(*ResponseOrganizationsGetOrganizationInventoryDevices)
+	return result, response, err
+
+}
+
+//GetOrganizationInventoryDevicesSwapsBulk List of device swaps for a given request ID ({id}).
+/* List of device swaps for a given request ID ({id}).
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+
+
+*/
+func (s *OrganizationsService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulk, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulk{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationInventoryDevicesSwapsBulk")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulk)
 	return result, response, err
 
 }
@@ -4219,22 +4843,25 @@ func (s *OrganizationsService) GetOrganizationNetworks(organizationID string, ge
 
 }
 
-//GetOrganizationOpenapiSpec Return the OpenAPI 2.0 Specification of the organization's API documentation in JSON
-/* Return the OpenAPI 2.0 Specification of the organization's API documentation in JSON
+//GetOrganizationOpenapiSpec Return the OpenAPI Specification of the organization's API documentation in JSON
+/* Return the OpenAPI Specification of the organization's API documentation in JSON
 
 @param organizationID organizationId path parameter. Organization ID
+@param getOrganizationOpenapiSpecQueryParams Filtering parameter
 
 
 */
-func (s *OrganizationsService) GetOrganizationOpenapiSpec(organizationID string) (*ResponseOrganizationsGetOrganizationOpenapiSpec, *resty.Response, error) {
+func (s *OrganizationsService) GetOrganizationOpenapiSpec(organizationID string, getOrganizationOpenapiSpecQueryParams *GetOrganizationOpenapiSpecQueryParams) (*ResponseOrganizationsGetOrganizationOpenapiSpec, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/openapiSpec"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
+	queryString, _ := query.Values(getOrganizationOpenapiSpecQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseOrganizationsGetOrganizationOpenapiSpec{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationOpenapiSpec{}).
 		SetError(&Error).
 		Get(path)
 
@@ -4776,6 +5403,42 @@ func (s *OrganizationsService) GetOrganizationSummaryTopDevicesModelsByUsage(org
 
 }
 
+//GetOrganizationSummaryTopNetworksByStatus List the client and status overview information for the networks in an organization
+/* List the client and status overview information for the networks in an organization. Usage is measured in kilobytes and from the last seven days.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSummaryTopNetworksByStatusQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationSummaryTopNetworksByStatus(organizationID string, getOrganizationSummaryTopNetworksByStatusQueryParams *GetOrganizationSummaryTopNetworksByStatusQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/summary/top/networks/byStatus"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSummaryTopNetworksByStatusQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSummaryTopNetworksByStatus")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus)
+	return result, response, err
+
+}
+
 //GetOrganizationSummaryTopSSIDsByUsage Return metrics for organization's top 10 ssids by data usage over given time range
 /* Return metrics for organization's top 10 ssids by data usage over given time range. Default unit is megabytes.
 
@@ -4916,6 +5579,41 @@ func (s *OrganizationsService) GetOrganizationWebhooksAlertTypes(organizationID 
 	}
 
 	result := response.Result().(*ResponseOrganizationsGetOrganizationWebhooksAlertTypes)
+	return result, response, err
+
+}
+
+//GetOrganizationWebhooksCallbacksStatus Return the status of an API callback
+/* Return the status of an API callback
+
+@param organizationID organizationId path parameter. Organization ID
+@param callbackID callbackId path parameter. Callback ID
+
+
+*/
+func (s *OrganizationsService) GetOrganizationWebhooksCallbacksStatus(organizationID string, callbackID string) (*ResponseOrganizationsGetOrganizationWebhooksCallbacksStatus, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/webhooks/callbacks/statuses/{callbackId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{callbackId}", fmt.Sprintf("%v", callbackID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseOrganizationsGetOrganizationWebhooksCallbacksStatus{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWebhooksCallbacksStatus")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationWebhooksCallbacksStatus)
 	return result, response, err
 
 }
@@ -5233,15 +5931,15 @@ func (s *OrganizationsService) CreateOrganizationBrandingPolicy(organizationID s
 
 }
 
-//ClaimIntoOrganization Claim a list of devices, licenses, and/or orders into an organization
-/* Claim a list of devices, licenses, and/or orders into an organization. When claiming by order, all devices and licenses in the order will be claimed; licenses will be added to the organization and devices will be placed in the organization's inventory.
+//ClaimIntoOrganization Claim a list of devices, licenses, and/or orders into an organization inventory
+/* Claim a list of devices, licenses, and/or orders into an organization inventory. When claiming by order, all devices and licenses in the order will be claimed; licenses will be added to the organization and devices will be placed in the organization's inventory. This operation can be used up to ten times within a single five minute window.
 
 @param organizationID organizationId path parameter. Organization ID
 
 
 */
 
-func (s *OrganizationsService) ClaimIntoOrganization(organizationID string, requestOrganizationsClaimIntoOrganization *RequestOrganizationsClaimIntoOrganization) (*resty.Response, error) {
+func (s *OrganizationsService) ClaimIntoOrganization(organizationID string, requestOrganizationsClaimIntoOrganization *RequestOrganizationsClaimIntoOrganization) (*ResponseOrganizationsClaimIntoOrganization, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/claim"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5250,20 +5948,21 @@ func (s *OrganizationsService) ClaimIntoOrganization(organizationID string, requ
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsClaimIntoOrganization).
-		// SetResult(&ResponseOrganizationsClaimIntoOrganization{}).
+		SetResult(&ResponseOrganizationsClaimIntoOrganization{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ClaimIntoOrganization")
+		return nil, response, fmt.Errorf("error with operation ClaimIntoOrganization")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsClaimIntoOrganization)
+	return result, response, err
 
 }
 
@@ -5310,7 +6009,7 @@ func (s *OrganizationsService) CloneOrganization(organizationID string, requestO
 
 */
 
-func (s *OrganizationsService) CreateOrganizationConfigTemplate(organizationID string, requestOrganizationsCreateOrganizationConfigTemplate *RequestOrganizationsCreateOrganizationConfigTemplate) (*resty.Response, error) {
+func (s *OrganizationsService) CreateOrganizationConfigTemplate(organizationID string, requestOrganizationsCreateOrganizationConfigTemplate *RequestOrganizationsCreateOrganizationConfigTemplate) (*ResponseOrganizationsCreateOrganizationConfigTemplate, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5319,20 +6018,21 @@ func (s *OrganizationsService) CreateOrganizationConfigTemplate(organizationID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsCreateOrganizationConfigTemplate).
-		// SetResult(&ResponseOrganizationsCreateOrganizationConfigTemplate{}).
+		SetResult(&ResponseOrganizationsCreateOrganizationConfigTemplate{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationConfigTemplate")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationConfigTemplate")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationConfigTemplate)
+	return result, response, err
 
 }
 
@@ -5372,14 +6072,14 @@ func (s *OrganizationsService) CreateOrganizationEarlyAccessFeaturesOptIn(organi
 }
 
 //ClaimIntoOrganizationInventory Claim a list of devices, licenses, and/or orders into an organization inventory
-/* Claim a list of devices, licenses, and/or orders into an organization inventory. When claiming by order, all devices and licenses in the order will be claimed; licenses will be added to the organization and devices will be placed in the organization's inventory. Use /organizations/{organizationId}/inventory/release to release devices from an organization.
+/* Claim a list of devices, licenses, and/or orders into an organization inventory. When claiming by order, all devices and licenses in the order will be claimed; licenses will be added to the organization and devices will be placed in the organization's inventory. This operation can be used up to ten times within a single five minute window.
 
 @param organizationID organizationId path parameter. Organization ID
 
 
 */
 
-func (s *OrganizationsService) ClaimIntoOrganizationInventory(organizationID string, requestOrganizationsClaimIntoOrganizationInventory *RequestOrganizationsClaimIntoOrganizationInventory) (*resty.Response, error) {
+func (s *OrganizationsService) ClaimIntoOrganizationInventory(organizationID string, requestOrganizationsClaimIntoOrganizationInventory *RequestOrganizationsClaimIntoOrganizationInventory) (*ResponseOrganizationsClaimIntoOrganizationInventory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/claim"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5388,20 +6088,56 @@ func (s *OrganizationsService) ClaimIntoOrganizationInventory(organizationID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsClaimIntoOrganizationInventory).
-		// SetResult(&ResponseOrganizationsClaimIntoOrganizationInventory{}).
+		SetResult(&ResponseOrganizationsClaimIntoOrganizationInventory{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ClaimIntoOrganizationInventory")
+		return nil, response, fmt.Errorf("error with operation ClaimIntoOrganizationInventory")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsClaimIntoOrganizationInventory)
+	return result, response, err
+
+}
+
+//CreateOrganizationInventoryDevicesSwapsBulk Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
+/* Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *OrganizationsService) CreateOrganizationInventoryDevicesSwapsBulk(organizationID string, requestOrganizationsCreateOrganizationInventoryDevicesSwapsBulk *RequestOrganizationsCreateOrganizationInventoryDevicesSwapsBulk) (*ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulk, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsCreateOrganizationInventoryDevicesSwapsBulk).
+		SetResult(&ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulk{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationInventoryDevicesSwapsBulk")
+	}
+
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationInventoryDevicesSwapsBulk)
+	return result, response, err
 
 }
 
@@ -5517,7 +6253,7 @@ func (s *OrganizationsService) CreateOrganizationInventoryOnboardingCloudMonitor
 
 */
 
-func (s *OrganizationsService) ReleaseFromOrganizationInventory(organizationID string, requestOrganizationsReleaseFromOrganizationInventory *RequestOrganizationsReleaseFromOrganizationInventory) (*resty.Response, error) {
+func (s *OrganizationsService) ReleaseFromOrganizationInventory(organizationID string, requestOrganizationsReleaseFromOrganizationInventory *RequestOrganizationsReleaseFromOrganizationInventory) (*ResponseOrganizationsReleaseFromOrganizationInventory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/release"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5526,20 +6262,21 @@ func (s *OrganizationsService) ReleaseFromOrganizationInventory(organizationID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsReleaseFromOrganizationInventory).
-		// SetResult(&ResponseOrganizationsReleaseFromOrganizationInventory{}).
+		SetResult(&ResponseOrganizationsReleaseFromOrganizationInventory{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation ReleaseFromOrganizationInventory")
+		return nil, response, fmt.Errorf("error with operation ReleaseFromOrganizationInventory")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsReleaseFromOrganizationInventory)
+	return result, response, err
 
 }
 
@@ -5761,7 +6498,7 @@ func (s *OrganizationsService) CombineOrganizationNetworks(organizationID string
 
 */
 
-func (s *OrganizationsService) CreateOrganizationPolicyObject(organizationID string, requestOrganizationsCreateOrganizationPolicyObject *RequestOrganizationsCreateOrganizationPolicyObject) (*resty.Response, error) {
+func (s *OrganizationsService) CreateOrganizationPolicyObject(organizationID string, requestOrganizationsCreateOrganizationPolicyObject *RequestOrganizationsCreateOrganizationPolicyObject) (*ResponseOrganizationsCreateOrganizationPolicyObject, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5770,20 +6507,21 @@ func (s *OrganizationsService) CreateOrganizationPolicyObject(organizationID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsCreateOrganizationPolicyObject).
-		// SetResult(&ResponseOrganizationsCreateOrganizationPolicyObject{}).
+		SetResult(&ResponseOrganizationsCreateOrganizationPolicyObject{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationPolicyObject")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationPolicyObject")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationPolicyObject)
+	return result, response, err
 
 }
 
@@ -5795,7 +6533,7 @@ func (s *OrganizationsService) CreateOrganizationPolicyObject(organizationID str
 
 */
 
-func (s *OrganizationsService) CreateOrganizationPolicyObjectsGroup(organizationID string, requestOrganizationsCreateOrganizationPolicyObjectsGroup *RequestOrganizationsCreateOrganizationPolicyObjectsGroup) (*resty.Response, error) {
+func (s *OrganizationsService) CreateOrganizationPolicyObjectsGroup(organizationID string, requestOrganizationsCreateOrganizationPolicyObjectsGroup *RequestOrganizationsCreateOrganizationPolicyObjectsGroup) (*ResponseOrganizationsCreateOrganizationPolicyObjectsGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/groups"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5804,20 +6542,21 @@ func (s *OrganizationsService) CreateOrganizationPolicyObjectsGroup(organization
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsCreateOrganizationPolicyObjectsGroup).
-		// SetResult(&ResponseOrganizationsCreateOrganizationPolicyObjectsGroup{}).
+		SetResult(&ResponseOrganizationsCreateOrganizationPolicyObjectsGroup{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationPolicyObjectsGroup")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationPolicyObjectsGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationPolicyObjectsGroup)
+	return result, response, err
 
 }
 
@@ -5864,7 +6603,7 @@ func (s *OrganizationsService) CreateOrganizationSamlIDp(organizationID string, 
 
 */
 
-func (s *OrganizationsService) CreateOrganizationSamlRole(organizationID string, requestOrganizationsCreateOrganizationSamlRole *RequestOrganizationsCreateOrganizationSamlRole) (*resty.Response, error) {
+func (s *OrganizationsService) CreateOrganizationSamlRole(organizationID string, requestOrganizationsCreateOrganizationSamlRole *RequestOrganizationsCreateOrganizationSamlRole) (*ResponseOrganizationsCreateOrganizationSamlRole, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/samlRoles"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5873,20 +6612,21 @@ func (s *OrganizationsService) CreateOrganizationSamlRole(organizationID string,
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsCreateOrganizationSamlRole).
-		// SetResult(&ResponseOrganizationsCreateOrganizationSamlRole{}).
+		SetResult(&ResponseOrganizationsCreateOrganizationSamlRole{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationSamlRole")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationSamlRole")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationSamlRole)
+	return result, response, err
 
 }
 
@@ -5928,7 +6668,7 @@ func (s *OrganizationsService) UpdateOrganization(organizationID string, request
 @param organizationID organizationId path parameter. Organization ID
 @param actionBatchID actionBatchId path parameter. Action batch ID
 */
-func (s *OrganizationsService) UpdateOrganizationActionBatch(organizationID string, actionBatchID string, requestOrganizationsUpdateOrganizationActionBatch *RequestOrganizationsUpdateOrganizationActionBatch) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationActionBatch(organizationID string, actionBatchID string, requestOrganizationsUpdateOrganizationActionBatch *RequestOrganizationsUpdateOrganizationActionBatch) (*ResponseOrganizationsUpdateOrganizationActionBatch, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/actionBatches/{actionBatchId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5938,19 +6678,21 @@ func (s *OrganizationsService) UpdateOrganizationActionBatch(organizationID stri
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationActionBatch).
+		SetResult(&ResponseOrganizationsUpdateOrganizationActionBatch{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationActionBatch")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationActionBatch")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationActionBatch)
+	return result, response, err
 
 }
 
@@ -6122,7 +6864,7 @@ func (s *OrganizationsService) UpdateOrganizationAdmin(organizationID string, ad
 @param organizationID organizationId path parameter. Organization ID
 @param alertConfigID alertConfigId path parameter. Alert config ID
 */
-func (s *OrganizationsService) UpdateOrganizationAlertsProfile(organizationID string, alertConfigID string, requestOrganizationsUpdateOrganizationAlertsProfile *RequestOrganizationsUpdateOrganizationAlertsProfile) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationAlertsProfile(organizationID string, alertConfigID string, requestOrganizationsUpdateOrganizationAlertsProfile *RequestOrganizationsUpdateOrganizationAlertsProfile) (*ResponseOrganizationsUpdateOrganizationAlertsProfile, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/alerts/profiles/{alertConfigId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6132,19 +6874,21 @@ func (s *OrganizationsService) UpdateOrganizationAlertsProfile(organizationID st
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationAlertsProfile).
+		SetResult(&ResponseOrganizationsUpdateOrganizationAlertsProfile{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationAlertsProfile")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationAlertsProfile")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationAlertsProfile)
+	return result, response, err
 
 }
 
@@ -6220,7 +6964,7 @@ func (s *OrganizationsService) UpdateOrganizationBrandingPolicy(organizationID s
 @param organizationID organizationId path parameter. Organization ID
 @param configTemplateID configTemplateId path parameter. Config template ID
 */
-func (s *OrganizationsService) UpdateOrganizationConfigTemplate(organizationID string, configTemplateID string, requestOrganizationsUpdateOrganizationConfigTemplate *RequestOrganizationsUpdateOrganizationConfigTemplate) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationConfigTemplate(organizationID string, configTemplateID string, requestOrganizationsUpdateOrganizationConfigTemplate *RequestOrganizationsUpdateOrganizationConfigTemplate) (*ResponseOrganizationsUpdateOrganizationConfigTemplate, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates/{configTemplateId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6230,19 +6974,21 @@ func (s *OrganizationsService) UpdateOrganizationConfigTemplate(organizationID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationConfigTemplate).
+		SetResult(&ResponseOrganizationsUpdateOrganizationConfigTemplate{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationConfigTemplate")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationConfigTemplate")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationConfigTemplate)
+	return result, response, err
 
 }
 
@@ -6252,7 +6998,7 @@ func (s *OrganizationsService) UpdateOrganizationConfigTemplate(organizationID s
 @param organizationID organizationId path parameter. Organization ID
 @param optInID optInId path parameter. Opt in ID
 */
-func (s *OrganizationsService) UpdateOrganizationEarlyAccessFeaturesOptIn(organizationID string, optInID string, requestOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn *RequestOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationEarlyAccessFeaturesOptIn(organizationID string, optInID string, requestOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn *RequestOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn) (*ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/earlyAccess/features/optIns/{optInId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6262,19 +7008,21 @@ func (s *OrganizationsService) UpdateOrganizationEarlyAccessFeaturesOptIn(organi
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn).
+		SetResult(&ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationEarlyAccessFeaturesOptIn")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationEarlyAccessFeaturesOptIn")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn)
+	return result, response, err
 
 }
 
@@ -6350,7 +7098,7 @@ func (s *OrganizationsService) UpdateOrganizationLoginSecurity(organizationID st
 @param organizationID organizationId path parameter. Organization ID
 @param policyObjectGroupID policyObjectGroupId path parameter. Policy object group ID
 */
-func (s *OrganizationsService) UpdateOrganizationPolicyObjectsGroup(organizationID string, policyObjectGroupID string, requestOrganizationsUpdateOrganizationPolicyObjectsGroup *RequestOrganizationsUpdateOrganizationPolicyObjectsGroup) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationPolicyObjectsGroup(organizationID string, policyObjectGroupID string, requestOrganizationsUpdateOrganizationPolicyObjectsGroup *RequestOrganizationsUpdateOrganizationPolicyObjectsGroup) (*ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/groups/{policyObjectGroupId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6360,19 +7108,21 @@ func (s *OrganizationsService) UpdateOrganizationPolicyObjectsGroup(organization
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationPolicyObjectsGroup).
+		SetResult(&ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationPolicyObjectsGroup")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationPolicyObjectsGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup)
+	return result, response, err
 
 }
 
@@ -6382,7 +7132,7 @@ func (s *OrganizationsService) UpdateOrganizationPolicyObjectsGroup(organization
 @param organizationID organizationId path parameter. Organization ID
 @param policyObjectID policyObjectId path parameter. Policy object ID
 */
-func (s *OrganizationsService) UpdateOrganizationPolicyObject(organizationID string, policyObjectID string, requestOrganizationsUpdateOrganizationPolicyObject *RequestOrganizationsUpdateOrganizationPolicyObject) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationPolicyObject(organizationID string, policyObjectID string, requestOrganizationsUpdateOrganizationPolicyObject *RequestOrganizationsUpdateOrganizationPolicyObject) (*ResponseOrganizationsUpdateOrganizationPolicyObject, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/{policyObjectId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6392,19 +7142,21 @@ func (s *OrganizationsService) UpdateOrganizationPolicyObject(organizationID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationPolicyObject).
+		SetResult(&ResponseOrganizationsUpdateOrganizationPolicyObject{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationPolicyObject")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationPolicyObject")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationPolicyObject)
+	return result, response, err
 
 }
 
@@ -6513,7 +7265,7 @@ func (s *OrganizationsService) UpdateOrganizationSamlRole(organizationID string,
 
 @param organizationID organizationId path parameter. Organization ID
 */
-func (s *OrganizationsService) UpdateOrganizationSNMP(organizationID string, requestOrganizationsUpdateOrganizationSnmp *RequestOrganizationsUpdateOrganizationSNMP) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationSNMP(organizationID string, requestOrganizationsUpdateOrganizationSnmp *RequestOrganizationsUpdateOrganizationSNMP) (*ResponseOrganizationsUpdateOrganizationSNMP, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/snmp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6522,19 +7274,21 @@ func (s *OrganizationsService) UpdateOrganizationSNMP(organizationID string, req
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationSnmp).
+		SetResult(&ResponseOrganizationsUpdateOrganizationSNMP{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationSnmp")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationSnmp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationSNMP)
+	return result, response, err
 
 }
 

--- a/sdk/sensor.go
+++ b/sdk/sensor.go
@@ -25,25 +25,24 @@ type GetOrganizationSensorReadingsHistoryQueryParams struct {
 	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 7 days. The default is 2 hours.
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter readings by network.
 	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter readings by sensor.
-	Metrics       []string `url:"metrics[],omitempty"`     //Types of sensor readings to retrieve. If no metrics are supplied, all available types of readings will be retrieved. Allowed values are battery, button, door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Metrics       []string `url:"metrics[],omitempty"`     //Types of sensor readings to retrieve. If no metrics are supplied, all available types of readings will be retrieved. Allowed values are apparentPower, battery, button, co2, current, door, downstreamPower, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, remoteLockoutSwitch, temperature, tvoc, voltage, and water.
 }
 type GetOrganizationSensorReadingsLatestQueryParams struct {
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 100. Default is 100.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter readings by network.
 	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter readings by sensor.
-	Metrics       []string `url:"metrics[],omitempty"`     //Types of sensor readings to retrieve. If no metrics are supplied, all available types of readings will be retrieved. Allowed values are battery, button, door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Metrics       []string `url:"metrics[],omitempty"`     //Types of sensor readings to retrieve. If no metrics are supplied, all available types of readings will be retrieved. Allowed values are apparentPower, battery, button, co2, current, door, downstreamPower, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, remoteLockoutSwitch, temperature, tvoc, voltage, and water.
 }
 
-type ResponseSensorGetDeviceSensorRelationships []ResponseItemSensorGetDeviceSensorRelationships // Array of ResponseSensorGetDeviceSensorRelationships
-type ResponseItemSensorGetDeviceSensorRelationships struct {
-	Livestream *ResponseItemSensorGetDeviceSensorRelationshipsLivestream `json:"livestream,omitempty"` // A role defined between an MT sensor and an MV camera that adds the camera's livestream to the sensor's details page. Snapshots from the camera will also appear in alert notifications that the sensor triggers.
+type ResponseSensorGetDeviceSensorRelationships struct {
+	Livestream *ResponseSensorGetDeviceSensorRelationshipsLivestream `json:"livestream,omitempty"` // A role defined between an MT sensor and an MV camera that adds the camera's livestream to the sensor's details page. Snapshots from the camera will also appear in alert notifications that the sensor triggers.
 }
-type ResponseItemSensorGetDeviceSensorRelationshipsLivestream struct {
-	RelatedDevices *[]ResponseItemSensorGetDeviceSensorRelationshipsLivestreamRelatedDevices `json:"relatedDevices,omitempty"` // An array of the related devices for the role
+type ResponseSensorGetDeviceSensorRelationshipsLivestream struct {
+	RelatedDevices *[]ResponseSensorGetDeviceSensorRelationshipsLivestreamRelatedDevices `json:"relatedDevices,omitempty"` // An array of the related devices for the role
 }
-type ResponseItemSensorGetDeviceSensorRelationshipsLivestreamRelatedDevices struct {
+type ResponseSensorGetDeviceSensorRelationshipsLivestreamRelatedDevices struct {
 	ProductType string `json:"productType,omitempty"` // The product type of the related device
 	Serial      string `json:"serial,omitempty"`      // The serial of the related device
 }
@@ -62,13 +61,21 @@ type ResponseSensorGetNetworkSensorAlertsCurrentOverviewByMetric struct {
 	SupportedMetrics []string                                                           `json:"supportedMetrics,omitempty"` // List of metrics that are supported for alerts, based on available sensor devices in the network
 }
 type ResponseSensorGetNetworkSensorAlertsCurrentOverviewByMetricCounts struct {
+	ApparentPower    *int                                                                    `json:"apparentPower,omitempty"`    // Number of sensors that are currently alerting due to apparent power readings
+	Co2              *int                                                                    `json:"co2,omitempty"`              // Number of sensors that are currently alerting due to CO2 readings
+	Current          *int                                                                    `json:"current,omitempty"`          // Number of sensors that are currently alerting due to electrical current readings
 	Door             *int                                                                    `json:"door,omitempty"`             // Number of sensors that are currently alerting due to an open door
+	Frequency        *int                                                                    `json:"frequency,omitempty"`        // Number of sensors that are currently alerting due to frequency readings
 	Humidity         *int                                                                    `json:"humidity,omitempty"`         // Number of sensors that are currently alerting due to humidity readings
 	IndoorAirQuality *int                                                                    `json:"indoorAirQuality,omitempty"` // Number of sensors that are currently alerting due to indoor air quality readings
 	Noise            *ResponseSensorGetNetworkSensorAlertsCurrentOverviewByMetricCountsNoise `json:"noise,omitempty"`            // Object containing the number of sensors that are currently alerting due to noise readings
 	Pm25             *int                                                                    `json:"pm25,omitempty"`             // Number of sensors that are currently alerting due to PM2.5 readings
+	PowerFactor      *int                                                                    `json:"powerFactor,omitempty"`      // Number of sensors that are currently alerting due to power factor readings
+	RealPower        *int                                                                    `json:"realPower,omitempty"`        // Number of sensors that are currently alerting due to real power readings
 	Temperature      *int                                                                    `json:"temperature,omitempty"`      // Number of sensors that are currently alerting due to temperature readings
 	Tvoc             *int                                                                    `json:"tvoc,omitempty"`             // Number of sensors that are currently alerting due to TVOC readings
+	UpstreamPower    *int                                                                    `json:"upstreamPower,omitempty"`    // Number of sensors that are currently alerting due to an upstream power outage
+	Voltage          *int                                                                    `json:"voltage,omitempty"`          // Number of sensors that are currently alerting due to voltage readings
 	Water            *int                                                                    `json:"water,omitempty"`            // Number of sensors that are currently alerting due to the presence of water
 }
 type ResponseSensorGetNetworkSensorAlertsCurrentOverviewByMetricCountsNoise struct {
@@ -81,13 +88,21 @@ type ResponseItemSensorGetNetworkSensorAlertsOverviewByMetric struct {
 	StartTs string                                                          `json:"startTs,omitempty"` // Start of the timespan over which sensor alerts are counted
 }
 type ResponseItemSensorGetNetworkSensorAlertsOverviewByMetricCounts struct {
+	ApparentPower    *int                                                                 `json:"apparentPower,omitempty"`    // Number of sensor alerts that occurred due to apparent power readings
+	Co2              *int                                                                 `json:"co2,omitempty"`              // Number of sensors that are currently alerting due to CO2 readings
+	Current          *int                                                                 `json:"current,omitempty"`          // Number of sensor alerts that occurred due to electrical current readings
 	Door             *int                                                                 `json:"door,omitempty"`             // Number of sensor alerts that occurred due to an open door
+	Frequency        *int                                                                 `json:"frequency,omitempty"`        // Number of sensor alerts that occurred due to frequency readings
 	Humidity         *int                                                                 `json:"humidity,omitempty"`         // Number of sensor alerts that occurred due to humidity readings
 	IndoorAirQuality *int                                                                 `json:"indoorAirQuality,omitempty"` // Number of sensor alerts that occurred due to indoor air quality readings
 	Noise            *ResponseItemSensorGetNetworkSensorAlertsOverviewByMetricCountsNoise `json:"noise,omitempty"`            // Object containing the number of sensor alerts that occurred due to noise readings
 	Pm25             *int                                                                 `json:"pm25,omitempty"`             // Number of sensor alerts that occurred due to PM2.5 readings
+	PowerFactor      *int                                                                 `json:"powerFactor,omitempty"`      // Number of sensor alerts that occurred due to power factor readings
+	RealPower        *int                                                                 `json:"realPower,omitempty"`        // Number of sensor alerts that occurred due to real power readings
 	Temperature      *int                                                                 `json:"temperature,omitempty"`      // Number of sensor alerts that occurred due to temperature readings
 	Tvoc             *int                                                                 `json:"tvoc,omitempty"`             // Number of sensor alerts that occurred due to TVOC readings
+	UpstreamPower    *int                                                                 `json:"upstreamPower,omitempty"`    // Number of sensor alerts that occurred due to upstream power outages
+	Voltage          *int                                                                 `json:"voltage,omitempty"`          // Number of sensor alerts that occurred due to voltage readings
 	Water            *int                                                                 `json:"water,omitempty"`            // Number of sensor alerts that occurred due to the presence of water
 }
 type ResponseItemSensorGetNetworkSensorAlertsOverviewByMetricCountsNoise struct {
@@ -98,28 +113,44 @@ type ResponseItemSensorGetNetworkSensorAlertsProfiles struct {
 	Conditions *[]ResponseItemSensorGetNetworkSensorAlertsProfilesConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                        `json:"name,omitempty"`       // Name of the sensor alert profile.
 	ProfileID  string                                                        `json:"profileId,omitempty"`  // ID of the sensor alert profile.
-	Recipients *ResponseItemSensorGetNetworkSensorAlertsProfilesRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *ResponseItemSensorGetNetworkSensorAlertsProfilesRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *ResponseItemSensorGetNetworkSensorAlertsProfilesSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                      `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditions struct {
-	Direction string                                                               `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                                 `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                               `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                               `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                                 `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                               `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThreshold struct {
+	ApparentPower    *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -140,6 +171,12 @@ type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdPm25 str
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -148,6 +185,12 @@ type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdTemperat
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.
@@ -165,28 +208,44 @@ type ResponseSensorCreateNetworkSensorAlertsProfile struct {
 	Conditions *[]ResponseSensorCreateNetworkSensorAlertsProfileConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                      `json:"name,omitempty"`       // Name of the sensor alert profile.
 	ProfileID  string                                                      `json:"profileId,omitempty"`  // ID of the sensor alert profile.
-	Recipients *ResponseSensorCreateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *ResponseSensorCreateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *ResponseSensorCreateNetworkSensorAlertsProfileSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                    `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditions struct {
-	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
+	ApparentPower    *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -207,6 +266,12 @@ type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdPm25 struc
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -215,6 +280,12 @@ type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperatur
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.
@@ -232,28 +303,44 @@ type ResponseSensorGetNetworkSensorAlertsProfile struct {
 	Conditions *[]ResponseSensorGetNetworkSensorAlertsProfileConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                   `json:"name,omitempty"`       // Name of the sensor alert profile.
 	ProfileID  string                                                   `json:"profileId,omitempty"`  // ID of the sensor alert profile.
-	Recipients *ResponseSensorGetNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *ResponseSensorGetNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *ResponseSensorGetNetworkSensorAlertsProfileSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                 `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditions struct {
-	Direction string                                                          `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                            `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                          `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                          `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                            `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                          `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *ResponseSensorGetNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThreshold struct {
+	ApparentPower    *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -274,6 +361,12 @@ type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdPm25 struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -282,6 +375,12 @@ type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdTemperature s
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.
@@ -299,28 +398,44 @@ type ResponseSensorUpdateNetworkSensorAlertsProfile struct {
 	Conditions *[]ResponseSensorUpdateNetworkSensorAlertsProfileConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                      `json:"name,omitempty"`       // Name of the sensor alert profile.
 	ProfileID  string                                                      `json:"profileId,omitempty"`  // ID of the sensor alert profile.
-	Recipients *ResponseSensorUpdateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *ResponseSensorUpdateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *ResponseSensorUpdateNetworkSensorAlertsProfileSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                    `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditions struct {
-	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
+	ApparentPower    *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -341,6 +456,12 @@ type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPm25 struc
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -349,6 +470,12 @@ type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperatur
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.
@@ -397,20 +524,32 @@ type ResponseItemSensorGetNetworkSensorRelationshipsRelationshipsLivestreamRelat
 }
 type ResponseSensorGetOrganizationSensorReadingsHistory []ResponseItemSensorGetOrganizationSensorReadingsHistory // Array of ResponseSensorGetOrganizationSensorReadingsHistory
 type ResponseItemSensorGetOrganizationSensorReadingsHistory struct {
-	Battery          *ResponseItemSensorGetOrganizationSensorReadingsHistoryBattery          `json:"battery,omitempty"`          // Reading for the 'battery' metric. This will only be present if the 'metric' property equals 'battery'.
-	Button           *ResponseItemSensorGetOrganizationSensorReadingsHistoryButton           `json:"button,omitempty"`           // Reading for the 'button' metric. This will only be present if the 'metric' property equals 'button'.
-	Door             *ResponseItemSensorGetOrganizationSensorReadingsHistoryDoor             `json:"door,omitempty"`             // Reading for the 'door' metric. This will only be present if the 'metric' property equals 'door'.
-	Humidity         *ResponseItemSensorGetOrganizationSensorReadingsHistoryHumidity         `json:"humidity,omitempty"`         // Reading for the 'humidity' metric. This will only be present if the 'metric' property equals 'humidity'.
-	IndoorAirQuality *ResponseItemSensorGetOrganizationSensorReadingsHistoryIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Reading for the 'indoorAirQuality' metric. This will only be present if the 'metric' property equals 'indoorAirQuality'.
-	Metric           string                                                                  `json:"metric,omitempty"`           // Type of sensor reading.
-	Network          *ResponseItemSensorGetOrganizationSensorReadingsHistoryNetwork          `json:"network,omitempty"`          // Network to which the sensor belongs.
-	Noise            *ResponseItemSensorGetOrganizationSensorReadingsHistoryNoise            `json:"noise,omitempty"`            // Reading for the 'noise' metric. This will only be present if the 'metric' property equals 'noise'.
-	Pm25             *ResponseItemSensorGetOrganizationSensorReadingsHistoryPm25             `json:"pm25,omitempty"`             // Reading for the 'pm25' metric. This will only be present if the 'metric' property equals 'pm25'.
-	Serial           string                                                                  `json:"serial,omitempty"`           // Serial number of the sensor that took the reading.
-	Temperature      *ResponseItemSensorGetOrganizationSensorReadingsHistoryTemperature      `json:"temperature,omitempty"`      // Reading for the 'temperature' metric. This will only be present if the 'metric' property equals 'temperature'.
-	Ts               string                                                                  `json:"ts,omitempty"`               // Time at which the reading occurred, in ISO8601 format.
-	Tvoc             *ResponseItemSensorGetOrganizationSensorReadingsHistoryTvoc             `json:"tvoc,omitempty"`             // Reading for the 'tvoc' metric. This will only be present if the 'metric' property equals 'tvoc'.
-	Water            *ResponseItemSensorGetOrganizationSensorReadingsHistoryWater            `json:"water,omitempty"`            // Reading for the 'water' metric. This will only be present if the 'metric' property equals 'water'.
+	ApparentPower       *ResponseItemSensorGetOrganizationSensorReadingsHistoryApparentPower       `json:"apparentPower,omitempty"`       // Reading for the 'apparentPower' metric. This will only be present if the 'metric' property equals 'apparentPower'.
+	Battery             *ResponseItemSensorGetOrganizationSensorReadingsHistoryBattery             `json:"battery,omitempty"`             // Reading for the 'battery' metric. This will only be present if the 'metric' property equals 'battery'.
+	Button              *ResponseItemSensorGetOrganizationSensorReadingsHistoryButton              `json:"button,omitempty"`              // Reading for the 'button' metric. This will only be present if the 'metric' property equals 'button'.
+	Co2                 *ResponseItemSensorGetOrganizationSensorReadingsHistoryCo2                 `json:"co2,omitempty"`                 // Reading for the 'co2' metric. This will only be present if the 'metric' property equals 'co2'.
+	Current             *ResponseItemSensorGetOrganizationSensorReadingsHistoryCurrent             `json:"current,omitempty"`             // Reading for the 'current' metric. This will only be present if the 'metric' property equals 'current'.
+	Door                *ResponseItemSensorGetOrganizationSensorReadingsHistoryDoor                `json:"door,omitempty"`                // Reading for the 'door' metric. This will only be present if the 'metric' property equals 'door'.
+	DownstreamPower     *ResponseItemSensorGetOrganizationSensorReadingsHistoryDownstreamPower     `json:"downstreamPower,omitempty"`     // Reading for the 'downstreamPower' metric. This will only be present if the 'metric' property equals 'downstreamPower'.
+	Frequency           *ResponseItemSensorGetOrganizationSensorReadingsHistoryFrequency           `json:"frequency,omitempty"`           // Reading for the 'frequency' metric. This will only be present if the 'metric' property equals 'frequency'.
+	Humidity            *ResponseItemSensorGetOrganizationSensorReadingsHistoryHumidity            `json:"humidity,omitempty"`            // Reading for the 'humidity' metric. This will only be present if the 'metric' property equals 'humidity'.
+	IndoorAirQuality    *ResponseItemSensorGetOrganizationSensorReadingsHistoryIndoorAirQuality    `json:"indoorAirQuality,omitempty"`    // Reading for the 'indoorAirQuality' metric. This will only be present if the 'metric' property equals 'indoorAirQuality'.
+	Metric              string                                                                     `json:"metric,omitempty"`              // Type of sensor reading.
+	Network             *ResponseItemSensorGetOrganizationSensorReadingsHistoryNetwork             `json:"network,omitempty"`             // Network to which the sensor belongs.
+	Noise               *ResponseItemSensorGetOrganizationSensorReadingsHistoryNoise               `json:"noise,omitempty"`               // Reading for the 'noise' metric. This will only be present if the 'metric' property equals 'noise'.
+	Pm25                *ResponseItemSensorGetOrganizationSensorReadingsHistoryPm25                `json:"pm25,omitempty"`                // Reading for the 'pm25' metric. This will only be present if the 'metric' property equals 'pm25'.
+	PowerFactor         *ResponseItemSensorGetOrganizationSensorReadingsHistoryPowerFactor         `json:"powerFactor,omitempty"`         // Reading for the 'powerFactor' metric. This will only be present if the 'metric' property equals 'powerFactor'.
+	RealPower           *ResponseItemSensorGetOrganizationSensorReadingsHistoryRealPower           `json:"realPower,omitempty"`           // Reading for the 'realPower' metric. This will only be present if the 'metric' property equals 'realPower'.
+	RemoteLockoutSwitch *ResponseItemSensorGetOrganizationSensorReadingsHistoryRemoteLockoutSwitch `json:"remoteLockoutSwitch,omitempty"` // Reading for the 'remoteLockoutSwitch' metric. This will only be present if the 'metric' property equals 'remoteLockoutSwitch'.
+	Serial              string                                                                     `json:"serial,omitempty"`              // Serial number of the sensor that took the reading.
+	Temperature         *ResponseItemSensorGetOrganizationSensorReadingsHistoryTemperature         `json:"temperature,omitempty"`         // Reading for the 'temperature' metric. This will only be present if the 'metric' property equals 'temperature'.
+	Ts                  string                                                                     `json:"ts,omitempty"`                  // Time at which the reading occurred, in ISO8601 format.
+	Tvoc                *ResponseItemSensorGetOrganizationSensorReadingsHistoryTvoc                `json:"tvoc,omitempty"`                // Reading for the 'tvoc' metric. This will only be present if the 'metric' property equals 'tvoc'.
+	Voltage             *ResponseItemSensorGetOrganizationSensorReadingsHistoryVoltage             `json:"voltage,omitempty"`             // Reading for the 'voltage' metric. This will only be present if the 'metric' property equals 'voltage'.
+	Water               *ResponseItemSensorGetOrganizationSensorReadingsHistoryWater               `json:"water,omitempty"`               // Reading for the 'water' metric. This will only be present if the 'metric' property equals 'water'.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Apparent power reading in volt-amperes.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryBattery struct {
 	Percentage *int `json:"percentage,omitempty"` // Remaining battery life.
@@ -418,8 +557,20 @@ type ResponseItemSensorGetOrganizationSensorReadingsHistoryBattery struct {
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryButton struct {
 	PressType string `json:"pressType,omitempty"` // Type of button press that occurred.
 }
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryCo2 struct {
+	Concentration *int `json:"concentration,omitempty"` // CO2 reading in parts per million.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Electrical current reading in amperes.
+}
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryDoor struct {
 	Open *bool `json:"open,omitempty"` // True if the door is open.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryDownstreamPower struct {
+	Enabled *bool `json:"enabled,omitempty"` // True if power is turned on to the device that is connected downstream of the MT40 power monitor.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Electrical current frequency reading in hertz.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryHumidity struct {
 	RelativePercentage *int `json:"relativePercentage,omitempty"` // Humidity reading in %RH.
@@ -440,12 +591,24 @@ type ResponseItemSensorGetOrganizationSensorReadingsHistoryNoiseAmbient struct {
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryPm25 struct {
 	Concentration *int `json:"concentration,omitempty"` // PM2.5 reading in micrograms per cubic meter.
 }
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Power factor reading as a percentage.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Real power reading in watts.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryRemoteLockoutSwitch struct {
+	Locked *bool `json:"locked,omitempty"` // True if power controls are disabled via the MT40's physical remote lockout switch.
+}
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Temperature reading in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Temperature reading in degrees Fahrenheit.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryTvoc struct {
 	Concentration *int `json:"concentration,omitempty"` // TVOC reading in micrograms per cubic meter.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsHistoryVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Voltage reading in volts.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsHistoryWater struct {
 	Present *bool `json:"present,omitempty"` // True if water is detected.
@@ -461,18 +624,30 @@ type ResponseItemSensorGetOrganizationSensorReadingsLatestNetwork struct {
 	Name string `json:"name,omitempty"` // Name of the network.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadings struct {
-	Battery          *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsBattery          `json:"battery,omitempty"`          // Reading for the 'battery' metric. This will only be present if the 'metric' property equals 'battery'.
-	Button           *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsButton           `json:"button,omitempty"`           // Reading for the 'button' metric. This will only be present if the 'metric' property equals 'button'.
-	Door             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsDoor             `json:"door,omitempty"`             // Reading for the 'door' metric. This will only be present if the 'metric' property equals 'door'.
-	Humidity         *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsHumidity         `json:"humidity,omitempty"`         // Reading for the 'humidity' metric. This will only be present if the 'metric' property equals 'humidity'.
-	IndoorAirQuality *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Reading for the 'indoorAirQuality' metric. This will only be present if the 'metric' property equals 'indoorAirQuality'.
-	Metric           string                                                                         `json:"metric,omitempty"`           // Type of sensor reading.
-	Noise            *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsNoise            `json:"noise,omitempty"`            // Reading for the 'noise' metric. This will only be present if the 'metric' property equals 'noise'.
-	Pm25             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsPm25             `json:"pm25,omitempty"`             // Reading for the 'pm25' metric. This will only be present if the 'metric' property equals 'pm25'.
-	Temperature      *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTemperature      `json:"temperature,omitempty"`      // Reading for the 'temperature' metric. This will only be present if the 'metric' property equals 'temperature'.
-	Ts               string                                                                         `json:"ts,omitempty"`               // Time at which the reading occurred, in ISO8601 format.
-	Tvoc             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTvoc             `json:"tvoc,omitempty"`             // Reading for the 'tvoc' metric. This will only be present if the 'metric' property equals 'tvoc'.
-	Water            *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsWater            `json:"water,omitempty"`            // Reading for the 'water' metric. This will only be present if the 'metric' property equals 'water'.
+	ApparentPower       *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsApparentPower       `json:"apparentPower,omitempty"`       // Reading for the 'apparentPower' metric. This will only be present if the 'metric' property equals 'apparentPower'.
+	Battery             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsBattery             `json:"battery,omitempty"`             // Reading for the 'battery' metric. This will only be present if the 'metric' property equals 'battery'.
+	Button              *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsButton              `json:"button,omitempty"`              // Reading for the 'button' metric. This will only be present if the 'metric' property equals 'button'.
+	Co2                 *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsCo2                 `json:"co2,omitempty"`                 // Reading for the 'co2' metric. This will only be present if the 'metric' property equals 'co2'.
+	Current             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsCurrent             `json:"current,omitempty"`             // Reading for the 'current' metric. This will only be present if the 'metric' property equals 'current'.
+	Door                *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsDoor                `json:"door,omitempty"`                // Reading for the 'door' metric. This will only be present if the 'metric' property equals 'door'.
+	DownstreamPower     *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsDownstreamPower     `json:"downstreamPower,omitempty"`     // Reading for the 'downstreamPower' metric. This will only be present if the 'metric' property equals 'downstreamPower'.
+	Frequency           *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsFrequency           `json:"frequency,omitempty"`           // Reading for the 'frequency' metric. This will only be present if the 'metric' property equals 'frequency'.
+	Humidity            *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsHumidity            `json:"humidity,omitempty"`            // Reading for the 'humidity' metric. This will only be present if the 'metric' property equals 'humidity'.
+	IndoorAirQuality    *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsIndoorAirQuality    `json:"indoorAirQuality,omitempty"`    // Reading for the 'indoorAirQuality' metric. This will only be present if the 'metric' property equals 'indoorAirQuality'.
+	Metric              string                                                                            `json:"metric,omitempty"`              // Type of sensor reading.
+	Noise               *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsNoise               `json:"noise,omitempty"`               // Reading for the 'noise' metric. This will only be present if the 'metric' property equals 'noise'.
+	Pm25                *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsPm25                `json:"pm25,omitempty"`                // Reading for the 'pm25' metric. This will only be present if the 'metric' property equals 'pm25'.
+	PowerFactor         *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsPowerFactor         `json:"powerFactor,omitempty"`         // Reading for the 'powerFactor' metric. This will only be present if the 'metric' property equals 'powerFactor'.
+	RealPower           *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsRealPower           `json:"realPower,omitempty"`           // Reading for the 'realPower' metric. This will only be present if the 'metric' property equals 'realPower'.
+	RemoteLockoutSwitch *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsRemoteLockoutSwitch `json:"remoteLockoutSwitch,omitempty"` // Reading for the 'remoteLockoutSwitch' metric. This will only be present if the 'metric' property equals 'remoteLockoutSwitch'.
+	Temperature         *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTemperature         `json:"temperature,omitempty"`         // Reading for the 'temperature' metric. This will only be present if the 'metric' property equals 'temperature'.
+	Ts                  string                                                                            `json:"ts,omitempty"`                  // Time at which the reading occurred, in ISO8601 format.
+	Tvoc                *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTvoc                `json:"tvoc,omitempty"`                // Reading for the 'tvoc' metric. This will only be present if the 'metric' property equals 'tvoc'.
+	Voltage             *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsVoltage             `json:"voltage,omitempty"`             // Reading for the 'voltage' metric. This will only be present if the 'metric' property equals 'voltage'.
+	Water               *ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsWater               `json:"water,omitempty"`               // Reading for the 'water' metric. This will only be present if the 'metric' property equals 'water'.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Apparent power reading in volt-amperes.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsBattery struct {
 	Percentage *int `json:"percentage,omitempty"` // Remaining battery life.
@@ -480,8 +655,20 @@ type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsBattery struct
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsButton struct {
 	PressType string `json:"pressType,omitempty"` // Type of button press that occurred.
 }
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsCo2 struct {
+	Concentration *int `json:"concentration,omitempty"` // CO2 reading in parts per million.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Electrical current reading in amperes.
+}
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsDoor struct {
 	Open *bool `json:"open,omitempty"` // True if the door is open.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsDownstreamPower struct {
+	Enabled *bool `json:"enabled,omitempty"` // True if power is turned on to the device that is connected downstream of the MT40 power monitor.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Electrical current frequency reading in hertz.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsHumidity struct {
 	RelativePercentage *int `json:"relativePercentage,omitempty"` // Humidity reading in %RH.
@@ -498,12 +685,24 @@ type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsNoiseAmbient s
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsPm25 struct {
 	Concentration *int `json:"concentration,omitempty"` // PM2.5 reading in micrograms per cubic meter.
 }
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Power factor reading as a percentage.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Real power reading in watts.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsRemoteLockoutSwitch struct {
+	Locked *bool `json:"locked,omitempty"` // True if power controls are disabled via the MT40's physical remote lockout switch.
+}
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Temperature reading in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Temperature reading in degrees Fahrenheit.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsTvoc struct {
 	Concentration *int `json:"concentration,omitempty"` // TVOC reading in micrograms per cubic meter.
+}
+type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Voltage reading in volts.
 }
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsWater struct {
 	Present *bool `json:"present,omitempty"` // True if water is detected.
@@ -520,28 +719,44 @@ type RequestSensorUpdateDeviceSensorRelationshipsLivestreamRelatedDevices struct
 type RequestSensorCreateNetworkSensorAlertsProfile struct {
 	Conditions *[]RequestSensorCreateNetworkSensorAlertsProfileConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                     `json:"name,omitempty"`       // Name of the sensor alert profile.
-	Recipients *RequestSensorCreateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *RequestSensorCreateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *RequestSensorCreateNetworkSensorAlertsProfileSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                   `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditions struct {
-	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *RequestSensorCreateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
+	ApparentPower    *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -562,6 +777,12 @@ type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdPm25 struct
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -570,6 +791,12 @@ type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdTemperature
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.
@@ -585,28 +812,44 @@ type RequestSensorCreateNetworkSensorAlertsProfileSchedule struct {
 type RequestSensorUpdateNetworkSensorAlertsProfile struct {
 	Conditions *[]RequestSensorUpdateNetworkSensorAlertsProfileConditions `json:"conditions,omitempty"` // List of conditions that will cause the profile to send an alert.
 	Name       string                                                     `json:"name,omitempty"`       // Name of the sensor alert profile.
-	Recipients *RequestSensorUpdateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will recieve the alert.
+	Recipients *RequestSensorUpdateNetworkSensorAlertsProfileRecipients   `json:"recipients,omitempty"` // List of recipients that will receive the alert.
 	Schedule   *RequestSensorUpdateNetworkSensorAlertsProfileSchedule     `json:"schedule,omitempty"`   // The sensor schedule to use with the alert profile.
 	Serials    []string                                                   `json:"serials,omitempty"`    // List of device serials assigned to this sensor alert profile.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditions struct {
-	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature and humidity thresholds.
-	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, and 1 hour. Default is 0.
-	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are door, humidity, indoorAirQuality, noise, pm25, temperature, tvoc, and water.
+	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
+	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
+	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
 	Threshold *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
+	ApparentPower    *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Current          *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
+	Frequency        *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
 	Humidity         *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdHumidity         `json:"humidity,omitempty"`         // Humidity threshold. One of 'relativePercentage' or 'quality' must be provided.
 	IndoorAirQuality *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdIndoorAirQuality `json:"indoorAirQuality,omitempty"` // Indoor air quality score threshold. One of 'score' or 'quality' must be provided.
 	Noise            *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdNoise            `json:"noise,omitempty"`            // Noise threshold. 'ambient' must be provided.
 	Pm25             *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPm25             `json:"pm25,omitempty"`             // PM2.5 concentration threshold. One of 'concentration' or 'quality' must be provided.
+	PowerFactor      *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPowerFactor      `json:"powerFactor,omitempty"`      // Power factor threshold. 'percentage' must be provided.
+	RealPower        *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdRealPower        `json:"realPower,omitempty"`        // Real power threshold. 'draw' must be provided.
 	Temperature      *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperature      `json:"temperature,omitempty"`      // Temperature threshold. One of 'celsius', 'fahrenheit', or 'quality' must be provided.
 	Tvoc             *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTvoc             `json:"tvoc,omitempty"`             // TVOC concentration threshold. One of 'concentration' or 'quality' must be provided.
+	UpstreamPower    *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower    `json:"upstreamPower,omitempty"`    // Upstream power threshold. 'outageDetected' must be provided and set to true.
+	Voltage          *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdVoltage          `json:"voltage,omitempty"`          // Voltage threshold. 'level' must be provided.
 	Water            *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdWater            `json:"water,omitempty"`            // Water detection threshold. 'present' must be provided and set to true.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor struct {
 	Open *bool `json:"open,omitempty"` // Alerting threshold for a door open event. Must be set to true.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in hertz. Must be between 0 and 60.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdHumidity struct {
 	Quality            string `json:"quality,omitempty"`            // Alerting threshold as a qualitative humidity level.
@@ -627,6 +870,12 @@ type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPm25 struct
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as PM2.5 parts per million.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative PM2.5 level.
 }
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdPowerFactor struct {
+	Percentage *int `json:"percentage,omitempty"` // Alerting threshold as the ratio of active power to apparent power. Must be between 0 and 100.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdRealPower struct {
+	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in watts. Must be between 0 and 3750.
+}
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperature struct {
 	Celsius    *float64 `json:"celsius,omitempty"`    // Alerting threshold in degrees Celsius.
 	Fahrenheit *float64 `json:"fahrenheit,omitempty"` // Alerting threshold in degrees Fahrenheit.
@@ -635,6 +884,12 @@ type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTemperature
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdTvoc struct {
 	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as TVOC micrograms per cubic meter.
 	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative TVOC level.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdUpstreamPower struct {
+	OutageDetected *bool `json:"outageDetected,omitempty"` // Alerting threshold for an upstream power event. Must be set to true.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdVoltage struct {
+	Level *float64 `json:"level,omitempty"` // Alerting threshold in volts. Must be between 0 and 250.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdWater struct {
 	Present *bool `json:"present,omitempty"` // Alerting threshold for a water detection event. Must be set to true.

--- a/sdk/sm.go
+++ b/sdk/sm.go
@@ -11,10 +11,12 @@ import (
 type SmService service
 
 type GetNetworkSmDevicesQueryParams struct {
-	Fields        []string `url:"fields[],omitempty"`      //Additional fields that will be displayed for each device.     The default fields are: id, name, tags, ssid, wifiMac, osName, systemModel, uuid, and serialNumber. The additional fields are: ip,     systemType, availableDeviceCapacity, kioskAppName, biosVersion, lastConnected, missingAppsCount, userSuppliedAddress, location, lastUser,     ownerEmail, ownerUsername, osBuild, publicIp, phoneNumber, diskInfoJson, deviceCapacity, isManaged, hadMdm, isSupervised, meid, imei, iccid,     simCarrierNetwork, cellularDataUsed, isHotspotEnabled, createdAt, batteryEstCharge, quarantined, avName, avRunning, asName, fwName,     isRooted, loginRequired, screenLockEnabled, screenLockDelay, autoLoginDisabled, autoTags, hasMdm, hasDesktopAgent, diskEncryptionEnabled,     hardwareEncryptionCaps, passCodeLock, usesHardwareKeystore, androidSecurityPatchVersion, and url.
+	Fields        []string `url:"fields[],omitempty"`      //Additional fields that will be displayed for each device.     The default fields are: id, name, tags, ssid, wifiMac, osName, systemModel, uuid, and serialNumber. The additional fields are: ip,     systemType, availableDeviceCapacity, kioskAppName, biosVersion, lastConnected, missingAppsCount, userSuppliedAddress, location, lastUser,     ownerEmail, ownerUsername, osBuild, publicIp, phoneNumber, diskInfoJson, deviceCapacity, isManaged, hadMdm, isSupervised, meid, imei, iccid,     simCarrierNetwork, cellularDataUsed, isHotspotEnabled, createdAt, batteryEstCharge, quarantined, avName, avRunning, asName, fwName,     isRooted, loginRequired, screenLockEnabled, screenLockDelay, autoLoginDisabled, autoTags, hasMdm, hasDesktopAgent, diskEncryptionEnabled,     hardwareEncryptionCaps, passCodeLock, usesHardwareKeystore, androidSecurityPatchVersion, cellular, and url.
 	WifiMacs      []string `url:"wifiMacs[],omitempty"`    //Filter devices by wifi mac(s).
 	Serials       []string `url:"serials[],omitempty"`     //Filter devices by serial(s).
 	IDs           []string `url:"ids[],omitempty"`         //Filter devices by id(s).
+	UUIDs         []string `url:"uuids[],omitempty"`       //Filter devices by uuid(s).
+	SystemTypes   []string `url:"systemTypes[],omitempty"` //Filter devices by system type(s).
 	Scope         []string `url:"scope[],omitempty"`       //Specify a scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags.
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -40,6 +42,9 @@ type GetNetworkSmDevicePerformanceHistoryQueryParams struct {
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
+type GetNetworkSmProfilesQueryParams struct {
+	PayloadTypes []string `url:"payloadTypes[],omitempty"` //Filter by payload types
+}
 type GetNetworkSmTargetGroupsQueryParams struct {
 	WithDetails bool `url:"withDetails,omitempty"` //Boolean indicating if the the ids of the devices or users scoped by the target group should be included in the response
 }
@@ -61,6 +66,17 @@ type GetNetworkSmUsersQueryParams struct {
 	Usernames []string `url:"usernames[],omitempty"` //Filter users by username(s).
 	Emails    []string `url:"emails[],omitempty"`    //Filter users by email(s).
 	Scope     []string `url:"scope[],omitempty"`     //Specifiy a scope (one of all, none, withAny, withAll, withoutAny, withoutAll) and a set of tags.
+}
+type GetOrganizationSmAdminsRolesQueryParams struct {
+	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 50.
+	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 50.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter Sentry Policies by Network Id
 }
 
 type ResponseSmCreateNetworkSmBypassActivationLockAttempt interface{}
@@ -119,6 +135,12 @@ type ResponseItemSmModifyNetworkSmDevicesTags struct {
 type ResponseSmMoveNetworkSmDevices struct {
 	IDs        []string `json:"ids,omitempty"`        // The Meraki Ids of the set of devices.
 	NewNetwork string   `json:"newNetwork,omitempty"` // The network to which the devices was moved.
+}
+type ResponseSmRebootNetworkSmDevices struct {
+	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of endpoints.
+}
+type ResponseSmShutdownNetworkSmDevices struct {
+	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of endpoints.
 }
 type ResponseSmWipeNetworkSmDevices struct {
 	ID string `json:"id,omitempty"` // The Meraki Id of the devices.
@@ -266,7 +288,9 @@ type ResponseItemSmGetNetworkSmDeviceSoftwares struct {
 	Vendor            string `json:"vendor,omitempty"`            // The vendor of the software.
 	Version           string `json:"version,omitempty"`           // Full version notation for the software.
 }
-type ResponseSmUnenrollNetworkSmDevice interface{}
+type ResponseSmUnenrollNetworkSmDevice struct {
+	Success *bool `json:"success,omitempty"` // Boolean indicating whether the operation was completed successfully.
+}
 type ResponseSmGetNetworkSmDeviceWLANLists []ResponseItemSmGetNetworkSmDeviceWLANLists // Array of ResponseSmGetNetworkSmDeviceWlanLists
 type ResponseItemSmGetNetworkSmDeviceWLANLists struct {
 	CreatedAt string `json:"createdAt,omitempty"` // When the Meraki record for the wlanList was created.
@@ -275,37 +299,51 @@ type ResponseItemSmGetNetworkSmDeviceWLANLists struct {
 }
 type ResponseSmGetNetworkSmProfiles []ResponseItemSmGetNetworkSmProfiles // Array of ResponseSmGetNetworkSmProfiles
 type ResponseItemSmGetNetworkSmProfiles struct {
-	Description string   `json:"description,omitempty"` // Description of a profile.
-	ID          string   `json:"id,omitempty"`          // ID of a profile.
-	Name        string   `json:"name,omitempty"`        // Name of a profile.
-	Scope       string   `json:"scope,omitempty"`       // Scope of a profile.
-	Tags        []string `json:"tags,omitempty"`        // Tags of a profile.
+	Description  string   `json:"description,omitempty"`  // Description of a profile.
+	ID           string   `json:"id,omitempty"`           // ID of a profile.
+	Name         string   `json:"name,omitempty"`         // Name of a profile.
+	PayloadTypes []string `json:"payloadTypes,omitempty"` // Payloads in the profile.
+	Scope        string   `json:"scope,omitempty"`        // Scope of a profile.
+	Tags         []string `json:"tags,omitempty"`         // Tags of a profile.
 }
 type ResponseSmGetNetworkSmTargetGroups []ResponseItemSmGetNetworkSmTargetGroups // Array of ResponseSmGetNetworkSmTargetGroups
 type ResponseItemSmGetNetworkSmTargetGroups struct {
-	Name  string `json:"name,omitempty"`  //
-	Scope string `json:"scope,omitempty"` //
-	Tags  string `json:"tags,omitempty"`  //
-	Type  string `json:"type,omitempty"`  //
+	ID    string   `json:"id,omitempty"`    // The ID of this target group.
+	Name  string   `json:"name,omitempty"`  // The name of this target group.
+	Scope string   `json:"scope,omitempty"` // The scope of the target group.
+	Tags  []string `json:"tags,omitempty"`  // The tags of the target group.
 }
-type ResponseSmCreateNetworkSmTargetGroup interface{}
+type ResponseSmCreateNetworkSmTargetGroup struct {
+	ID    string   `json:"id,omitempty"`    // The ID of this target group.
+	Name  string   `json:"name,omitempty"`  // The name of this target group.
+	Scope string   `json:"scope,omitempty"` // The scope of the target group.
+	Tags  []string `json:"tags,omitempty"`  // The tags of the target group.
+}
 type ResponseSmGetNetworkSmTargetGroup struct {
-	Name  string `json:"name,omitempty"`  //
-	Scope string `json:"scope,omitempty"` //
-	Tags  string `json:"tags,omitempty"`  //
-	Type  string `json:"type,omitempty"`  //
+	ID    string   `json:"id,omitempty"`    // The ID of this target group.
+	Name  string   `json:"name,omitempty"`  // The name of this target group.
+	Scope string   `json:"scope,omitempty"` // The scope of the target group.
+	Tags  []string `json:"tags,omitempty"`  // The tags of the target group.
 }
-type ResponseSmUpdateNetworkSmTargetGroup interface{}
+type ResponseSmUpdateNetworkSmTargetGroup struct {
+	ID    string   `json:"id,omitempty"`    // The ID of this target group.
+	Name  string   `json:"name,omitempty"`  // The name of this target group.
+	Scope string   `json:"scope,omitempty"` // The scope of the target group.
+	Tags  []string `json:"tags,omitempty"`  // The tags of the target group.
+}
 type ResponseSmGetNetworkSmTrustedAccessConfigs []ResponseItemSmGetNetworkSmTrustedAccessConfigs // Array of ResponseSmGetNetworkSmTrustedAccessConfigs
 type ResponseItemSmGetNetworkSmTrustedAccessConfigs struct {
-	AccessEndAt   string   `json:"accessEndAt,omitempty"`   // time that access ends
-	AccessStartAt string   `json:"accessStartAt,omitempty"` // time that access starts
-	ID            string   `json:"id,omitempty"`            // device ID
-	Name          string   `json:"name,omitempty"`          // device name
-	Scope         string   `json:"scope,omitempty"`         // scope
-	SSIDName      string   `json:"ssidName,omitempty"`      // SSID name
-	Tags          []string `json:"tags,omitempty"`          // device tags
-	TimeboundType string   `json:"timeboundType,omitempty"` // type of access period, either a static range or a dynamic period
+	AccessEndAt                string   `json:"accessEndAt,omitempty"`                // time that access ends
+	AccessStartAt              string   `json:"accessStartAt,omitempty"`              // time that access starts
+	AdditionalEmailText        string   `json:"additionalEmailText,omitempty"`        // Optional email text
+	ID                         string   `json:"id,omitempty"`                         // device ID
+	Name                       string   `json:"name,omitempty"`                       // device name
+	NotifyTimeBeforeAccessEnds *int     `json:"notifyTimeBeforeAccessEnds,omitempty"` // Time before access expiration reminder email sends
+	Scope                      string   `json:"scope,omitempty"`                      // scope
+	SendExpirationEmails       *bool    `json:"sendExpirationEmails,omitempty"`       // Send Email Notifications
+	SSIDName                   string   `json:"ssidName,omitempty"`                   // SSID name
+	Tags                       []string `json:"tags,omitempty"`                       // device tags
+	TimeboundType              string   `json:"timeboundType,omitempty"`              // type of access period, either a static range or a dynamic period
 }
 type ResponseSmGetNetworkSmUserAccessDevices []ResponseItemSmGetNetworkSmUserAccessDevices // Array of ResponseSmGetNetworkSmUserAccessDevices
 type ResponseItemSmGetNetworkSmUserAccessDevices struct {
@@ -378,17 +416,141 @@ type ResponseItemSmGetNetworkSmUserSoftwares struct {
 	Vendor            string `json:"vendor,omitempty"`            // The vendor of the software.
 	Version           string `json:"version,omitempty"`           // Full version notation for the software.
 }
+type ResponseSmGetOrganizationSmAdminsRoles struct {
+	Items *[]ResponseSmGetOrganizationSmAdminsRolesItems `json:"items,omitempty"` // Array of Limited Access Roles
+	Meta  *ResponseSmGetOrganizationSmAdminsRolesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseSmGetOrganizationSmAdminsRolesItems struct {
+	Name   string   `json:"name,omitempty"`   // The name of the limited access role
+	RoleID string   `json:"roleId,omitempty"` // The Id of the limited access role
+	Scope  string   `json:"scope,omitempty"`  // The scope of the limited access role
+	Tags   []string `json:"tags,omitempty"`   // The tags of the limited access role
+}
+type ResponseSmGetOrganizationSmAdminsRolesMeta struct {
+	Counts *ResponseSmGetOrganizationSmAdminsRolesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseSmGetOrganizationSmAdminsRolesMetaCounts struct {
+	Items *ResponseSmGetOrganizationSmAdminsRolesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseSmGetOrganizationSmAdminsRolesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseSmCreateOrganizationSmAdminsRole struct {
+	Name   string   `json:"name,omitempty"`   // The name of the limited access role
+	RoleID string   `json:"roleId,omitempty"` // The Id of the limited access role
+	Scope  string   `json:"scope,omitempty"`  // The scope of the limited access role
+	Tags   []string `json:"tags,omitempty"`   // The tags of the limited access role
+}
+type ResponseSmGetOrganizationSmAdminsRole struct {
+	Name   string   `json:"name,omitempty"`   // The name of the limited access role
+	RoleID string   `json:"roleId,omitempty"` // The Id of the limited access role
+	Scope  string   `json:"scope,omitempty"`  // The scope of the limited access role
+	Tags   []string `json:"tags,omitempty"`   // The tags of the limited access role
+}
+type ResponseSmUpdateOrganizationSmAdminsRole struct {
+	Name   string   `json:"name,omitempty"`   // The name of the limited access role
+	RoleID string   `json:"roleId,omitempty"` // The Id of the limited access role
+	Scope  string   `json:"scope,omitempty"`  // The scope of the limited access role
+	Tags   []string `json:"tags,omitempty"`   // The tags of the limited access role
+}
 type ResponseSmGetOrganizationSmApnsCert struct {
 	Certificate string `json:"certificate,omitempty"` // Organization APNS Certificate used by devices to communication with Apple
 }
+type ResponseSmUpdateOrganizationSmSentryPoliciesAssignments struct {
+	Items *[]ResponseSmUpdateOrganizationSmSentryPoliciesAssignmentsItems `json:"items,omitempty"` // Sentry Group Policies for the Organization keyed by Network Id
+}
+type ResponseSmUpdateOrganizationSmSentryPoliciesAssignmentsItems struct {
+	NetworkID string                                                                  `json:"networkId,omitempty"` // The Id of the Network
+	Policies  *[]ResponseSmUpdateOrganizationSmSentryPoliciesAssignmentsItemsPolicies `json:"policies,omitempty"`  // Array of Sentry Group Policies for the Network
+}
+type ResponseSmUpdateOrganizationSmSentryPoliciesAssignmentsItemsPolicies struct {
+	CreatedAt     string   `json:"createdAt,omitempty"`     // The creation time of the Sentry Policy
+	GroupNumber   string   `json:"groupNumber,omitempty"`   // The number of the Group Policy
+	GroupPolicyID string   `json:"groupPolicyId,omitempty"` // The Id of the Group Policy. This is associated with the network specified by the networkId.
+	LastUpdatedAt string   `json:"lastUpdatedAt,omitempty"` // The last update time of the Sentry Policy
+	NetworkID     string   `json:"networkId,omitempty"`     // The Id of the Network the Sentry Policy is associated with. In a locale, this should be the Wireless Group if present, otherwise the Wired Group.
+	PolicyID      string   `json:"policyId,omitempty"`      // The Id of the Sentry Policy
+	Priority      string   `json:"priority,omitempty"`      // The priority of the Sentry Policy
+	Scope         string   `json:"scope,omitempty"`         // The scope of the Sentry Policy
+	SmNetworkID   string   `json:"smNetworkId,omitempty"`   // The Id of the Systems Manager Network the Sentry Policy is assigned to
+	Tags          []string `json:"tags,omitempty"`          // The tags of the Sentry Policy
+}
+type ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork []ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork // Array of ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork struct {
+	Items *[]ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkItems `json:"items,omitempty"` // Sentry Group Policies for the Organization keyed by the Network or Locale Id the Policy belongs to
+	Meta  *ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkItems struct {
+	NetworkID string                                                                            `json:"networkId,omitempty"` // The Id of the Network
+	Policies  *[]ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkItemsPolicies `json:"policies,omitempty"`  // Array of Sentry Group Policies for the Network
+}
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkItemsPolicies struct {
+	CreatedAt     string   `json:"createdAt,omitempty"`     // The creation time of the Sentry Policy
+	GroupNumber   string   `json:"groupNumber,omitempty"`   // The number of the Group Policy
+	GroupPolicyID string   `json:"groupPolicyId,omitempty"` // The Id of the Group Policy. This is associated with the network specified by the networkId.
+	LastUpdatedAt string   `json:"lastUpdatedAt,omitempty"` // The last update time of the Sentry Policy
+	NetworkID     string   `json:"networkId,omitempty"`     // The Id of the Network the Sentry Policy is associated with. In a locale, this should be the Wireless Group if present, otherwise the Wired Group.
+	PolicyID      string   `json:"policyId,omitempty"`      // The Id of the Sentry Policy
+	Priority      string   `json:"priority,omitempty"`      // The priority of the Sentry Policy
+	Scope         string   `json:"scope,omitempty"`         // The scope of the Sentry Policy
+	SmNetworkID   string   `json:"smNetworkId,omitempty"`   // The Id of the Systems Manager Network the Sentry Policy is assigned to
+	Tags          []string `json:"tags,omitempty"`          // The tags of the Sentry Policy
+}
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMeta struct {
+	Counts *ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMetaCounts struct {
+	Items *ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemSmGetOrganizationSmSentryPoliciesAssignmentsByNetworkMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
 type ResponseSmGetOrganizationSmVppAccounts []ResponseItemSmGetOrganizationSmVppAccounts // Array of ResponseSmGetOrganizationSmVppAccounts
 type ResponseItemSmGetOrganizationSmVppAccounts struct {
-	ID              string `json:"id,omitempty"`              // The id of the VPP Account
-	VppServiceToken string `json:"vppServiceToken,omitempty"` // The VPP Account's Service Token
+	AllowedAdmins        string                                                 `json:"allowedAdmins,omitempty"`        // The allowed admins for the VPP account
+	AssignableNetworkIDs []string                                               `json:"assignableNetworkIds,omitempty"` // The network IDs of the assignable networks for the VPP account
+	AssignableNetworks   string                                                 `json:"assignableNetworks,omitempty"`   // The assignable networks for the VPP account
+	ContentToken         string                                                 `json:"contentToken,omitempty"`         // The VPP service token
+	Email                string                                                 `json:"email,omitempty"`                // The email address associated with the VPP account
+	ID                   string                                                 `json:"id,omitempty"`                   // The id of the VPP Account
+	LastForceSyncedAt    string                                                 `json:"lastForceSyncedAt,omitempty"`    // The last time the VPP account was force synced
+	LastSyncedAt         string                                                 `json:"lastSyncedAt,omitempty"`         // The last time the VPP account was synced
+	Name                 string                                                 `json:"name,omitempty"`                 // The name of the VPP account
+	NetworkIDAdmins      string                                                 `json:"networkIdAdmins,omitempty"`      // The network IDs of the admins for the VPP account
+	ParsedToken          *ResponseItemSmGetOrganizationSmVppAccountsParsedToken `json:"parsedToken,omitempty"`          // The parsed VPP service token
+	VppAccountID         string                                                 `json:"vppAccountId,omitempty"`         // The id of the VPP Account
+	VppLocationID        string                                                 `json:"vppLocationId,omitempty"`        // The VPP location ID
+	VppLocationName      string                                                 `json:"vppLocationName,omitempty"`      // The VPP location name
+	VppServiceToken      string                                                 `json:"vppServiceToken,omitempty"`      // The VPP Account's Service Token
+}
+type ResponseItemSmGetOrganizationSmVppAccountsParsedToken struct {
+	ExpiresAt   string `json:"expiresAt,omitempty"`   // The expiration time of the token
+	HashedToken string `json:"hashedToken,omitempty"` // The hashed token
+	OrgName     string `json:"orgName,omitempty"`     // The organization name
 }
 type ResponseSmGetOrganizationSmVppAccount struct {
-	ID              string `json:"id,omitempty"`              // The id of the VPP Account
-	VppServiceToken string `json:"vppServiceToken,omitempty"` // The VPP Account's Service Token
+	AllowedAdmins        string                                            `json:"allowedAdmins,omitempty"`        // The allowed admins for the VPP account
+	AssignableNetworkIDs []string                                          `json:"assignableNetworkIds,omitempty"` // The network IDs of the assignable networks for the VPP account
+	AssignableNetworks   string                                            `json:"assignableNetworks,omitempty"`   // The assignable networks for the VPP account
+	ContentToken         string                                            `json:"contentToken,omitempty"`         // The VPP service token
+	Email                string                                            `json:"email,omitempty"`                // The email address associated with the VPP account
+	ID                   string                                            `json:"id,omitempty"`                   // The id of the VPP Account
+	LastForceSyncedAt    string                                            `json:"lastForceSyncedAt,omitempty"`    // The last time the VPP account was force synced
+	LastSyncedAt         string                                            `json:"lastSyncedAt,omitempty"`         // The last time the VPP account was synced
+	Name                 string                                            `json:"name,omitempty"`                 // The name of the VPP account
+	NetworkIDAdmins      string                                            `json:"networkIdAdmins,omitempty"`      // The network IDs of the admins for the VPP account
+	ParsedToken          *ResponseSmGetOrganizationSmVppAccountParsedToken `json:"parsedToken,omitempty"`          // The parsed VPP service token
+	VppAccountID         string                                            `json:"vppAccountId,omitempty"`         // The id of the VPP Account
+	VppLocationID        string                                            `json:"vppLocationId,omitempty"`        // The VPP location ID
+	VppLocationName      string                                            `json:"vppLocationName,omitempty"`      // The VPP location name
+	VppServiceToken      string                                            `json:"vppServiceToken,omitempty"`      // The VPP Account's Service Token
+}
+type ResponseSmGetOrganizationSmVppAccountParsedToken struct {
+	ExpiresAt   string `json:"expiresAt,omitempty"`   // The expiration time of the token
+	HashedToken string `json:"hashedToken,omitempty"` // The hashed token
+	OrgName     string `json:"orgName,omitempty"`     // The organization name
 }
 type RequestSmCreateNetworkSmBypassActivationLockAttempt struct {
 	IDs []string `json:"ids,omitempty"` // The ids of the devices to attempt activation lock bypass.
@@ -412,7 +574,7 @@ type RequestSmUpdateNetworkSmDevicesFieldsDeviceFields struct {
 type RequestSmLockNetworkSmDevices struct {
 	IDs      []string `json:"ids,omitempty"`      // The ids of the devices to be locked.
 	Pin      *int     `json:"pin,omitempty"`      // The pin number for locking macOS devices (a six digit number). Required only for macOS devices.
-	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the devices to be wiped.
+	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the devices to be locked.
 	Serials  []string `json:"serials,omitempty"`  // The serials of the devices to be locked.
 	WifiMacs []string `json:"wifiMacs,omitempty"` // The wifiMacs of the devices to be locked.
 }
@@ -431,11 +593,34 @@ type RequestSmMoveNetworkSmDevices struct {
 	Serials    []string `json:"serials,omitempty"`    // The serials of the devices to be moved.
 	WifiMacs   []string `json:"wifiMacs,omitempty"`   // The wifiMacs of the devices to be moved.
 }
+type RequestSmRebootNetworkSmDevices struct {
+	IDs                          []string `json:"ids,omitempty"`                          // The ids of the endpoints to be rebooted.
+	KextPaths                    []string `json:"kextPaths,omitempty"`                    // The KextPaths of the endpoints to be rebooted. Available for macOS 11+
+	NotifyUser                   *bool    `json:"notifyUser,omitempty"`                   // Whether or not to notify the user before rebooting the endpoint. Available for macOS 11.3+
+	RebuildKernelCache           *bool    `json:"rebuildKernelCache,omitempty"`           // Whether or not to rebuild the kernel cache when rebooting the endpoint. Available for macOS 11+
+	RequestRequiresNetworkTether *bool    `json:"requestRequiresNetworkTether,omitempty"` // Whether or not the request requires network tethering. Available for macOS and supervised iOS or tvOS
+	Scope                        []string `json:"scope,omitempty"`                        // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the endpoints to be rebooted.
+	Serials                      []string `json:"serials,omitempty"`                      // The serials of the endpoints to be rebooted.
+	WifiMacs                     []string `json:"wifiMacs,omitempty"`                     // The wifiMacs of the endpoints to be rebooted.
+}
+type RequestSmShutdownNetworkSmDevices struct {
+	IDs      []string `json:"ids,omitempty"`      // The ids of the endpoints to be shutdown.
+	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the endpoints to be shutdown.
+	Serials  []string `json:"serials,omitempty"`  // The serials of the endpoints to be shutdown.
+	WifiMacs []string `json:"wifiMacs,omitempty"` // The wifiMacs of the endpoints to be shutdown.
+}
 type RequestSmWipeNetworkSmDevices struct {
 	ID      string `json:"id,omitempty"`      // The id of the device to be wiped.
 	Pin     *int   `json:"pin,omitempty"`     // The pin number (a six digit value) for wiping a macOS device. Required only for macOS devices.
 	Serial  string `json:"serial,omitempty"`  // The serial of the device to be wiped.
 	WifiMac string `json:"wifiMac,omitempty"` // The wifiMac of the device to be wiped.
+}
+type RequestSmInstallNetworkSmDeviceApps struct {
+	AppIDs []string `json:"appIds,omitempty"` // ids of applications to be installed
+	Force  *bool    `json:"force,omitempty"`  // By default, installation of an app which is believed to already be present on the device will be skipped. If you'd like to force the installation of the app, set this parameter to true.
+}
+type RequestSmUninstallNetworkSmDeviceApps struct {
+	AppIDs []string `json:"appIds,omitempty"` // ids of applications to be uninstalled
 }
 type RequestSmCreateNetworkSmTargetGroup struct {
 	Name  string `json:"name,omitempty"`  // The name of this target group
@@ -444,6 +629,30 @@ type RequestSmCreateNetworkSmTargetGroup struct {
 type RequestSmUpdateNetworkSmTargetGroup struct {
 	Name  string `json:"name,omitempty"`  // The name of this target group
 	Scope string `json:"scope,omitempty"` // The scope and tag options of the target group. Comma separated values beginning with one of withAny, withAll, withoutAny, withoutAll, all, none, followed by tags. Default to none if empty.
+}
+type RequestSmCreateOrganizationSmAdminsRole struct {
+	Name  string   `json:"name,omitempty"`  // The name of the Limited Access Role
+	Scope string   `json:"scope,omitempty"` // The scope of the Limited Access Role
+	Tags  []string `json:"tags,omitempty"`  // The tags of the Limited Access Role
+}
+type RequestSmUpdateOrganizationSmAdminsRole struct {
+	Name  string   `json:"name,omitempty"`  // The name of the Limited Access Role
+	Scope string   `json:"scope,omitempty"` // The scope of the Limited Access Role
+	Tags  []string `json:"tags,omitempty"`  // The tags of the Limited Access Role
+}
+type RequestSmUpdateOrganizationSmSentryPoliciesAssignments struct {
+	Items *[]RequestSmUpdateOrganizationSmSentryPoliciesAssignmentsItems `json:"items,omitempty"` // Sentry Group Policies for the Organization keyed by Network Id
+}
+type RequestSmUpdateOrganizationSmSentryPoliciesAssignmentsItems struct {
+	NetworkID string                                                                 `json:"networkId,omitempty"` // The Id of the Network
+	Policies  *[]RequestSmUpdateOrganizationSmSentryPoliciesAssignmentsItemsPolicies `json:"policies,omitempty"`  // Array of Sentry Group Policies for the Network
+}
+type RequestSmUpdateOrganizationSmSentryPoliciesAssignmentsItemsPolicies struct {
+	GroupPolicyID string   `json:"groupPolicyId,omitempty"` // The Group Policy Id
+	PolicyID      string   `json:"policyId,omitempty"`      // The Sentry Policy Id, if updating an existing Sentry Policy
+	Scope         string   `json:"scope,omitempty"`         // The scope of the Sentry Policy
+	SmNetworkID   string   `json:"smNetworkId,omitempty"`   // The Id of the Systems Manager Network
+	Tags          []string `json:"tags,omitempty"`          // The tags for the Sentry Policy
 }
 
 //GetNetworkSmBypassActivationLockAttempt Bypass activation lock attempt status
@@ -953,18 +1162,21 @@ func (s *SmService) GetNetworkSmDeviceWLANLists(networkID string, deviceID strin
 /* List all profiles in a network
 
 @param networkID networkId path parameter. Network ID
+@param getNetworkSmProfilesQueryParams Filtering parameter
 
 
 */
-func (s *SmService) GetNetworkSmProfiles(networkID string) (*ResponseSmGetNetworkSmProfiles, *resty.Response, error) {
+func (s *SmService) GetNetworkSmProfiles(networkID string, getNetworkSmProfilesQueryParams *GetNetworkSmProfilesQueryParams) (*ResponseSmGetNetworkSmProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/profiles"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
+	queryString, _ := query.Values(getNetworkSmProfilesQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseSmGetNetworkSmProfiles{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSmGetNetworkSmProfiles{}).
 		SetError(&Error).
 		Get(path)
 
@@ -1234,6 +1446,77 @@ func (s *SmService) GetNetworkSmUserSoftwares(networkID string, userID string) (
 
 }
 
+//GetOrganizationSmAdminsRoles List the Limited Access Roles for an organization
+/* List the Limited Access Roles for an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSmAdminsRolesQueryParams Filtering parameter
+
+
+*/
+func (s *SmService) GetOrganizationSmAdminsRoles(organizationID string, getOrganizationSmAdminsRolesQueryParams *GetOrganizationSmAdminsRolesQueryParams) (*ResponseSmGetOrganizationSmAdminsRoles, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/admins/roles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSmAdminsRolesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSmGetOrganizationSmAdminsRoles{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSmAdminsRoles")
+	}
+
+	result := response.Result().(*ResponseSmGetOrganizationSmAdminsRoles)
+	return result, response, err
+
+}
+
+//GetOrganizationSmAdminsRole Return a Limited Access Role
+/* Return a Limited Access Role
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+
+
+*/
+func (s *SmService) GetOrganizationSmAdminsRole(organizationID string, roleID string) (*ResponseSmGetOrganizationSmAdminsRole, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/admins/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseSmGetOrganizationSmAdminsRole{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSmAdminsRole")
+	}
+
+	result := response.Result().(*ResponseSmGetOrganizationSmAdminsRole)
+	return result, response, err
+
+}
+
 //GetOrganizationSmApnsCert Get the organization's APNS certificate
 /* Get the organization's APNS certificate
 
@@ -1263,6 +1546,42 @@ func (s *SmService) GetOrganizationSmApnsCert(organizationID string) (*ResponseS
 	}
 
 	result := response.Result().(*ResponseSmGetOrganizationSmApnsCert)
+	return result, response, err
+
+}
+
+//GetOrganizationSmSentryPoliciesAssignmentsByNetwork List the Sentry Policies for an organization ordered in ascending order of priority
+/* List the Sentry Policies for an organization ordered in ascending order of priority
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams Filtering parameter
+
+
+*/
+func (s *SmService) GetOrganizationSmSentryPoliciesAssignmentsByNetwork(organizationID string, getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams *GetOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams) (*ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/sentry/policies/assignments/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSmSentryPoliciesAssignmentsByNetwork")
+	}
+
+	result := response.Result().(*ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork)
 	return result, response, err
 
 }
@@ -1509,6 +1828,76 @@ func (s *SmService) MoveNetworkSmDevices(networkID string, requestSmMoveNetworkS
 
 }
 
+//RebootNetworkSmDevices Reboot a set of endpoints
+/* Reboot a set of endpoints
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *SmService) RebootNetworkSmDevices(networkID string, requestSmRebootNetworkSmDevices *RequestSmRebootNetworkSmDevices) (*ResponseSmRebootNetworkSmDevices, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/reboot"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmRebootNetworkSmDevices).
+		SetResult(&ResponseSmRebootNetworkSmDevices{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation RebootNetworkSmDevices")
+	}
+
+	result := response.Result().(*ResponseSmRebootNetworkSmDevices)
+	return result, response, err
+
+}
+
+//ShutdownNetworkSmDevices Shutdown a set of endpoints
+/* Shutdown a set of endpoints
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *SmService) ShutdownNetworkSmDevices(networkID string, requestSmShutdownNetworkSmDevices *RequestSmShutdownNetworkSmDevices) (*ResponseSmShutdownNetworkSmDevices, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/shutdown"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmShutdownNetworkSmDevices).
+		SetResult(&ResponseSmShutdownNetworkSmDevices{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation ShutdownNetworkSmDevices")
+	}
+
+	result := response.Result().(*ResponseSmShutdownNetworkSmDevices)
+	return result, response, err
+
+}
+
 //WipeNetworkSmDevices Wipe a device
 /* Wipe a device
 
@@ -1541,6 +1930,41 @@ func (s *SmService) WipeNetworkSmDevices(networkID string, requestSmWipeNetworkS
 
 	result := response.Result().(*ResponseSmWipeNetworkSmDevices)
 	return result, response, err
+
+}
+
+//InstallNetworkSmDeviceApps Install applications on a device
+/* Install applications on a device
+
+@param networkID networkId path parameter. Network ID
+@param deviceID deviceId path parameter. Device ID
+
+
+*/
+
+func (s *SmService) InstallNetworkSmDeviceApps(networkID string, deviceID string, requestSmInstallNetworkSmDeviceApps *RequestSmInstallNetworkSmDeviceApps) (*resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/installApps"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmInstallNetworkSmDeviceApps).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation InstallNetworkSmDeviceApps")
+	}
+
+	return response, err
 
 }
 
@@ -1587,7 +2011,7 @@ func (s *SmService) RefreshNetworkSmDeviceDetails(networkID string, deviceID str
 
 */
 
-func (s *SmService) UnenrollNetworkSmDevice(networkID string, deviceID string) (*resty.Response, error) {
+func (s *SmService) UnenrollNetworkSmDevice(networkID string, deviceID string) (*ResponseSmUnenrollNetworkSmDevice, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/unenroll"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1596,8 +2020,43 @@ func (s *SmService) UnenrollNetworkSmDevice(networkID string, deviceID string) (
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetResult(&ResponseSmUnenrollNetworkSmDevice{}).
+		SetError(&Error).
+		Post(path)
 
-		// SetResult(&ResponseSmUnenrollNetworkSmDevice{}).
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UnenrollNetworkSmDevice")
+	}
+
+	result := response.Result().(*ResponseSmUnenrollNetworkSmDevice)
+	return result, response, err
+
+}
+
+//UninstallNetworkSmDeviceApps Uninstall applications on a device
+/* Uninstall applications on a device
+
+@param networkID networkId path parameter. Network ID
+@param deviceID deviceId path parameter. Device ID
+
+
+*/
+
+func (s *SmService) UninstallNetworkSmDeviceApps(networkID string, deviceID string, requestSmUninstallNetworkSmDeviceApps *RequestSmUninstallNetworkSmDeviceApps) (*resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/uninstallApps"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmUninstallNetworkSmDeviceApps).
 		SetError(&Error).
 		Post(path)
 
@@ -1607,7 +2066,7 @@ func (s *SmService) UnenrollNetworkSmDevice(networkID string, deviceID string) (
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UnenrollNetworkSmDevice")
+		return response, fmt.Errorf("error with operation UninstallNetworkSmDeviceApps")
 	}
 
 	return response, err
@@ -1622,7 +2081,7 @@ func (s *SmService) UnenrollNetworkSmDevice(networkID string, deviceID string) (
 
 */
 
-func (s *SmService) CreateNetworkSmTargetGroup(networkID string, requestSmCreateNetworkSmTargetGroup *RequestSmCreateNetworkSmTargetGroup) (*resty.Response, error) {
+func (s *SmService) CreateNetworkSmTargetGroup(networkID string, requestSmCreateNetworkSmTargetGroup *RequestSmCreateNetworkSmTargetGroup) (*ResponseSmCreateNetworkSmTargetGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/targetGroups"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1631,20 +2090,56 @@ func (s *SmService) CreateNetworkSmTargetGroup(networkID string, requestSmCreate
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSmCreateNetworkSmTargetGroup).
-		// SetResult(&ResponseSmCreateNetworkSmTargetGroup{}).
+		SetResult(&ResponseSmCreateNetworkSmTargetGroup{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkSmTargetGroup")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkSmTargetGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSmCreateNetworkSmTargetGroup)
+	return result, response, err
+
+}
+
+//CreateOrganizationSmAdminsRole Create a Limited Access Role
+/* Create a Limited Access Role
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *SmService) CreateOrganizationSmAdminsRole(organizationID string, requestSmCreateOrganizationSmAdminsRole *RequestSmCreateOrganizationSmAdminsRole) (*ResponseSmCreateOrganizationSmAdminsRole, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/admins/roles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmCreateOrganizationSmAdminsRole).
+		SetResult(&ResponseSmCreateOrganizationSmAdminsRole{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationSmAdminsRole")
+	}
+
+	result := response.Result().(*ResponseSmCreateOrganizationSmAdminsRole)
+	return result, response, err
 
 }
 
@@ -1686,7 +2181,7 @@ func (s *SmService) UpdateNetworkSmDevicesFields(networkID string, requestSmUpda
 @param networkID networkId path parameter. Network ID
 @param targetGroupID targetGroupId path parameter. Target group ID
 */
-func (s *SmService) UpdateNetworkSmTargetGroup(networkID string, targetGroupID string, requestSmUpdateNetworkSmTargetGroup *RequestSmUpdateNetworkSmTargetGroup) (*resty.Response, error) {
+func (s *SmService) UpdateNetworkSmTargetGroup(networkID string, targetGroupID string, requestSmUpdateNetworkSmTargetGroup *RequestSmUpdateNetworkSmTargetGroup) (*ResponseSmUpdateNetworkSmTargetGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/targetGroups/{targetGroupId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1696,19 +2191,87 @@ func (s *SmService) UpdateNetworkSmTargetGroup(networkID string, targetGroupID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSmUpdateNetworkSmTargetGroup).
+		SetResult(&ResponseSmUpdateNetworkSmTargetGroup{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSmTargetGroup")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSmTargetGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSmUpdateNetworkSmTargetGroup)
+	return result, response, err
+
+}
+
+//UpdateOrganizationSmAdminsRole Update a Limited Access Role
+/* Update a Limited Access Role
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+*/
+func (s *SmService) UpdateOrganizationSmAdminsRole(organizationID string, roleID string, requestSmUpdateOrganizationSmAdminsRole *RequestSmUpdateOrganizationSmAdminsRole) (*ResponseSmUpdateOrganizationSmAdminsRole, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/admins/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmUpdateOrganizationSmAdminsRole).
+		SetResult(&ResponseSmUpdateOrganizationSmAdminsRole{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationSmAdminsRole")
+	}
+
+	result := response.Result().(*ResponseSmUpdateOrganizationSmAdminsRole)
+	return result, response, err
+
+}
+
+//UpdateOrganizationSmSentryPoliciesAssignments Update an Organizations Sentry Policies using the provided list
+/* Update an Organizations Sentry Policies using the provided list. Sentry Policies are ordered in descending order of priority (i.e. highest priority at the bottom, this is opposite the Dashboard UI). Policies not present in the request will be deleted.
+
+@param organizationID organizationId path parameter. Organization ID
+*/
+func (s *SmService) UpdateOrganizationSmSentryPoliciesAssignments(organizationID string, requestSmUpdateOrganizationSmSentryPoliciesAssignments *RequestSmUpdateOrganizationSmSentryPoliciesAssignments) (*ResponseSmUpdateOrganizationSmSentryPoliciesAssignments, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/sm/sentry/policies/assignments"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSmUpdateOrganizationSmSentryPoliciesAssignments).
+		SetResult(&ResponseSmUpdateOrganizationSmSentryPoliciesAssignments{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationSmSentryPoliciesAssignments")
+	}
+
+	result := response.Result().(*ResponseSmUpdateOrganizationSmSentryPoliciesAssignments)
+	return result, response, err
 
 }
 
@@ -1774,6 +2337,40 @@ func (s *SmService) DeleteNetworkSmUserAccessDevice(networkID string, userAccess
 
 	if response.IsError() {
 		return response, fmt.Errorf("error with operation DeleteNetworkSmUserAccessDevice")
+	}
+
+	return response, err
+
+}
+
+//DeleteOrganizationSmAdminsRole Delete a Limited Access Role
+/* Delete a Limited Access Role
+
+@param organizationID organizationId path parameter. Organization ID
+@param roleID roleId path parameter. Role ID
+
+
+*/
+func (s *SmService) DeleteOrganizationSmAdminsRole(organizationID string, roleID string) (*resty.Response, error) {
+	//organizationID string,roleID string
+	path := "/api/v1/organizations/{organizationId}/sm/admins/roles/{roleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{roleId}", fmt.Sprintf("%v", roleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteOrganizationSmAdminsRole")
 	}
 
 	return response, err

--- a/sdk/switch.go
+++ b/sdk/switch.go
@@ -36,6 +36,11 @@ type GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams st
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
+type GetOrganizationSummarySwitchPowerHistoryQueryParams struct {
+	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+}
 type GetOrganizationSwitchPortsBySwitchQueryParams struct {
 	PerPage                   int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 50. Default is 50.
 	StartingAfter             string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -63,6 +68,8 @@ type ResponseItemSwitchGetDeviceSwitchPorts struct {
 	LinkNegotiation             string                                         `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
 	LinkNegotiationCapabilities []string                                       `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
 	MacAllowList                []string                                       `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseItemSwitchGetDeviceSwitchPortsMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseItemSwitchGetDeviceSwitchPortsModule  `json:"module,omitempty"`                      // Expansion module
 	Name                        string                                         `json:"name,omitempty"`                        // The name of the switch port.
 	PeerSgtCapable              *bool                                          `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
 	PoeEnabled                  *bool                                          `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
@@ -77,8 +84,14 @@ type ResponseItemSwitchGetDeviceSwitchPorts struct {
 	Tags                        []string                                       `json:"tags,omitempty"`                        // The list of tags of the switch port.
 	Type                        string                                         `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
 	Udld                        string                                         `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                           `json:"vlan,omitempty"`                        // The VLAN of the switch port. A null value will clear the value set for trunk ports.
+	VLAN                        *int                                           `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN                   *int                                           `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseItemSwitchGetDeviceSwitchPortsModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseItemSwitchGetDeviceSwitchPortsProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -100,6 +113,7 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatuses struct {
 	PortID         string                                                       `json:"portId,omitempty"`         // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
 	PowerUsageInWh *float64                                                     `json:"powerUsageInWh,omitempty"` // How much power (in watt-hours) has been delivered by this port during the timespan.
 	SecurePort     *ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePort    `json:"securePort,omitempty"`     // The Secure Port status of the port.
+	SpanningTree   *ResponseItemSwitchGetDeviceSwitchPortsStatusesSpanningTree  `json:"spanningTree,omitempty"`   // The Spanning Tree Protocol (STP) information of the connected device.
 	Speed          string                                                       `json:"speed,omitempty"`          // The current data transfer rate which the port is operating at.
 	Status         string                                                       `json:"status,omitempty"`         // The current connection status of the port.
 	TrafficInKbps  *ResponseItemSwitchGetDeviceSwitchPortsStatusesTrafficInKbps `json:"trafficInKbps,omitempty"`  // A breakdown of the average speed of data that has passed through this port during the timespan.
@@ -138,8 +152,11 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePort struct {
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePortConfigOverrides struct {
 	AllowedVLANs string `json:"allowedVlans,omitempty"` // The VLANs allowed on the . Only applicable to trunk ports.
 	Type         string `json:"type,omitempty"`         // The type of the  ('trunk' or 'access').
-	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the . A null value will clear the value set for trunk ports.
+	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the . For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN    *int   `json:"voiceVlan,omitempty"`    // The voice VLAN of the . Only applicable to access ports.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsStatusesSpanningTree struct {
+	Statuses []string `json:"statuses,omitempty"` // The current Spanning Tree Protocol statuses of the port.
 }
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesTrafficInKbps struct {
 	Recv  *float64 `json:"recv,omitempty"`  // The average speed of the data received (in kilobits-per-second).
@@ -153,20 +170,20 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatusesUsageInKb struct {
 }
 type ResponseSwitchGetDeviceSwitchPortsStatusesPackets []ResponseItemSwitchGetDeviceSwitchPortsStatusesPackets // Array of ResponseSwitchGetDeviceSwitchPortsStatusesPackets
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesPackets struct {
-	Packets *[]ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPackets `json:"packets,omitempty"` //
-	PortID  string                                                          `json:"portId,omitempty"`  //
+	Packets *[]ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPackets `json:"packets,omitempty"` // The packet counts on the switch.
+	PortID  string                                                          `json:"portId,omitempty"`  // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
 }
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPackets struct {
-	Desc       string                                                                  `json:"desc,omitempty"`       //
-	RatePerSec *ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPacketsRatePerSec `json:"ratePerSec,omitempty"` //
-	Recv       *int                                                                    `json:"recv,omitempty"`       //
-	Sent       *int                                                                    `json:"sent,omitempty"`       //
-	Total      *int                                                                    `json:"total,omitempty"`      //
+	Desc       string                                                                  `json:"desc,omitempty"`       // The type of packets being counted.
+	RatePerSec *ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPacketsRatePerSec `json:"ratePerSec,omitempty"` // Packet rates measured in packets per second.
+	Recv       *int                                                                    `json:"recv,omitempty"`       // The total count of packets received by the switch during the timespan.
+	Sent       *int                                                                    `json:"sent,omitempty"`       // The total count of packets sent by the switch during the timespan.
+	Total      *int                                                                    `json:"total,omitempty"`      // The total count of sent and received packets.
 }
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPacketsRatePerSec struct {
-	Recv  *int `json:"recv,omitempty"`  //
-	Sent  *int `json:"sent,omitempty"`  //
-	Total *int `json:"total,omitempty"` //
+	Recv  *int `json:"recv,omitempty"`  // The rate of packets received during the timespan
+	Sent  *int `json:"sent,omitempty"`  // The rate of packets sent during the timespan
+	Total *int `json:"total,omitempty"` // The rate of all packets sent and received during the timespan
 }
 type ResponseSwitchGetDeviceSwitchPort struct {
 	AccessPolicyNumber          *int                                      `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
@@ -180,6 +197,8 @@ type ResponseSwitchGetDeviceSwitchPort struct {
 	LinkNegotiation             string                                    `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
 	LinkNegotiationCapabilities []string                                  `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
 	MacAllowList                []string                                  `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchGetDeviceSwitchPortMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchGetDeviceSwitchPortModule  `json:"module,omitempty"`                      // Expansion module
 	Name                        string                                    `json:"name,omitempty"`                        // The name of the switch port.
 	PeerSgtCapable              *bool                                     `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
 	PoeEnabled                  *bool                                     `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
@@ -194,8 +213,14 @@ type ResponseSwitchGetDeviceSwitchPort struct {
 	Tags                        []string                                  `json:"tags,omitempty"`                        // The list of tags of the switch port.
 	Type                        string                                    `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
 	Udld                        string                                    `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                      `json:"vlan,omitempty"`                        // The VLAN of the switch port. A null value will clear the value set for trunk ports.
+	VLAN                        *int                                      `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN                   *int                                      `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseSwitchGetDeviceSwitchPortMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseSwitchGetDeviceSwitchPortModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseSwitchGetDeviceSwitchPortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -214,6 +239,8 @@ type ResponseSwitchUpdateDeviceSwitchPort struct {
 	LinkNegotiation             string                                       `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
 	LinkNegotiationCapabilities []string                                     `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
 	MacAllowList                []string                                     `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchUpdateDeviceSwitchPortMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchUpdateDeviceSwitchPortModule  `json:"module,omitempty"`                      // Expansion module
 	Name                        string                                       `json:"name,omitempty"`                        // The name of the switch port.
 	PeerSgtCapable              *bool                                        `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
 	PoeEnabled                  *bool                                        `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
@@ -228,8 +255,14 @@ type ResponseSwitchUpdateDeviceSwitchPort struct {
 	Tags                        []string                                     `json:"tags,omitempty"`                        // The list of tags of the switch port.
 	Type                        string                                       `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
 	Udld                        string                                       `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                         `json:"vlan,omitempty"`                        // The VLAN of the switch port. A null value will clear the value set for trunk ports.
+	VLAN                        *int                                         `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN                   *int                                         `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseSwitchUpdateDeviceSwitchPortMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseSwitchUpdateDeviceSwitchPortModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseSwitchUpdateDeviceSwitchPortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -350,43 +383,78 @@ type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceOspfV3 struct {
 	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv6 area
 }
 type ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcp struct {
-	BootFileName         string                                                                 `json:"bootFileName,omitempty"`         //
-	BootNextServer       string                                                                 `json:"bootNextServer,omitempty"`       //
-	BootOptionsEnabled   *bool                                                                  `json:"bootOptionsEnabled,omitempty"`   //
-	DhcpLeaseTime        string                                                                 `json:"dhcpLeaseTime,omitempty"`        //
-	DhcpMode             string                                                                 `json:"dhcpMode,omitempty"`             //
-	DhcpOptions          *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          //
-	DNSCustomNameservers []string                                                               `json:"dnsCustomNameservers,omitempty"` //
-	DNSNameserversOption string                                                                 `json:"dnsNameserversOption,omitempty"` //
-	FixedIPAssignments   *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   //
-	ReservedIPRanges     *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     //
+	BootFileName         string                                                                 `json:"bootFileName,omitempty"`         // The PXE boot server file name for the DHCP server running on the switch stack interface
+	BootNextServer       string                                                                 `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch stack interface
+	BootOptionsEnabled   *bool                                                                  `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch stack interface
+	DhcpLeaseTime        string                                                                 `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on the switch stack interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                 `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	DhcpOptions          *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch stack interface
+	DhcpRelayServerIPs   []string                                                               `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch stack interface
+	DNSCustomNameservers []string                                                               `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
+	DNSNameserversOption string                                                                 `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface ('googlePublicDns', 'openDns' or 'custom')
+	FixedIPAssignments   *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+	ReservedIPRanges     *[]ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
 }
 type ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpDhcpOptions struct {
-	Code  string `json:"code,omitempty"`  //
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Value string `json:"value,omitempty"` // The value of the DHCP option
 }
 type ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments struct {
-	IP   string `json:"ip,omitempty"`   //
-	Mac  string `json:"mac,omitempty"`  //
-	Name string `json:"name,omitempty"` //
+	IP   string `json:"ip,omitempty"`   // The IP address of the client which has fixed IP address assigned to it
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the client which has fixed IP address
+	Name string `json:"name,omitempty"` // The name of the client which has fixed IP address
 }
 type ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcpReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` //
-	End     string `json:"end,omitempty"`     //
-	Start   string `json:"start,omitempty"`   //
+	Comment string `json:"comment,omitempty"` // The comment for the reserved IP range
+	End     string `json:"end,omitempty"`     // The ending IP address of the reserved IP range
+	Start   string `json:"start,omitempty"`   // The starting IP address of the reserved IP range
 }
-type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcp interface{}
+type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcp struct {
+	BootFileName         string                                                                    `json:"bootFileName,omitempty"`         // The PXE boot server file name for the DHCP server running on the switch stack interface
+	BootNextServer       string                                                                    `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch stack interface
+	BootOptionsEnabled   *bool                                                                     `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch stack interface
+	DhcpLeaseTime        string                                                                    `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on the switch stack interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                    `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	DhcpOptions          *[]ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch stack interface
+	DhcpRelayServerIPs   []string                                                                  `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch stack interface
+	DNSCustomNameservers []string                                                                  `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
+	DNSNameserversOption string                                                                    `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface ('googlePublicDns', 'openDns' or 'custom')
+	FixedIPAssignments   *[]ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+	ReservedIPRanges     *[]ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+}
+type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpDhcpOptions struct {
+	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Value string `json:"value,omitempty"` // The value of the DHCP option
+}
+type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments struct {
+	IP   string `json:"ip,omitempty"`   // The IP address of the client which has fixed IP address assigned to it
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the client which has fixed IP address
+	Name string `json:"name,omitempty"` // The name of the client which has fixed IP address
+}
+type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpReservedIPRanges struct {
+	Comment string `json:"comment,omitempty"` // The comment for the reserved IP range
+	End     string `json:"end,omitempty"`     // The ending IP address of the reserved IP range
+	Start   string `json:"start,omitempty"`   // The starting IP address of the reserved IP range
+}
 type ResponseSwitchGetDeviceSwitchRoutingStaticRoutes []ResponseItemSwitchGetDeviceSwitchRoutingStaticRoutes // Array of ResponseSwitchGetDeviceSwitchRoutingStaticRoutes
 type ResponseItemSwitchGetDeviceSwitchRoutingStaticRoutes struct {
-	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     //
-	Name                        string `json:"name,omitempty"`                        //
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //
-	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` //
-	StaticRouteID               string `json:"staticRouteId,omitempty"`               //
-	Subnet                      string `json:"subnet,omitempty"`                      //
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
-type ResponseSwitchCreateDeviceSwitchRoutingStaticRoute interface{}
+type ResponseSwitchCreateDeviceSwitchRoutingStaticRoute struct {
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
+}
 type ResponseSwitchGetDeviceSwitchRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
@@ -395,13 +463,24 @@ type ResponseSwitchGetDeviceSwitchRoutingStaticRoute struct {
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
-type ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute interface{}
-type ResponseSwitchGetDeviceSwitchWarmSpare struct {
-	Enabled       *bool  `json:"enabled,omitempty"`       //
-	PrimarySerial string `json:"primarySerial,omitempty"` //
-	SpareSerial   string `json:"spareSerial,omitempty"`   //
+type ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute struct {
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
-type ResponseSwitchUpdateDeviceSwitchWarmSpare interface{}
+type ResponseSwitchGetDeviceSwitchWarmSpare struct {
+	Enabled       *bool  `json:"enabled,omitempty"`       // Enable or disable warm spare for a switch
+	PrimarySerial string `json:"primarySerial,omitempty"` // Serial number of the primary switch
+	SpareSerial   string `json:"spareSerial,omitempty"`   // Serial number of the warm spare switch
+}
+type ResponseSwitchUpdateDeviceSwitchWarmSpare struct {
+	Enabled       *bool  `json:"enabled,omitempty"`       // Enable or disable warm spare for a switch
+	PrimarySerial string `json:"primarySerial,omitempty"` // Serial number of the primary switch
+	SpareSerial   string `json:"spareSerial,omitempty"`   // Serial number of the warm spare switch
+}
 type ResponseSwitchGetNetworkSwitchAccessControlLists struct {
 	Rules *[]ResponseSwitchGetNetworkSwitchAccessControlListsRules `json:"rules,omitempty"` // An ordered array of the access control list rules
 }
@@ -455,35 +534,10 @@ type ResponseSwitchUpdateNetworkSwitchAccessControlListsRules struct {
 	SrcPort   string `json:"srcPort,omitempty"`   // Source port
 	VLAN      string `json:"vlan,omitempty"`      // ncoming traffic VLAN
 }
-
-func (r *ResponseSwitchUpdateNetworkSwitchAccessControlListsRules) UnmarshalJSON(data []byte) error {
-	type Alias ResponseSwitchUpdateNetworkSwitchAccessControlListsRules
-	aux := &struct {
-		SrcPort interface{} `json:"srcPort"`
-		VLAN    interface{} `json:"vlan"`
-		DstCidr interface{} `json:"dstCidr"`
-		DstPort interface{} `json:"dstPort"`
-		SrcCidr interface{} `json:"srcCidr"`
-
-		*Alias
-	}{
-		Alias: (*Alias)(r),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	r.SrcPort = convertToString(aux.SrcPort)
-	r.VLAN = convertToString(aux.VLAN)
-	r.DstCidr = convertToString(aux.DstCidr)
-	r.DstPort = convertToString(aux.DstPort)
-	r.SrcCidr = convertToString(aux.SrcCidr)
-	return nil
-}
-
 type ResponseSwitchGetNetworkSwitchAccessPolicies []ResponseItemSwitchGetNetworkSwitchAccessPolicies // Array of ResponseSwitchGetNetworkSwitchAccessPolicies
 type ResponseItemSwitchGetNetworkSwitchAccessPolicies struct {
-	AccessPolicyType               string                                                                     `json:"accessPolicyType,omitempty"` // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
-	AccessPolicyNumber             string                                                                     `json:"accessPolicyNumber,omitempty"`
+	AccessPolicyType               string                                                                     `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
+	Counts                         *ResponseItemSwitchGetNetworkSwitchAccessPoliciesCounts                    `json:"counts,omitempty"`                         // Counts associated with the access policy
 	Dot1X                          *ResponseItemSwitchGetNetworkSwitchAccessPoliciesDot1X                     `json:"dot1x,omitempty"`                          // 802.1x Settings
 	GuestPortBouncing              *bool                                                                      `json:"guestPortBouncing,omitempty"`              // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	GuestVLANID                    *int                                                                       `json:"guestVlanId,omitempty"`                    // ID for the guest VLAN allow unauthorized devices access to limited network resources
@@ -494,12 +548,18 @@ type ResponseItemSwitchGetNetworkSwitchAccessPolicies struct {
 	RadiusAccountingEnabled        *bool                                                                      `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                      `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                                     `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                                     `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                      `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                      `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a response_objectific set of IP addresses or hostnames prior to authentication
 	URLRedirectWalledGardenRanges  []string                                                                   `json:"urlRedirectWalledGardenRanges,omitempty"`  // IP address ranges, in CIDR notation, to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
 	VoiceVLANClients               *bool                                                                      `json:"voiceVlanClients,omitempty"`               // CDP/LLDP capable voice clients will be able to use this VLAN. Automatically true when hostMode is 'Multi-Domain'.
+}
+type ResponseItemSwitchGetNetworkSwitchAccessPoliciesCounts struct {
+	Ports *ResponseItemSwitchGetNetworkSwitchAccessPoliciesCountsPorts `json:"ports,omitempty"` // Counts associated with ports
+}
+type ResponseItemSwitchGetNetworkSwitchAccessPoliciesCountsPorts struct {
+	WithThisPolicy *int `json:"withThisPolicy,omitempty"` // Number of ports in the network with this policy. For template networks, this is the number of template ports (not child ports) with this policy.
 }
 type ResponseItemSwitchGetNetworkSwitchAccessPoliciesDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
@@ -524,6 +584,7 @@ type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusServers struct {
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                                  `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
+	Counts                         *ResponseSwitchCreateNetworkSwitchAccessPolicyCounts                    `json:"counts,omitempty"`                         // Counts associated with the access policy
 	Dot1X                          *ResponseSwitchCreateNetworkSwitchAccessPolicyDot1X                     `json:"dot1x,omitempty"`                          // 802.1x Settings
 	GuestPortBouncing              *bool                                                                   `json:"guestPortBouncing,omitempty"`              // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	GuestVLANID                    *int                                                                    `json:"guestVlanId,omitempty"`                    // ID for the guest VLAN allow unauthorized devices access to limited network resources
@@ -534,12 +595,18 @@ type ResponseSwitchCreateNetworkSwitchAccessPolicy struct {
 	RadiusAccountingEnabled        *bool                                                                   `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                   `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                                  `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                                  `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                   `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                   `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a response_objectific set of IP addresses or hostnames prior to authentication
 	URLRedirectWalledGardenRanges  []string                                                                `json:"urlRedirectWalledGardenRanges,omitempty"`  // IP address ranges, in CIDR notation, to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
 	VoiceVLANClients               *bool                                                                   `json:"voiceVlanClients,omitempty"`               // CDP/LLDP capable voice clients will be able to use this VLAN. Automatically true when hostMode is 'Multi-Domain'.
+}
+type ResponseSwitchCreateNetworkSwitchAccessPolicyCounts struct {
+	Ports *ResponseSwitchCreateNetworkSwitchAccessPolicyCountsPorts `json:"ports,omitempty"` // Counts associated with ports
+}
+type ResponseSwitchCreateNetworkSwitchAccessPolicyCountsPorts struct {
+	WithThisPolicy *int `json:"withThisPolicy,omitempty"` // Number of ports in the network with this policy. For template networks, this is the number of template ports (not child ports) with this policy.
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
@@ -564,7 +631,7 @@ type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusServers struct {
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                               `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
-	AccessPolicyNumber             string                                                               `json:"accessPolicyNumber,omitempty"`             // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
+	Counts                         *ResponseSwitchGetNetworkSwitchAccessPolicyCounts                    `json:"counts,omitempty"`                         // Counts associated with the access policy
 	Dot1X                          *ResponseSwitchGetNetworkSwitchAccessPolicyDot1X                     `json:"dot1x,omitempty"`                          // 802.1x Settings
 	GuestPortBouncing              *bool                                                                `json:"guestPortBouncing,omitempty"`              // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	GuestVLANID                    *int                                                                 `json:"guestVlanId,omitempty"`                    // ID for the guest VLAN allow unauthorized devices access to limited network resources
@@ -575,12 +642,18 @@ type ResponseSwitchGetNetworkSwitchAccessPolicy struct {
 	RadiusAccountingEnabled        *bool                                                                `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]ResponseSwitchGetNetworkSwitchAccessPolicyRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                               `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                               `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]ResponseSwitchGetNetworkSwitchAccessPolicyRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a response_objectific set of IP addresses or hostnames prior to authentication
 	URLRedirectWalledGardenRanges  []string                                                             `json:"urlRedirectWalledGardenRanges,omitempty"`  // IP address ranges, in CIDR notation, to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
 	VoiceVLANClients               *bool                                                                `json:"voiceVlanClients,omitempty"`               // CDP/LLDP capable voice clients will be able to use this VLAN. Automatically true when hostMode is 'Multi-Domain'.
+}
+type ResponseSwitchGetNetworkSwitchAccessPolicyCounts struct {
+	Ports *ResponseSwitchGetNetworkSwitchAccessPolicyCountsPorts `json:"ports,omitempty"` // Counts associated with ports
+}
+type ResponseSwitchGetNetworkSwitchAccessPolicyCountsPorts struct {
+	WithThisPolicy *int `json:"withThisPolicy,omitempty"` // Number of ports in the network with this policy. For template networks, this is the number of template ports (not child ports) with this policy.
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
@@ -605,22 +678,29 @@ type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusServers struct {
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                                  `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
+	Counts                         *ResponseSwitchUpdateNetworkSwitchAccessPolicyCounts                    `json:"counts,omitempty"`                         // Counts associated with the access policy
 	Dot1X                          *ResponseSwitchUpdateNetworkSwitchAccessPolicyDot1X                     `json:"dot1x,omitempty"`                          // 802.1x Settings
 	GuestPortBouncing              *bool                                                                   `json:"guestPortBouncing,omitempty"`              // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	GuestVLANID                    *int                                                                    `json:"guestVlanId,omitempty"`                    // ID for the guest VLAN allow unauthorized devices access to limited network resources
 	HostMode                       string                                                                  `json:"hostMode,omitempty"`                       // Choose the Host Mode for the access policy.
-	IncreaseAccessSpeed            *bool                                                                   `json:"increaseAccessSpeed,omitempty"`            // Enabling this option will make switches execute 802.1X and MAC-bypass authentication simultaneously so that clients authenticate faster. Only required when accessPolicyType is 'Hybrid Authentication.
+	IncreaseAccessSpeed            *bool                                                                   `json:"increaseAccessSpeed,omitempty"`            // Enabling this option will make switches execute 802.1X and MAC-bypass authentication simultaneously so that clients authenticate faster. Only required when accessPolicyType is Hybrid Authentication.
 	Name                           string                                                                  `json:"name,omitempty"`                           // Name of the access policy
 	Radius                         *ResponseSwitchUpdateNetworkSwitchAccessPolicyRadius                    `json:"radius,omitempty"`                         // Object for RADIUS Settings
 	RadiusAccountingEnabled        *bool                                                                   `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                   `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                                  `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                                  `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                   `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                   `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a response_objectific set of IP addresses or hostnames prior to authentication
 	URLRedirectWalledGardenRanges  []string                                                                `json:"urlRedirectWalledGardenRanges,omitempty"`  // IP address ranges, in CIDR notation, to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
 	VoiceVLANClients               *bool                                                                   `json:"voiceVlanClients,omitempty"`               // CDP/LLDP capable voice clients will be able to use this VLAN. Automatically true when hostMode is 'Multi-Domain'.
+}
+type ResponseSwitchUpdateNetworkSwitchAccessPolicyCounts struct {
+	Ports *ResponseSwitchUpdateNetworkSwitchAccessPolicyCountsPorts `json:"ports,omitempty"` // Counts associated with ports
+}
+type ResponseSwitchUpdateNetworkSwitchAccessPolicyCountsPorts struct {
+	WithThisPolicy *int `json:"withThisPolicy,omitempty"` // Number of ports in the network with this policy. For template networks, this is the number of template ports (not child ports) with this policy.
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
@@ -644,16 +724,16 @@ type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusServers struct {
 	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS server listens on for access requests
 }
 type ResponseSwitchGetNetworkSwitchAlternateManagementInterface struct {
-	Enabled   *bool                                                                 `json:"enabled,omitempty"`   //
-	Protocols []string                                                              `json:"protocols,omitempty"` //
-	Switches  *[]ResponseSwitchGetNetworkSwitchAlternateManagementInterfaceSwitches `json:"switches,omitempty"`  //
-	VLANID    *int                                                                  `json:"vlanId,omitempty"`    //
+	Enabled   *bool                                                                 `json:"enabled,omitempty"`   // Boolean value to enable or disable AMI configuration. If enabled, VLAN and protocols must be set
+	Protocols []string                                                              `json:"protocols,omitempty"` // Can be one or more of the following values: 'radius', 'snmp' or 'syslog'
+	Switches  *[]ResponseSwitchGetNetworkSwitchAlternateManagementInterfaceSwitches `json:"switches,omitempty"`  // Array of switch serial number and IP assignment. If parameter is present, it cannot have empty body. Note: switches parameter is not applicable for template networks, in other words, do not put 'switches' in the body when updating template networks. Also, an empty 'switches' array will remove all previous assignments
+	VLANID    *int                                                                  `json:"vlanId,omitempty"`    // Alternate management VLAN, must be between 1 and 4094
 }
 type ResponseSwitchGetNetworkSwitchAlternateManagementInterfaceSwitches struct {
-	AlternateManagementIP string `json:"alternateManagementIp,omitempty"` //
-	Gateway               string `json:"gateway,omitempty"`               //
-	Serial                string `json:"serial,omitempty"`                //
-	SubnetMask            string `json:"subnetMask,omitempty"`            //
+	AlternateManagementIP string `json:"alternateManagementIp,omitempty"` // Switch alternative management IP. To remove a prior IP setting, provide an empty string
+	Gateway               string `json:"gateway,omitempty"`               // Switch gateway must be in IP format. Only and must be specified for Polaris switches
+	Serial                string `json:"serial,omitempty"`                // Switch serial number
+	SubnetMask            string `json:"subnetMask,omitempty"`            // Switch subnet mask must be in IP format. Only and must be specified for Polaris switches
 }
 type ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface interface{}
 type ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen []ResponseItemSwitchGetNetworkSwitchDhcpV4ServersSeen // Array of ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen
@@ -765,23 +845,39 @@ type ResponseItemSwitchGetNetworkSwitchDhcpV4ServersSeenSeenBy struct {
 	URL    string `json:"url,omitempty"`    // Url link to device.
 }
 type ResponseSwitchGetNetworkSwitchDhcpServerPolicy struct {
-	Alerts         *ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlerts        `json:"alerts,omitempty"`         //
-	AllowedServers []string                                                     `json:"allowedServers,omitempty"` //
-	ArpInspection  *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspection `json:"arpInspection,omitempty"`  //
-	BlockedServers []string                                                     `json:"blockedServers,omitempty"` //
-	DefaultPolicy  string                                                       `json:"defaultPolicy,omitempty"`  //
+	Alerts         *ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlerts        `json:"alerts,omitempty"`         // Email alert settings for DHCP servers
+	AllowedServers []string                                                     `json:"allowedServers,omitempty"` // List the MAC addresses of DHCP servers to permit on the network when defaultPolicy is set       to block.An empty array will clear the entries.
+	ArpInspection  *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspection `json:"arpInspection,omitempty"`  // Dynamic ARP Inspection settings
+	BlockedServers []string                                                     `json:"blockedServers,omitempty"` // List the MAC addresses of DHCP servers to block on the network when defaultPolicy is set       to allow.An empty array will clear the entries.
+	DefaultPolicy  string                                                       `json:"defaultPolicy,omitempty"`  // 'allow' or 'block' new DHCP servers. Default value is 'allow'.
 }
 type ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlerts struct {
-	Email *ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlertsEmail `json:"email,omitempty"` //
+	Email *ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlertsEmail `json:"email,omitempty"` // Alert settings for DHCP servers
 }
 type ResponseSwitchGetNetworkSwitchDhcpServerPolicyAlertsEmail struct {
-	Enabled *bool `json:"enabled,omitempty"` //
+	Enabled *bool `json:"enabled,omitempty"` // When enabled, send an email if a new DHCP server is seen. Default value is false.
 }
 type ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspection struct {
-	Enabled           *bool    `json:"enabled,omitempty"`           //
-	UnsupportedModels []string `json:"unsupportedModels,omitempty"` //
+	Enabled           *bool    `json:"enabled,omitempty"`           // Enable or disable Dynamic ARP Inspection on the network. Default value is false.
+	UnsupportedModels []string `json:"unsupportedModels,omitempty"` // List of switch models that does not support dynamic ARP inspection
 }
-type ResponseSwitchUpdateNetworkSwitchDhcpServerPolicy interface{}
+type ResponseSwitchUpdateNetworkSwitchDhcpServerPolicy struct {
+	Alerts         *ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyAlerts        `json:"alerts,omitempty"`         // Email alert settings for DHCP servers
+	AllowedServers []string                                                        `json:"allowedServers,omitempty"` // List the MAC addresses of DHCP servers to permit on the network when defaultPolicy is set       to block.An empty array will clear the entries.
+	ArpInspection  *ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyArpInspection `json:"arpInspection,omitempty"`  // Dynamic ARP Inspection settings
+	BlockedServers []string                                                        `json:"blockedServers,omitempty"` // List the MAC addresses of DHCP servers to block on the network when defaultPolicy is set       to allow.An empty array will clear the entries.
+	DefaultPolicy  string                                                          `json:"defaultPolicy,omitempty"`  // 'allow' or 'block' new DHCP servers. Default value is 'allow'.
+}
+type ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyAlerts struct {
+	Email *ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyAlertsEmail `json:"email,omitempty"` // Alert settings for DHCP servers
+}
+type ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyAlertsEmail struct {
+	Enabled *bool `json:"enabled,omitempty"` // When enabled, send an email if a new DHCP server is seen. Default value is false.
+}
+type ResponseSwitchUpdateNetworkSwitchDhcpServerPolicyArpInspection struct {
+	Enabled           *bool    `json:"enabled,omitempty"`           // Enable or disable Dynamic ARP Inspection on the network. Default value is false.
+	UnsupportedModels []string `json:"unsupportedModels,omitempty"` // List of switch models that does not support dynamic ARP inspection
+}
 type ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers []ResponseItemSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers // Array of ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers
 type ResponseItemSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers struct {
 	IPv4            *ResponseItemSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersIPv4 `json:"ipv4,omitempty"`            // IPv4 attributes of the trusted server.
@@ -819,22 +915,22 @@ type ResponseItemSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDe
 	URL                string `json:"url,omitempty"`                // Url link to switch.
 }
 type ResponseSwitchGetNetworkSwitchDscpToCosMappings struct {
-	Mappings *[]ResponseSwitchGetNetworkSwitchDscpToCosMappingsMappings `json:"mappings,omitempty"` //
+	Mappings *[]ResponseSwitchGetNetworkSwitchDscpToCosMappingsMappings `json:"mappings,omitempty"` // An array of DSCP to CoS mappings. An empty array will reset the mappings to default.
 }
 type ResponseSwitchGetNetworkSwitchDscpToCosMappingsMappings struct {
-	Cos   *int   `json:"cos,omitempty"`   //
-	Dscp  *int   `json:"dscp,omitempty"`  //
-	Title string `json:"title,omitempty"` //
+	Cos   *int   `json:"cos,omitempty"`   // The actual layer-2 CoS queue the DSCP value is mapped to. These are not bits set on outgoing frames. Value can be in the range of 0 to 5 inclusive.
+	Dscp  *int   `json:"dscp,omitempty"`  // The Differentiated Services Code Point (DSCP) tag in the IP header that will be mapped to a particular Class-of-Service (CoS) queue. Value can be in the range of 0 to 63 inclusive.
+	Title string `json:"title,omitempty"` // Label for the mapping (optional).
 }
 type ResponseSwitchUpdateNetworkSwitchDscpToCosMappings interface{}
 type ResponseSwitchGetNetworkSwitchLinkAggregations []ResponseItemSwitchGetNetworkSwitchLinkAggregations // Array of ResponseSwitchGetNetworkSwitchLinkAggregations
 type ResponseItemSwitchGetNetworkSwitchLinkAggregations struct {
 	ID          string                                                           `json:"id,omitempty"`          //
-	SwitchPorts *[]ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts `json:"switchPorts,omitempty"` // Array of switch or stack ports for creating aggregation group. Minimum 2 and maximum 8 ports are supported.
+	SwitchPorts *[]ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts `json:"switchPorts,omitempty"` //
 }
 type ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts struct {
-	PortID string `json:"portId,omitempty"` // Port identifier of switch port. For modules, the identifier is "SlotNumber_ModuleType_PortNumber" (Ex: "1_8X10G_1"), otherwise it is just the port number (Ex: "8").
-	Serial string `json:"serial,omitempty"` // Serial number of the switch.
+	PortID string `json:"portId,omitempty"` //
+	Serial string `json:"serial,omitempty"` //
 }
 type ResponseSwitchCreateNetworkSwitchLinkAggregation struct {
 	ID          string                                                         `json:"id,omitempty"`          //
@@ -847,66 +943,165 @@ type ResponseSwitchCreateNetworkSwitchLinkAggregationSwitchPorts struct {
 type ResponseSwitchUpdateNetworkSwitchLinkAggregation interface{}
 type ResponseSwitchGetNetworkSwitchMtu struct {
 	DefaultMtuSize *int                                          `json:"defaultMtuSize,omitempty"` // MTU size for the entire network. Default value is 9578.
-	Overrides      *[]ResponseSwitchGetNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch profiles.       An empty array will clear overrides.
+	Overrides      *[]ResponseSwitchGetNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch templates.       An empty array will clear overrides.
 }
 type ResponseSwitchGetNetworkSwitchMtuOverrides struct {
-	MtuSize        *int     `json:"mtuSize,omitempty"`        // MTU size for the switches or switch profiles.
-	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch profile IDs. Applicable only for template network.
+	MtuSize        *int     `json:"mtuSize,omitempty"`        // MTU size for the switches or switch templates.
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs. Applicable only for template network.
 	Switches       []string `json:"switches,omitempty"`       // List of switch serials. Applicable only for switch network.
 }
 type ResponseSwitchUpdateNetworkSwitchMtu interface{}
 type ResponseSwitchGetNetworkSwitchPortSchedules []ResponseItemSwitchGetNetworkSwitchPortSchedules // Array of ResponseSwitchGetNetworkSwitchPortSchedules
 type ResponseItemSwitchGetNetworkSwitchPortSchedules struct {
-	ID           string                                                       `json:"id,omitempty"`           //
-	Name         string                                                       `json:"name,omitempty"`         // The name for your port schedule. Required
-	PortSchedule *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortSchedule `json:"portSchedule,omitempty"` //     The schedule for switch port scheduling. Schedules are applied to days of the week.     When it's empty, default schedule with all days of a week are configured.     Any unspecified day in the schedule is added as a default schedule configuration of the day.
+	ID           string                                                       `json:"id,omitempty"`           // Switch port schedule ID
+	Name         string                                                       `json:"name,omitempty"`         // Switch port schedule name
+	NetworkID    string                                                       `json:"networkId,omitempty"`    // Network ID
+	PortSchedule *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortSchedule `json:"portSchedule,omitempty"` // Port schedule
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortSchedule struct {
-	Friday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleFriday    `json:"friday,omitempty"`    // The schedule object for Friday.
-	Monday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleMonday    `json:"monday,omitempty"`    // The schedule object for Monday.
-	Saturday  *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSaturday  `json:"saturday,omitempty"`  // The schedule object for Saturday.
-	Sunday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSunday    `json:"sunday,omitempty"`    // The schedule object for Sunday.
-	Thursday  *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleThursday  `json:"thursday,omitempty"`  // The schedule object for Thursday.
-	Tuesday   *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleTuesday   `json:"tuesday,omitempty"`   // The schedule object for Tuesday.
-	Wednesday *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleWednesday `json:"wednesday,omitempty"` // The schedule object for Wednesday.
+	Friday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleFriday    `json:"friday,omitempty"`    // Friday schedule
+	Monday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleMonday    `json:"monday,omitempty"`    // Monday schedule
+	Saturday  *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSaturday  `json:"saturday,omitempty"`  // Saturday schedule
+	Sunday    *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSunday    `json:"sunday,omitempty"`    // Sunday schedule
+	Thursday  *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleThursday  `json:"thursday,omitempty"`  // Thursday schedule
+	Tuesday   *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleTuesday   `json:"tuesday,omitempty"`   // Tuesday schedule
+	Wednesday *ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleWednesday `json:"wednesday,omitempty"` // Wednesday schedule
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleFriday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleMonday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSaturday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleSunday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleThursday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleTuesday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
 type ResponseItemSwitchGetNetworkSwitchPortSchedulesPortScheduleWednesday struct {
-	Active *bool  `json:"active,omitempty"` // Whether the schedule is active (true) or inactive (false) during the time specified between 'from' and 'to'. Defaults to true.
-	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'. Must be less than the time specified in 'to'. Defaults to '00:00'. Only 30 minute increments are allowed.
-	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
 }
-type ResponseSwitchCreateNetworkSwitchPortSchedule interface{}
-type ResponseSwitchUpdateNetworkSwitchPortSchedule interface{}
+type ResponseSwitchCreateNetworkSwitchPortSchedule struct {
+	ID           string                                                     `json:"id,omitempty"`           // Switch port schedule ID
+	Name         string                                                     `json:"name,omitempty"`         // Switch port schedule name
+	NetworkID    string                                                     `json:"networkId,omitempty"`    // Network ID
+	PortSchedule *ResponseSwitchCreateNetworkSwitchPortSchedulePortSchedule `json:"portSchedule,omitempty"` // Port schedule
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortSchedule struct {
+	Friday    *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleFriday    `json:"friday,omitempty"`    // Friday schedule
+	Monday    *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleMonday    `json:"monday,omitempty"`    // Monday schedule
+	Saturday  *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleSaturday  `json:"saturday,omitempty"`  // Saturday schedule
+	Sunday    *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleSunday    `json:"sunday,omitempty"`    // Sunday schedule
+	Thursday  *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleThursday  `json:"thursday,omitempty"`  // Thursday schedule
+	Tuesday   *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleTuesday   `json:"tuesday,omitempty"`   // Tuesday schedule
+	Wednesday *ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleWednesday `json:"wednesday,omitempty"` // Wednesday schedule
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleFriday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleMonday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleSaturday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleSunday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleThursday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleTuesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchCreateNetworkSwitchPortSchedulePortScheduleWednesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedule struct {
+	ID           string                                                     `json:"id,omitempty"`           // Switch port schedule ID
+	Name         string                                                     `json:"name,omitempty"`         // Switch port schedule name
+	NetworkID    string                                                     `json:"networkId,omitempty"`    // Network ID
+	PortSchedule *ResponseSwitchUpdateNetworkSwitchPortSchedulePortSchedule `json:"portSchedule,omitempty"` // Port schedule
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortSchedule struct {
+	Friday    *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleFriday    `json:"friday,omitempty"`    // Friday schedule
+	Monday    *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleMonday    `json:"monday,omitempty"`    // Monday schedule
+	Saturday  *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleSaturday  `json:"saturday,omitempty"`  // Saturday schedule
+	Sunday    *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleSunday    `json:"sunday,omitempty"`    // Sunday schedule
+	Thursday  *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleThursday  `json:"thursday,omitempty"`  // Thursday schedule
+	Tuesday   *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleTuesday   `json:"tuesday,omitempty"`   // Tuesday schedule
+	Wednesday *ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleWednesday `json:"wednesday,omitempty"` // Wednesday schedule
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleFriday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleMonday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleSaturday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleSunday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleThursday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleTuesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
+type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleWednesday struct {
+	Active *bool  `json:"active,omitempty"` // Whether the schedule is active or inactive
+	From   string `json:"from,omitempty"`   // The time, from '00:00' to '24:00'
+	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'
+}
 type ResponseSwitchGetNetworkSwitchQosRules []ResponseItemSwitchGetNetworkSwitchQosRules // Array of ResponseSwitchGetNetworkSwitchQosRules
 type ResponseItemSwitchGetNetworkSwitchQosRules struct {
 	Dscp         *int   `json:"dscp,omitempty"`         //
@@ -933,51 +1128,75 @@ type ResponseSwitchGetNetworkSwitchQosRulesOrder struct {
 }
 type ResponseSwitchUpdateNetworkSwitchQosRulesOrder interface{}
 type ResponseSwitchGetNetworkSwitchQosRule struct {
-	Dscp         *int   `json:"dscp,omitempty"`         //
-	DstPort      *int   `json:"dstPort,omitempty"`      //
-	DstPortRange string `json:"dstPortRange,omitempty"` //
-	ID           string `json:"id,omitempty"`           //
-	Protocol     string `json:"protocol,omitempty"`     //
-	SrcPort      *int   `json:"srcPort,omitempty"`      //
-	SrcPortRange string `json:"srcPortRange,omitempty"` //
-	VLAN         *int   `json:"vlan,omitempty"`         //
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag. Set this to -1 to trust incoming DSCP. Default value is 0
+	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	ID           string `json:"id,omitempty"`           // Qos Rule id
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY"
+	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
 }
 type ResponseSwitchUpdateNetworkSwitchQosRule interface{}
 type ResponseSwitchGetNetworkSwitchRoutingMulticast struct {
-	DefaultSettings *ResponseSwitchGetNetworkSwitchRoutingMulticastDefaultSettings `json:"defaultSettings,omitempty"` //
-	Overrides       *[]ResponseSwitchGetNetworkSwitchRoutingMulticastOverrides     `json:"overrides,omitempty"`       //
+	DefaultSettings *ResponseSwitchGetNetworkSwitchRoutingMulticastDefaultSettings `json:"defaultSettings,omitempty"` // Default multicast setting for entire network. IGMP snooping and Flood unknown       multicast traffic settings are enabled by default.
+	Overrides       *[]ResponseSwitchGetNetworkSwitchRoutingMulticastOverrides     `json:"overrides,omitempty"`       // Array of paired switches/stacks/profiles and corresponding multicast settings.       An empty array will clear the multicast settings.
 }
 type ResponseSwitchGetNetworkSwitchRoutingMulticastDefaultSettings struct {
-	FloodUnknownMulticastTrafficEnabled *bool `json:"floodUnknownMulticastTrafficEnabled,omitempty"` //
-	IgmpSnoopingEnabled                 *bool `json:"igmpSnoopingEnabled,omitempty"`                 //
+	FloodUnknownMulticastTrafficEnabled *bool `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic enabled for the entire network
+	IgmpSnoopingEnabled                 *bool `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping enabled for the entire network
 }
 type ResponseSwitchGetNetworkSwitchRoutingMulticastOverrides struct {
-	FloodUnknownMulticastTrafficEnabled *bool    `json:"floodUnknownMulticastTrafficEnabled,omitempty"` //
-	IgmpSnoopingEnabled                 *bool    `json:"igmpSnoopingEnabled,omitempty"`                 //
-	Switches                            []string `json:"switches,omitempty"`                            //
+	FloodUnknownMulticastTrafficEnabled *bool    `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic enabled for switches, switch stacks or switch templates
+	IgmpSnoopingEnabled                 *bool    `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping enabled for switches, switch stacks or switch templates
+	Stacks                              []string `json:"stacks,omitempty"`                              // (optional) List of switch stack ids for non-template network
+	SwitchProfiles                      []string `json:"switchProfiles,omitempty"`                      // (optional) List of switch templates ids for template network
+	Switches                            []string `json:"switches,omitempty"`                            // (optional) List of switch serials for non-template network
 }
-type ResponseSwitchUpdateNetworkSwitchRoutingMulticast interface{}
+type ResponseSwitchUpdateNetworkSwitchRoutingMulticast struct {
+	DefaultSettings *ResponseSwitchUpdateNetworkSwitchRoutingMulticastDefaultSettings `json:"defaultSettings,omitempty"` // Default multicast setting for entire network. IGMP snooping and Flood unknown       multicast traffic settings are enabled by default.
+	Overrides       *[]ResponseSwitchUpdateNetworkSwitchRoutingMulticastOverrides     `json:"overrides,omitempty"`       // Array of paired switches/stacks/profiles and corresponding multicast settings.       An empty array will clear the multicast settings.
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingMulticastDefaultSettings struct {
+	FloodUnknownMulticastTrafficEnabled *bool `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic enabled for the entire network
+	IgmpSnoopingEnabled                 *bool `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping enabled for the entire network
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingMulticastOverrides struct {
+	FloodUnknownMulticastTrafficEnabled *bool    `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic enabled for switches, switch stacks or switch templates
+	IgmpSnoopingEnabled                 *bool    `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping enabled for switches, switch stacks or switch templates
+	Stacks                              []string `json:"stacks,omitempty"`                              // (optional) List of switch stack ids for non-template network
+	SwitchProfiles                      []string `json:"switchProfiles,omitempty"`                      // (optional) List of switch templates ids for template network
+	Switches                            []string `json:"switches,omitempty"`                            // (optional) List of switch serials for non-template network
+}
 type ResponseSwitchGetNetworkSwitchRoutingMulticastRendezvousPoints []ResponseItemSwitchGetNetworkSwitchRoutingMulticastRendezvousPoints // Array of ResponseSwitchGetNetworkSwitchRoutingMulticastRendezvousPoints
 type ResponseItemSwitchGetNetworkSwitchRoutingMulticastRendezvousPoints struct {
-	InterfaceIP       string `json:"interfaceIp,omitempty"`       //
-	InterfaceName     string `json:"interfaceName,omitempty"`     //
-	MulticastGroup    string `json:"multicastGroup,omitempty"`    //
-	RendezvousPointID string `json:"rendezvousPointId,omitempty"` //
-	Serial            string `json:"serial,omitempty"`            //
+	InterfaceIP       string `json:"interfaceIp,omitempty"`       // The IP address of the interface to use.
+	InterfaceName     string `json:"interfaceName,omitempty"`     // The name of the interface to use.
+	MulticastGroup    string `json:"multicastGroup,omitempty"`    // 'Any', or the IP address of a multicast group.
+	RendezvousPointID string `json:"rendezvousPointId,omitempty"` // The id.
+	Serial            string `json:"serial,omitempty"`            // The serial.
 }
 type ResponseSwitchCreateNetworkSwitchRoutingMulticastRendezvousPoint struct {
-	InterfaceIP       string `json:"interfaceIp,omitempty"`       //
-	MulticastGroup    string `json:"multicastGroup,omitempty"`    //
-	RendezvousPointID string `json:"rendezvousPointId,omitempty"` //
+	InterfaceIP       string `json:"interfaceIp,omitempty"`       // The IP address of the interface to use.
+	InterfaceName     string `json:"interfaceName,omitempty"`     // The name of the interface to use.
+	MulticastGroup    string `json:"multicastGroup,omitempty"`    // 'Any', or the IP address of a multicast group.
+	RendezvousPointID string `json:"rendezvousPointId,omitempty"` // The id.
+	Serial            string `json:"serial,omitempty"`            // The serial.
 }
 type ResponseSwitchGetNetworkSwitchRoutingMulticastRendezvousPoint struct {
-	InterfaceIP       string `json:"interfaceIp,omitempty"`       //
-	InterfaceName     string `json:"interfaceName,omitempty"`     //
-	MulticastGroup    string `json:"multicastGroup,omitempty"`    //
-	RendezvousPointID string `json:"rendezvousPointId,omitempty"` //
-	Serial            string `json:"serial,omitempty"`            //
+	InterfaceIP       string `json:"interfaceIp,omitempty"`       // The IP address of the interface to use.
+	InterfaceName     string `json:"interfaceName,omitempty"`     // The name of the interface to use.
+	MulticastGroup    string `json:"multicastGroup,omitempty"`    // 'Any', or the IP address of a multicast group.
+	RendezvousPointID string `json:"rendezvousPointId,omitempty"` // The id.
+	Serial            string `json:"serial,omitempty"`            // The serial.
 }
-type ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint interface{}
+type ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint struct {
+	InterfaceIP       string `json:"interfaceIp,omitempty"`       // The IP address of the interface to use.
+	InterfaceName     string `json:"interfaceName,omitempty"`     // The name of the interface to use.
+	MulticastGroup    string `json:"multicastGroup,omitempty"`    // 'Any', or the IP address of a multicast group.
+	RendezvousPointID string `json:"rendezvousPointId,omitempty"` // The id.
+	Serial            string `json:"serial,omitempty"`            // The serial.
+}
 type ResponseSwitchGetNetworkSwitchRoutingOspf struct {
 	Areas                    *[]ResponseSwitchGetNetworkSwitchRoutingOspfAreas              `json:"areas,omitempty"`                    //
 	DeadTimerInSeconds       *int                                                           `json:"deadTimerInSeconds,omitempty"`       //
@@ -1009,153 +1228,276 @@ type ResponseSwitchGetNetworkSwitchRoutingOspfV3Areas struct {
 }
 type ResponseSwitchUpdateNetworkSwitchRoutingOspf interface{}
 type ResponseSwitchGetNetworkSwitchSettings struct {
-	PowerExceptions  *[]ResponseSwitchGetNetworkSwitchSettingsPowerExceptions `json:"powerExceptions,omitempty"`  // Exceptions on a per switch basis to "useCombinedPower"
-	UseCombinedPower *bool                                                    `json:"useCombinedPower,omitempty"` // The use Combined Power as the default behavior of secondary power supplies on supported devices.
-	VLAN             *int                                                     `json:"vlan,omitempty"`             // Management VLAN
+	MacBlocklist         *ResponseSwitchGetNetworkSwitchSettingsMacBlocklist         `json:"macBlocklist,omitempty"`         // MAC blocklist
+	PowerExceptions      *[]ResponseSwitchGetNetworkSwitchSettingsPowerExceptions    `json:"powerExceptions,omitempty"`      // Exceptions on a per switch basis to "useCombinedPower"
+	UplinkClientSampling *ResponseSwitchGetNetworkSwitchSettingsUplinkClientSampling `json:"uplinkClientSampling,omitempty"` // Uplink client sampling
+	UseCombinedPower     *bool                                                       `json:"useCombinedPower,omitempty"`     // The use Combined Power as the default behavior of secondary power supplies on supported devices.
+	VLAN                 *int                                                        `json:"vlan,omitempty"`                 // Management VLAN
+}
+type ResponseSwitchGetNetworkSwitchSettingsMacBlocklist struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable MAC blocklist for switches in the network
 }
 type ResponseSwitchGetNetworkSwitchSettingsPowerExceptions struct {
 	PowerType string `json:"powerType,omitempty"` // Per switch exception (combined, redundant, useNetworkSetting)
 	Serial    string `json:"serial,omitempty"`    // Serial number of the switch
 }
+type ResponseSwitchGetNetworkSwitchSettingsUplinkClientSampling struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable client sampling on uplink
+}
 type ResponseSwitchUpdateNetworkSwitchSettings struct {
-	PowerExceptions  *[]ResponseSwitchUpdateNetworkSwitchSettingsPowerExceptions `json:"powerExceptions,omitempty"`  // Exceptions on a per switch basis to "useCombinedPower"
-	UseCombinedPower *bool                                                       `json:"useCombinedPower,omitempty"` // The use Combined Power as the default behavior of secondary power supplies on supported devices.
-	VLAN             *int                                                        `json:"vlan,omitempty"`             // Management VLAN
+	MacBlocklist         *ResponseSwitchUpdateNetworkSwitchSettingsMacBlocklist         `json:"macBlocklist,omitempty"`         // MAC blocklist
+	PowerExceptions      *[]ResponseSwitchUpdateNetworkSwitchSettingsPowerExceptions    `json:"powerExceptions,omitempty"`      // Exceptions on a per switch basis to "useCombinedPower"
+	UplinkClientSampling *ResponseSwitchUpdateNetworkSwitchSettingsUplinkClientSampling `json:"uplinkClientSampling,omitempty"` // Uplink client sampling
+	UseCombinedPower     *bool                                                          `json:"useCombinedPower,omitempty"`     // The use Combined Power as the default behavior of secondary power supplies on supported devices.
+	VLAN                 *int                                                           `json:"vlan,omitempty"`                 // Management VLAN
+}
+type ResponseSwitchUpdateNetworkSwitchSettingsMacBlocklist struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable MAC blocklist for switches in the network
 }
 type ResponseSwitchUpdateNetworkSwitchSettingsPowerExceptions struct {
 	PowerType string `json:"powerType,omitempty"` // Per switch exception (combined, redundant, useNetworkSetting)
 	Serial    string `json:"serial,omitempty"`    // Serial number of the switch
 }
+type ResponseSwitchUpdateNetworkSwitchSettingsUplinkClientSampling struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable client sampling on uplink
+}
 type ResponseSwitchGetNetworkSwitchStacks []ResponseItemSwitchGetNetworkSwitchStacks // Array of ResponseSwitchGetNetworkSwitchStacks
 type ResponseItemSwitchGetNetworkSwitchStacks struct {
-	ID      string   `json:"id,omitempty"`      //
-	Name    string   `json:"name,omitempty"`    //
-	Serials []string `json:"serials,omitempty"` //
+	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
+	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
+	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
 }
-type ResponseSwitchCreateNetworkSwitchStack interface{}
+type ResponseSwitchCreateNetworkSwitchStack struct {
+	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
+	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
+	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+}
 type ResponseSwitchGetNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // Switch stacks id
-	Name    string   `json:"name,omitempty"`    // Switch stacks name
+	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
+	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
 	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
 }
 type ResponseSwitchAddNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // Switch stacks id
-	Name    string   `json:"name,omitempty"`    // Switch stacks name
+	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
+	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
 	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
 }
-type ResponseSwitchRemoveNetworkSwitchStack interface{}
+type ResponseSwitchRemoveNetworkSwitchStack struct {
+	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
+	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
+	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+}
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaces []ResponseItemSwitchGetNetworkSwitchStackRoutingInterfaces // Array of ResponseSwitchGetNetworkSwitchStackRoutingInterfaces
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfaces struct {
-	DefaultGateway   string                                                                `json:"defaultGateway,omitempty"`   //
-	InterfaceID      string                                                                `json:"interfaceId,omitempty"`      //
-	InterfaceIP      string                                                                `json:"interfaceIp,omitempty"`      //
-	IPv6             *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesIPv6         `json:"ipv6,omitempty"`             //
-	MulticastRouting string                                                                `json:"multicastRouting,omitempty"` //
-	Name             string                                                                `json:"name,omitempty"`             //
-	OspfSettings     *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfSettings `json:"ospfSettings,omitempty"`     //
-	OspfV3           *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfV3       `json:"ospfV3,omitempty"`           //
-	Subnet           string                                                                `json:"subnet,omitempty"`           //
-	VLANID           *int                                                                  `json:"vlanId,omitempty"`           //
+	DefaultGateway   string                                                                `json:"defaultGateway,omitempty"`   // IPv4 default gateway
+	InterfaceID      string                                                                `json:"interfaceId,omitempty"`      // The id
+	InterfaceIP      string                                                                `json:"interfaceIp,omitempty"`      // IPv4 address
+	IPv6             *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesIPv6         `json:"ipv6,omitempty"`             // IPv6 addressing
+	MulticastRouting string                                                                `json:"multicastRouting,omitempty"` // Multicast routing status
+	Name             string                                                                `json:"name,omitempty"`             // The name
+	OspfSettings     *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
+	OspfV3           *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
+	Subnet           string                                                                `json:"subnet,omitempty"`           // IPv4 subnet
+	VLANID           *int                                                                  `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesIPv6 struct {
-	Address        string `json:"address,omitempty"`        //
-	AssignmentMode string `json:"assignmentMode,omitempty"` //
-	Gateway        string `json:"gateway,omitempty"`        //
-	Prefix         string `json:"prefix,omitempty"`         //
+	Address        string `json:"address,omitempty"`        // IPv6 address
+	AssignmentMode string `json:"assignmentMode,omitempty"` // Assignment mode
+	Gateway        string `json:"gateway,omitempty"`        // IPv6 gateway
+	Prefix         string `json:"prefix,omitempty"`         // IPv6 subnet
 }
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfSettings struct {
-	Area             string `json:"area,omitempty"`             //
-	Cost             *int   `json:"cost,omitempty"`             //
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` //
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv4 area
 }
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfV3 struct {
-	Area             string `json:"area,omitempty"`             //
-	Cost             *int   `json:"cost,omitempty"`             //
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` //
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv6 area
 }
-type ResponseSwitchCreateNetworkSwitchStackRoutingInterface interface{}
+type ResponseSwitchCreateNetworkSwitchStackRoutingInterface struct {
+	DefaultGateway   string                                                              `json:"defaultGateway,omitempty"`   // IPv4 default gateway
+	InterfaceID      string                                                              `json:"interfaceId,omitempty"`      // The id
+	InterfaceIP      string                                                              `json:"interfaceIp,omitempty"`      // IPv4 address
+	IPv6             *ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceIPv6         `json:"ipv6,omitempty"`             // IPv6 addressing
+	MulticastRouting string                                                              `json:"multicastRouting,omitempty"` // Multicast routing status
+	Name             string                                                              `json:"name,omitempty"`             // The name
+	OspfSettings     *ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
+	OspfV3           *ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
+	Subnet           string                                                              `json:"subnet,omitempty"`           // IPv4 subnet
+	VLANID           *int                                                                `json:"vlanId,omitempty"`           // VLAN id
+}
+type ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceIPv6 struct {
+	Address        string `json:"address,omitempty"`        // IPv6 address
+	AssignmentMode string `json:"assignmentMode,omitempty"` // Assignment mode
+	Gateway        string `json:"gateway,omitempty"`        // IPv6 gateway
+	Prefix         string `json:"prefix,omitempty"`         // IPv6 subnet
+}
+type ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfSettings struct {
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv4 area
+}
+type ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfV3 struct {
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv6 area
+}
 type ResponseSwitchGetNetworkSwitchStackRoutingInterface struct {
-	DefaultGateway   string                                                           `json:"defaultGateway,omitempty"`   //
-	InterfaceID      string                                                           `json:"interfaceId,omitempty"`      //
-	InterfaceIP      string                                                           `json:"interfaceIp,omitempty"`      //
-	IPv6             *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceIPv6         `json:"ipv6,omitempty"`             //
-	MulticastRouting string                                                           `json:"multicastRouting,omitempty"` //
-	Name             string                                                           `json:"name,omitempty"`             //
-	OspfSettings     *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     //
-	OspfV3           *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           //
-	Subnet           string                                                           `json:"subnet,omitempty"`           //
-	VLANID           *int                                                             `json:"vlanId,omitempty"`           //
+	DefaultGateway   string                                                           `json:"defaultGateway,omitempty"`   // IPv4 default gateway
+	InterfaceID      string                                                           `json:"interfaceId,omitempty"`      // The id
+	InterfaceIP      string                                                           `json:"interfaceIp,omitempty"`      // IPv4 address
+	IPv6             *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceIPv6         `json:"ipv6,omitempty"`             // IPv6 addressing
+	MulticastRouting string                                                           `json:"multicastRouting,omitempty"` // Multicast routing status
+	Name             string                                                           `json:"name,omitempty"`             // The name
+	OspfSettings     *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
+	OspfV3           *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
+	Subnet           string                                                           `json:"subnet,omitempty"`           // IPv4 subnet
+	VLANID           *int                                                             `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceIPv6 struct {
-	Address        string `json:"address,omitempty"`        //
-	AssignmentMode string `json:"assignmentMode,omitempty"` //
-	Gateway        string `json:"gateway,omitempty"`        //
-	Prefix         string `json:"prefix,omitempty"`         //
+	Address        string `json:"address,omitempty"`        // IPv6 address
+	AssignmentMode string `json:"assignmentMode,omitempty"` // Assignment mode
+	Gateway        string `json:"gateway,omitempty"`        // IPv6 gateway
+	Prefix         string `json:"prefix,omitempty"`         // IPv6 subnet
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfSettings struct {
-	Area             string `json:"area,omitempty"`             //
-	Cost             *int   `json:"cost,omitempty"`             //
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` //
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv4 area
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfV3 struct {
-	Area             string `json:"area,omitempty"`             //
-	Cost             *int   `json:"cost,omitempty"`             //
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` //
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv6 area
 }
-type ResponseSwitchUpdateNetworkSwitchStackRoutingInterface interface{}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterface struct {
+	InterfaceID      string                                                              `json:"interfaceId,omitempty"`      // The id
+	InterfaceIP      string                                                              `json:"interfaceIp,omitempty"`      // IPv4 address
+	IPv6             *ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceIPv6         `json:"ipv6,omitempty"`             // IPv6 addressing
+	MulticastRouting string                                                              `json:"multicastRouting,omitempty"` // Multicast routing status
+	Name             string                                                              `json:"name,omitempty"`             // The name
+	OspfSettings     *ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
+	OspfV3           *ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
+	Subnet           string                                                              `json:"subnet,omitempty"`           // IPv4 subnet
+	VLANID           *int                                                                `json:"vlanId,omitempty"`           // VLAN id
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceIPv6 struct {
+	Address        string `json:"address,omitempty"`        // IPv6 address
+	AssignmentMode string `json:"assignmentMode,omitempty"` // Assignment mode
+	Gateway        string `json:"gateway,omitempty"`        // IPv6 gateway
+	Prefix         string `json:"prefix,omitempty"`         // IPv6 subnet
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfSettings struct {
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv4 area
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfV3 struct {
+	Area             string `json:"area,omitempty"`             // Area id
+	Cost             *int   `json:"cost,omitempty"`             // OSPF Cost
+	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // Disable sending Hello packets on this interface's IPv6 area
+}
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcp struct {
-	BootFileName         string                                                                       `json:"bootFileName,omitempty"`         //
-	BootNextServer       string                                                                       `json:"bootNextServer,omitempty"`       //
-	BootOptionsEnabled   *bool                                                                        `json:"bootOptionsEnabled,omitempty"`   //
-	DhcpLeaseTime        string                                                                       `json:"dhcpLeaseTime,omitempty"`        //
-	DhcpMode             string                                                                       `json:"dhcpMode,omitempty"`             //
-	DhcpOptions          *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          //
-	DNSCustomNameservers []string                                                                     `json:"dnsCustomNameservers,omitempty"` //
-	DNSNameserversOption string                                                                       `json:"dnsNameserversOption,omitempty"` //
-	FixedIPAssignments   *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   //
-	ReservedIPRanges     *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     //
+	BootFileName         string                                                                       `json:"bootFileName,omitempty"`         // The PXE boot server file name for the DHCP server running on the switch stack interface
+	BootNextServer       string                                                                       `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch stack interface
+	BootOptionsEnabled   *bool                                                                        `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch stack interface
+	DhcpLeaseTime        string                                                                       `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on the switch stack interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                       `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	DhcpOptions          *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch stack interface
+	DhcpRelayServerIPs   []string                                                                     `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch stack interface
+	DNSCustomNameservers []string                                                                     `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
+	DNSNameserversOption string                                                                       `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface ('googlePublicDns', 'openDns' or 'custom')
+	FixedIPAssignments   *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+	ReservedIPRanges     *[]ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions struct {
-	Code  string `json:"code,omitempty"`  //
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Value string `json:"value,omitempty"` // The value of the DHCP option
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments struct {
-	IP   string `json:"ip,omitempty"`   //
-	Mac  string `json:"mac,omitempty"`  //
-	Name string `json:"name,omitempty"` //
+	IP   string `json:"ip,omitempty"`   // The IP address of the client which has fixed IP address assigned to it
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the client which has fixed IP address
+	Name string `json:"name,omitempty"` // The name of the client which has fixed IP address
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` //
-	End     string `json:"end,omitempty"`     //
-	Start   string `json:"start,omitempty"`   //
+	Comment string `json:"comment,omitempty"` // The comment for the reserved IP range
+	End     string `json:"end,omitempty"`     // The ending IP address of the reserved IP range
+	Start   string `json:"start,omitempty"`   // The starting IP address of the reserved IP range
 }
-type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp interface{}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp struct {
+	BootFileName         string                                                                          `json:"bootFileName,omitempty"`         // The PXE boot server file name for the DHCP server running on the switch stack interface
+	BootNextServer       string                                                                          `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch stack interface
+	BootOptionsEnabled   *bool                                                                           `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch stack interface
+	DhcpLeaseTime        string                                                                          `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on the switch stack interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                          `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	DhcpOptions          *[]ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch stack interface
+	DhcpRelayServerIPs   []string                                                                        `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch stack interface
+	DNSCustomNameservers []string                                                                        `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
+	DNSNameserversOption string                                                                          `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface ('googlePublicDns', 'openDns' or 'custom')
+	FixedIPAssignments   *[]ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+	ReservedIPRanges     *[]ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions struct {
+	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Value string `json:"value,omitempty"` // The value of the DHCP option
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments struct {
+	IP   string `json:"ip,omitempty"`   // The IP address of the client which has fixed IP address assigned to it
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the client which has fixed IP address
+	Name string `json:"name,omitempty"` // The name of the client which has fixed IP address
+}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges struct {
+	Comment string `json:"comment,omitempty"` // The comment for the reserved IP range
+	End     string `json:"end,omitempty"`     // The ending IP address of the reserved IP range
+	Start   string `json:"start,omitempty"`   // The starting IP address of the reserved IP range
+}
 type ResponseSwitchGetNetworkSwitchStackRoutingStaticRoutes []ResponseItemSwitchGetNetworkSwitchStackRoutingStaticRoutes // Array of ResponseSwitchGetNetworkSwitchStackRoutingStaticRoutes
 type ResponseItemSwitchGetNetworkSwitchStackRoutingStaticRoutes struct {
-	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     //
-	Name                        string `json:"name,omitempty"`                        //
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //
-	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` //
-	StaticRouteID               string `json:"staticRouteId,omitempty"`               //
-	Subnet                      string `json:"subnet,omitempty"`                      //
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
-type ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute interface{}
+type ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute struct {
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
+}
 type ResponseSwitchGetNetworkSwitchStackRoutingStaticRoute struct {
-	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     //
-	Name                        string `json:"name,omitempty"`                        //
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //
-	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` //
-	StaticRouteID               string `json:"staticRouteId,omitempty"`               //
-	Subnet                      string `json:"subnet,omitempty"`                      //
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
-type ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute interface{}
+type ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute struct {
+	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
+	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
+	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
+}
 type ResponseSwitchGetNetworkSwitchStormControl struct {
 	BroadcastThreshold      *int `json:"broadcastThreshold,omitempty"`      // Broadcast threshold.
 	MulticastThreshold      *int `json:"multicastThreshold,omitempty"`      // Multicast threshold.
 	UnknownUnicastThreshold *int `json:"unknownUnicastThreshold,omitempty"` // Unknown Unicast threshold.
 }
-type ResponseSwitchUpdateNetworkSwitchStormControl interface{}
+type ResponseSwitchUpdateNetworkSwitchStormControl struct {
+	BroadcastThreshold      *int `json:"broadcastThreshold,omitempty"`      // Broadcast threshold.
+	MulticastThreshold      *int `json:"multicastThreshold,omitempty"`      // Multicast threshold.
+	UnknownUnicastThreshold *int `json:"unknownUnicastThreshold,omitempty"` // Unknown Unicast threshold.
+}
 type ResponseSwitchGetNetworkSwitchStp struct {
 	RstpEnabled       *bool                                                 `json:"rstpEnabled,omitempty"`       //
 	StpBridgePriority *[]ResponseSwitchGetNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` //
@@ -1165,38 +1507,47 @@ type ResponseSwitchGetNetworkSwitchStpStpBridgePriority struct {
 	Switches    []string `json:"switches,omitempty"`    //
 }
 type ResponseSwitchUpdateNetworkSwitchStp interface{}
-type ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles struct {
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles []ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfiles // Array of ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfiles struct {
 	Model           string `json:"model,omitempty"`           // Switch model
-	Name            string `json:"name,omitempty"`            // Switch profile name
-	SwitchProfileID string `json:"switchProfileId,omitempty"` // Switch profile id
+	Name            string `json:"name,omitempty"`            // Switch template name
+	SwitchProfileID string `json:"switchProfileId,omitempty"` // Switch template id
 }
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePorts []ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePorts // Array of ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePorts
 type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePorts struct {
-	AccessPolicyNumber          *int                                                                      `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch profile port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                                    `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch profile port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                                    `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch profile port. Only applicable to trunk ports.
+	AccessPolicyNumber          *int                                                                      `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                                    `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                                    `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
 	DaiTrusted                  *bool                                                                     `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                     `json:"enabled,omitempty"`                     // The status of the switch profile port.
+	Enabled                     *bool                                                                     `json:"enabled,omitempty"`                     // The status of the switch template port.
 	FlexibleStackingEnabled     *bool                                                                     `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                     `json:"isolationEnabled,omitempty"`            // The isolation status of the switch profile port.
-	LinkNegotiation             string                                                                    `json:"linkNegotiation,omitempty"`             // The link speed for the switch profile port.
-	LinkNegotiationCapabilities []string                                                                  `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch profile port.
+	IsolationEnabled            *bool                                                                     `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                                    `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                                  `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
 	MacAllowList                []string                                                                  `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Name                        string                                                                    `json:"name,omitempty"`                        // The name of the switch profile port.
-	PoeEnabled                  *bool                                                                     `json:"poeEnabled,omitempty"`                  // The PoE status of the switch profile port.
-	PortID                      string                                                                    `json:"portId,omitempty"`                      // The identifier of the switch profile port.
+	Mirror                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsModule  `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                                    `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                     `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                                    `json:"portId,omitempty"`                      // The identifier of the switch template port.
 	PortScheduleID              string                                                                    `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
 	Profile                     *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile `json:"profile,omitempty"`                     // Profile attributes
 	RstpEnabled                 *bool                                                                     `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
 	StickyMacAllowList          []string                                                                  `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
 	StickyMacAllowListLimit     *int                                                                      `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                     `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch profile port.
+	StormControlEnabled         *bool                                                                     `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
 	StpGuard                    string                                                                    `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                                  `json:"tags,omitempty"`                        // The list of tags of the switch profile port.
-	Type                        string                                                                    `json:"type,omitempty"`                        // The type of the switch profile port ('trunk' or 'access').
+	Tags                        []string                                                                  `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                                    `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
 	Udld                        string                                                                    `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                      `json:"vlan,omitempty"`                        // The VLAN of the switch profile port. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                      `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch profile port. Only applicable to access ports.
+	VLAN                        *int                                                                      `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                      `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -1204,31 +1555,39 @@ type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile st
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePort struct {
-	AccessPolicyNumber          *int                                                                 `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch profile port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                               `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch profile port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                               `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch profile port. Only applicable to trunk ports.
+	AccessPolicyNumber          *int                                                                 `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                               `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                               `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
 	DaiTrusted                  *bool                                                                `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                `json:"enabled,omitempty"`                     // The status of the switch profile port.
+	Enabled                     *bool                                                                `json:"enabled,omitempty"`                     // The status of the switch template port.
 	FlexibleStackingEnabled     *bool                                                                `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                `json:"isolationEnabled,omitempty"`            // The isolation status of the switch profile port.
-	LinkNegotiation             string                                                               `json:"linkNegotiation,omitempty"`             // The link speed for the switch profile port.
-	LinkNegotiationCapabilities []string                                                             `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch profile port.
+	IsolationEnabled            *bool                                                                `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                               `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                             `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
 	MacAllowList                []string                                                             `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Name                        string                                                               `json:"name,omitempty"`                        // The name of the switch profile port.
-	PoeEnabled                  *bool                                                                `json:"poeEnabled,omitempty"`                  // The PoE status of the switch profile port.
-	PortID                      string                                                               `json:"portId,omitempty"`                      // The identifier of the switch profile port.
+	Mirror                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortModule  `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                               `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                               `json:"portId,omitempty"`                      // The identifier of the switch template port.
 	PortScheduleID              string                                                               `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
 	Profile                     *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile `json:"profile,omitempty"`                     // Profile attributes
 	RstpEnabled                 *bool                                                                `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
 	StickyMacAllowList          []string                                                             `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
 	StickyMacAllowListLimit     *int                                                                 `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch profile port.
+	StormControlEnabled         *bool                                                                `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
 	StpGuard                    string                                                               `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                             `json:"tags,omitempty"`                        // The list of tags of the switch profile port.
-	Type                        string                                                               `json:"type,omitempty"`                        // The type of the switch profile port ('trunk' or 'access').
+	Tags                        []string                                                             `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                               `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
 	Udld                        string                                                               `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                 `json:"vlan,omitempty"`                        // The VLAN of the switch profile port. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                 `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch profile port. Only applicable to access ports.
+	VLAN                        *int                                                                 `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                 `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -1236,36 +1595,49 @@ type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile struct 
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
 type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePort struct {
-	AccessPolicyNumber          *int                                                                    `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch profile port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                                  `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch profile port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                                  `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch profile port. Only applicable to trunk ports.
+	AccessPolicyNumber          *int                                                                    `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                                  `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                                  `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
 	DaiTrusted                  *bool                                                                   `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                   `json:"enabled,omitempty"`                     // The status of the switch profile port.
+	Enabled                     *bool                                                                   `json:"enabled,omitempty"`                     // The status of the switch template port.
 	FlexibleStackingEnabled     *bool                                                                   `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                   `json:"isolationEnabled,omitempty"`            // The isolation status of the switch profile port.
-	LinkNegotiation             string                                                                  `json:"linkNegotiation,omitempty"`             // The link speed for the switch profile port.
-	LinkNegotiationCapabilities []string                                                                `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch profile port.
+	IsolationEnabled            *bool                                                                   `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                                  `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                                `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
 	MacAllowList                []string                                                                `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Name                        string                                                                  `json:"name,omitempty"`                        // The name of the switch profile port.
-	PoeEnabled                  *bool                                                                   `json:"poeEnabled,omitempty"`                  // The PoE status of the switch profile port.
-	PortID                      string                                                                  `json:"portId,omitempty"`                      // The identifier of the switch profile port.
+	Mirror                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortMirror  `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortModule  `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                                  `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                   `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                                  `json:"portId,omitempty"`                      // The identifier of the switch template port.
 	PortScheduleID              string                                                                  `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
 	Profile                     *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile `json:"profile,omitempty"`                     // Profile attributes
 	RstpEnabled                 *bool                                                                   `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
 	StickyMacAllowList          []string                                                                `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
 	StickyMacAllowListLimit     *int                                                                    `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                   `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch profile port.
+	StormControlEnabled         *bool                                                                   `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
 	StpGuard                    string                                                                  `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                                `json:"tags,omitempty"`                        // The list of tags of the switch profile port.
-	Type                        string                                                                  `json:"type,omitempty"`                        // The type of the switch profile port ('trunk' or 'access').
+	Tags                        []string                                                                `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                                  `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
 	Udld                        string                                                                  `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                    `json:"vlan,omitempty"`                        // The VLAN of the switch profile port. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                    `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch profile port. Only applicable to access ports.
+	VLAN                        *int                                                                    `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                    `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortMirror struct {
+	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
+}
+type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortModule struct {
+	Model string `json:"model,omitempty"` // The model of the expansion module.
 }
 type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
+}
+type ResponseSwitchGetOrganizationSummarySwitchPowerHistory []ResponseItemSwitchGetOrganizationSummarySwitchPowerHistory // Array of ResponseSwitchGetOrganizationSummarySwitchPowerHistory
+type ResponseItemSwitchGetOrganizationSummarySwitchPowerHistory struct {
+	Draw *float64 `json:"draw,omitempty"` // The PoE power draw in watts for all switch ports in the organization for the given interval.
+	Ts   string   `json:"ts,omitempty"`   // Timestamp of the start of the interval.
 }
 type ResponseSwitchCloneOrganizationSwitchDevices interface{}
 type ResponseSwitchGetOrganizationSwitchPortsBySwitch []ResponseItemSwitchGetOrganizationSwitchPortsBySwitch // Array of ResponseSwitchGetOrganizationSwitchPortsBySwitch
@@ -1295,7 +1667,7 @@ type ResponseItemSwitchGetOrganizationSwitchPortsBySwitchPorts struct {
 	StpGuard                string   `json:"stpGuard,omitempty"`                // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
 	Tags                    []string `json:"tags,omitempty"`                    // The list of tags of the switch port.
 	Type                    string   `json:"type,omitempty"`                    // The type of the switch port ('trunk' or 'access').
-	VLAN                    *int     `json:"vlan,omitempty"`                    // The VLAN of the switch port. A null value will clear the value set for trunk ports.
+	VLAN                    *int     `json:"vlan,omitempty"`                    // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN               *int     `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch port. Only applicable to access ports.
 }
 type RequestSwitchCycleDeviceSwitchPorts struct {
@@ -1325,7 +1697,7 @@ type RequestSwitchUpdateDeviceSwitchPort struct {
 	Tags                    []string                                    `json:"tags,omitempty"`                    // The list of tags of the switch port.
 	Type                    string                                      `json:"type,omitempty"`                    // The type of the switch port ('trunk' or 'access').
 	Udld                    string                                      `json:"udld,omitempty"`                    // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                    *int                                        `json:"vlan,omitempty"`                    // The VLAN of the switch port. A null value will clear the value set for trunk ports.
+	VLAN                    *int                                        `json:"vlan,omitempty"`                    // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN               *int                                        `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch port. Only applicable to access ports.
 }
 type RequestSwitchUpdateDeviceSwitchPortProfile struct {
@@ -1390,19 +1762,19 @@ type RequestSwitchUpdateDeviceSwitchRoutingInterfaceOspfV3 struct {
 type RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp struct {
 	BootFileName         string                                                                   `json:"bootFileName,omitempty"`         // The PXE boot server filename for the DHCP server running on the switch interface
 	BootNextServer       string                                                                   `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch interface
-	BootOptionsEnabled   *bool                                                                    `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch interface
-	DhcpLeaseTime        string                                                                   `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on switch interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
-	DhcpMode             string                                                                   `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	BootOptionsEnabled   *bool                                                                    `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch         interface
+	DhcpLeaseTime        string                                                                   `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on switch interface         ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                   `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch interface        ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
 	DhcpOptions          *[]RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch interface
 	DhcpRelayServerIPs   []string                                                                 `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch interface
-	DNSCustomNameservers []string                                                                 `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
-	DNSNameserversOption string                                                                   `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch interface ('googlePublicDns', 'openDns' or 'custom')
+	DNSCustomNameservers []string                                                                 `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is         'custom'
+	DNSNameserversOption string                                                                   `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch interface         ('googlePublicDns', 'openDns' or 'custom')
 	FixedIPAssignments   *[]RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP fixed IP assignments for the DHCP server running on the switch interface
 	ReservedIPRanges     *[]RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch interface
 }
 type RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcpDhcpOptions struct {
 	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
-	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of           ('text', 'ip', 'integer' or 'hex')
 	Value string `json:"value,omitempty"` // The value of the DHCP option
 }
 type RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcpFixedIPAssignments struct {
@@ -1459,7 +1831,7 @@ type RequestSwitchCreateNetworkSwitchAccessPolicy struct {
 	RadiusAccountingEnabled        *bool                                                                  `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]RequestSwitchCreateNetworkSwitchAccessPolicyRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                  `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                                 `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                                 `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]RequestSwitchCreateNetworkSwitchAccessPolicyRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                  `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                  `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
@@ -1501,7 +1873,7 @@ type RequestSwitchUpdateNetworkSwitchAccessPolicy struct {
 	RadiusAccountingEnabled        *bool                                                                  `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
 	RadiusAccountingServers        *[]RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`        // List of RADIUS accounting servers to require connecting devices to authenticate against before granting network access
 	RadiusCoaSupportEnabled        *bool                                                                  `json:"radiusCoaSupportEnabled,omitempty"`        // Change of authentication for RADIUS re-authentication and disconnection
-	RadiusGroupAttribute           string                                                                 `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are *""* for , or *"11"* for Group Policies ACL
+	RadiusGroupAttribute           string                                                                 `json:"radiusGroupAttribute,omitempty"`           // Acceptable values are `""` for , or `"11"` for Group Policies ACL
 	RadiusServers                  *[]RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusServers           `json:"radiusServers,omitempty"`                  // List of RADIUS servers to require connecting devices to authenticate against before granting network access
 	RadiusTestingEnabled           *bool                                                                  `json:"radiusTestingEnabled,omitempty"`           // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	URLRedirectWalledGardenEnabled *bool                                                                  `json:"urlRedirectWalledGardenEnabled,omitempty"` // Enable to restrict access for clients to a specific set of IP addresses or hostnames prior to authentication
@@ -1609,11 +1981,11 @@ type RequestSwitchUpdateNetworkSwitchLinkAggregationSwitchProfilePorts struct {
 }
 type RequestSwitchUpdateNetworkSwitchMtu struct {
 	DefaultMtuSize *int                                            `json:"defaultMtuSize,omitempty"` // MTU size for the entire network. Default value is 9578.
-	Overrides      *[]RequestSwitchUpdateNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch profiles. An empty array will clear overrides.
+	Overrides      *[]RequestSwitchUpdateNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch templates. An empty array will clear overrides.
 }
 type RequestSwitchUpdateNetworkSwitchMtuOverrides struct {
-	MtuSize        *int     `json:"mtuSize,omitempty"`        // MTU size for the switches or switch profiles.
-	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch profile IDs. Applicable only for template network.
+	MtuSize        *int     `json:"mtuSize,omitempty"`        // MTU size for the switches or switch templates.
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs. Applicable only for template network.
 	Switches       []string `json:"switches,omitempty"`       // List of switch serials. Applicable only for switch network.
 }
 type RequestSwitchCreateNetworkSwitchPortSchedule struct {
@@ -1742,18 +2114,18 @@ type RequestSwitchUpdateNetworkSwitchRoutingMulticastDefaultSettings struct {
 	IgmpSnoopingEnabled                 *bool `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping setting for entire network
 }
 type RequestSwitchUpdateNetworkSwitchRoutingMulticastOverrides struct {
-	FloodUnknownMulticastTrafficEnabled *bool    `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic setting for switches, switch stacks or switch profiles
-	IgmpSnoopingEnabled                 *bool    `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping setting for switches, switch stacks or switch profiles
+	FloodUnknownMulticastTrafficEnabled *bool    `json:"floodUnknownMulticastTrafficEnabled,omitempty"` // Flood unknown multicast traffic setting for switches, switch stacks or switch templates
+	IgmpSnoopingEnabled                 *bool    `json:"igmpSnoopingEnabled,omitempty"`                 // IGMP snooping setting for switches, switch stacks or switch templates
 	Stacks                              []string `json:"stacks,omitempty"`                              // List of switch stack ids for non-template network
-	SwitchProfiles                      []string `json:"switchProfiles,omitempty"`                      // List of switch profiles ids for template network
+	SwitchProfiles                      []string `json:"switchProfiles,omitempty"`                      // List of switch templates ids for template network
 	Switches                            []string `json:"switches,omitempty"`                            // List of switch serials for non-template network
 }
 type RequestSwitchCreateNetworkSwitchRoutingMulticastRendezvousPoint struct {
-	InterfaceIP    string `json:"interfaceIp,omitempty"`    // The IP address of the interface where the RP needs to be created.
+	InterfaceIP    string `json:"interfaceIp,omitempty"`    // The IP address of the interface where the RP needs to be created.
 	MulticastGroup string `json:"multicastGroup,omitempty"` // 'Any', or the IP address of a multicast group
 }
 type RequestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint struct {
-	InterfaceIP    string `json:"interfaceIp,omitempty"`    // The IP address of the interface to use
+	InterfaceIP    string `json:"interfaceIp,omitempty"`    // The IP address of the interface where the RP needs to be created.
 	MulticastGroup string `json:"multicastGroup,omitempty"` // 'Any', or the IP address of a multicast group
 }
 type RequestSwitchUpdateNetworkSwitchRoutingOspf struct {
@@ -1786,13 +2158,21 @@ type RequestSwitchUpdateNetworkSwitchRoutingOspfV3Areas struct {
 	AreaType string `json:"areaType,omitempty"` // Area types in OSPF. Must be one of: ["normal", "stub", "nssa"]
 }
 type RequestSwitchUpdateNetworkSwitchSettings struct {
-	PowerExceptions  *[]RequestSwitchUpdateNetworkSwitchSettingsPowerExceptions `json:"powerExceptions,omitempty"`  // Exceptions on a per switch basis to "useCombinedPower"
-	UseCombinedPower *bool                                                      `json:"useCombinedPower,omitempty"` // The use Combined Power as the default behavior of secondary power supplies on supported devices.
-	VLAN             *int                                                       `json:"vlan,omitempty"`             // Management VLAN
+	MacBlocklist         *RequestSwitchUpdateNetworkSwitchSettingsMacBlocklist         `json:"macBlocklist,omitempty"`         // MAC blocklist
+	PowerExceptions      *[]RequestSwitchUpdateNetworkSwitchSettingsPowerExceptions    `json:"powerExceptions,omitempty"`      // Exceptions on a per switch basis to "useCombinedPower"
+	UplinkClientSampling *RequestSwitchUpdateNetworkSwitchSettingsUplinkClientSampling `json:"uplinkClientSampling,omitempty"` // Uplink client sampling
+	UseCombinedPower     *bool                                                         `json:"useCombinedPower,omitempty"`     // The use Combined Power as the default behavior of secondary power supplies on supported devices.
+	VLAN                 *int                                                          `json:"vlan,omitempty"`                 // Management VLAN
+}
+type RequestSwitchUpdateNetworkSwitchSettingsMacBlocklist struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable MAC blocklist
 }
 type RequestSwitchUpdateNetworkSwitchSettingsPowerExceptions struct {
 	PowerType string `json:"powerType,omitempty"` // Per switch exception (combined, redundant, useNetworkSetting)
 	Serial    string `json:"serial,omitempty"`    // Serial number of the switch
+}
+type RequestSwitchUpdateNetworkSwitchSettingsUplinkClientSampling struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable uplink client sampling
 }
 type RequestSwitchCreateNetworkSwitchStack struct {
 	Name    string   `json:"name,omitempty"`    // The name of the new stack
@@ -1849,19 +2229,19 @@ type RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfSettings struct {
 type RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp struct {
 	BootFileName         string                                                                         `json:"bootFileName,omitempty"`         // The PXE boot server file name for the DHCP server running on the switch stack interface
 	BootNextServer       string                                                                         `json:"bootNextServer,omitempty"`       // The PXE boot server IP for the DHCP server running on the switch stack interface
-	BootOptionsEnabled   *bool                                                                          `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch stack interface
-	DhcpLeaseTime        string                                                                         `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on switch stack interface ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
-	DhcpMode             string                                                                         `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
-	DhcpOptions          *[]RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the switch stack interface
+	BootOptionsEnabled   *bool                                                                          `json:"bootOptionsEnabled,omitempty"`   // Enable DHCP boot options to provide PXE boot options configs for the dhcp server running on the switch         stack interface
+	DhcpLeaseTime        string                                                                         `json:"dhcpLeaseTime,omitempty"`        // The DHCP lease time config for the dhcp server running on switch stack interface         ('30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week')
+	DhcpMode             string                                                                         `json:"dhcpMode,omitempty"`             // The DHCP mode options for the switch stack interface         ('dhcpDisabled', 'dhcpRelay' or 'dhcpServer')
+	DhcpOptions          *[]RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions        `json:"dhcpOptions,omitempty"`          // Array of DHCP options consisting of code, type and value for the DHCP server running on the         switch stack interface
 	DhcpRelayServerIPs   []string                                                                       `json:"dhcpRelayServerIps,omitempty"`   // The DHCP relay server IPs to which DHCP packets would get relayed for the switch stack interface
-	DNSCustomNameservers []string                                                                       `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is 'custom'
-	DNSNameserversOption string                                                                         `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface ('googlePublicDns', 'openDns' or 'custom')
+	DNSCustomNameservers []string                                                                       `json:"dnsCustomNameservers,omitempty"` // The DHCP name server IPs when DHCP name server option is '         custom'
+	DNSNameserversOption string                                                                         `json:"dnsNameserversOption,omitempty"` // The DHCP name server option for the dhcp server running on the switch stack interface         ('googlePublicDns', 'openDns' or 'custom')
 	FixedIPAssignments   *[]RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments `json:"fixedIpAssignments,omitempty"`   // Array of DHCP fixed IP assignments for the DHCP server running on the switch stack interface
 	ReservedIPRanges     *[]RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges   `json:"reservedIpRanges,omitempty"`     // Array of DHCP reserved IP assignments for the DHCP server running on the switch stack interface
 }
 type RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpDhcpOptions struct {
 	Code  string `json:"code,omitempty"`  // The code for DHCP option which should be from 2 to 254
-	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of ('text', 'ip', 'integer' or 'hex')
+	Type  string `json:"type,omitempty"`  // The type of the DHCP option which should be one of           ('text', 'ip', 'integer' or 'hex')
 	Value string `json:"value,omitempty"` // The value of the DHCP option
 }
 type RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpFixedIPAssignments struct {
@@ -1895,38 +2275,38 @@ type RequestSwitchUpdateNetworkSwitchStormControl struct {
 }
 type RequestSwitchUpdateNetworkSwitchStp struct {
 	RstpEnabled       *bool                                                   `json:"rstpEnabled,omitempty"`       // The spanning tree protocol status in network
-	StpBridgePriority *[]RequestSwitchUpdateNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` // STP bridge priority for switches/stacks or switch profiles. An empty array will clear the STP bridge priority settings.
+	StpBridgePriority *[]RequestSwitchUpdateNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` // STP bridge priority for switches/stacks or switch templates. An empty array will clear the STP bridge priority settings.
 }
 type RequestSwitchUpdateNetworkSwitchStpStpBridgePriority struct {
 	Stacks         []string `json:"stacks,omitempty"`         // List of stack IDs
-	StpPriority    *int     `json:"stpPriority,omitempty"`    // STP priority for switch, stacks, or switch profiles
-	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch profile IDs
+	StpPriority    *int     `json:"stpPriority,omitempty"`    // STP priority for switch, stacks, or switch templates
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs
 	Switches       []string `json:"switches,omitempty"`       // List of switch serial numbers
 }
 type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePort struct {
-	AccessPolicyNumber      *int                                                                   `json:"accessPolicyNumber,omitempty"`      // The number of a custom access policy to configure on the switch profile port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType        string                                                                 `json:"accessPolicyType,omitempty"`        // The type of the access policy of the switch profile port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs            string                                                                 `json:"allowedVlans,omitempty"`            // The VLANs allowed on the switch profile port. Only applicable to trunk ports.
+	AccessPolicyNumber      *int                                                                   `json:"accessPolicyNumber,omitempty"`      // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType        string                                                                 `json:"accessPolicyType,omitempty"`        // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs            string                                                                 `json:"allowedVlans,omitempty"`            // The VLANs allowed on the switch template port. Only applicable to trunk ports.
 	DaiTrusted              *bool                                                                  `json:"daiTrusted,omitempty"`              // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                 *bool                                                                  `json:"enabled,omitempty"`                 // The status of the switch profile port.
+	Enabled                 *bool                                                                  `json:"enabled,omitempty"`                 // The status of the switch template port.
 	FlexibleStackingEnabled *bool                                                                  `json:"flexibleStackingEnabled,omitempty"` // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled        *bool                                                                  `json:"isolationEnabled,omitempty"`        // The isolation status of the switch profile port.
-	LinkNegotiation         string                                                                 `json:"linkNegotiation,omitempty"`         // The link speed for the switch profile port.
+	IsolationEnabled        *bool                                                                  `json:"isolationEnabled,omitempty"`        // The isolation status of the switch template port.
+	LinkNegotiation         string                                                                 `json:"linkNegotiation,omitempty"`         // The link speed for the switch template port.
 	MacAllowList            []string                                                               `json:"macAllowList,omitempty"`            // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Name                    string                                                                 `json:"name,omitempty"`                    // The name of the switch profile port.
-	PoeEnabled              *bool                                                                  `json:"poeEnabled,omitempty"`              // The PoE status of the switch profile port.
+	Name                    string                                                                 `json:"name,omitempty"`                    // The name of the switch template port.
+	PoeEnabled              *bool                                                                  `json:"poeEnabled,omitempty"`              // The PoE status of the switch template port.
 	PortScheduleID          string                                                                 `json:"portScheduleId,omitempty"`          // The ID of the port schedule. A value of null will clear the port schedule.
 	Profile                 *RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile `json:"profile,omitempty"`                 // Profile attributes
 	RstpEnabled             *bool                                                                  `json:"rstpEnabled,omitempty"`             // The rapid spanning tree protocol status.
 	StickyMacAllowList      []string                                                               `json:"stickyMacAllowList,omitempty"`      // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
 	StickyMacAllowListLimit *int                                                                   `json:"stickyMacAllowListLimit,omitempty"` // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled     *bool                                                                  `json:"stormControlEnabled,omitempty"`     // The storm control status of the switch profile port.
+	StormControlEnabled     *bool                                                                  `json:"stormControlEnabled,omitempty"`     // The storm control status of the switch template port.
 	StpGuard                string                                                                 `json:"stpGuard,omitempty"`                // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                    []string                                                               `json:"tags,omitempty"`                    // The list of tags of the switch profile port.
-	Type                    string                                                                 `json:"type,omitempty"`                    // The type of the switch profile port ('trunk' or 'access').
+	Tags                    []string                                                               `json:"tags,omitempty"`                    // The list of tags of the switch template port.
+	Type                    string                                                                 `json:"type,omitempty"`                    // The type of the switch template port ('trunk' or 'access').
 	Udld                    string                                                                 `json:"udld,omitempty"`                    // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                    *int                                                                   `json:"vlan,omitempty"`                    // The VLAN of the switch profile port. A null value will clear the value set for trunk ports.
-	VoiceVLAN               *int                                                                   `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch profile port. Only applicable to access ports.
+	VLAN                    *int                                                                   `json:"vlan,omitempty"`                    // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN               *int                                                                   `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch template port. Only applicable to access ports.
 }
 type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -3272,8 +3652,8 @@ func (s *SwitchService) GetNetworkSwitchStp(networkID string) (*ResponseSwitchGe
 
 }
 
-//GetOrganizationConfigTemplateSwitchProfiles List the switch profiles for your switch template configuration
-/* List the switch profiles for your switch template configuration
+//GetOrganizationConfigTemplateSwitchProfiles List the switch templates for your switch template configuration
+/* List the switch templates for your switch template configuration
 
 @param organizationID organizationId path parameter. Organization ID
 @param configTemplateID configTemplateId path parameter. Config template ID
@@ -3307,8 +3687,8 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfiles(organization
 
 }
 
-//GetOrganizationConfigTemplateSwitchProfilePorts Return all the ports of a switch profile
-/* Return all the ports of a switch profile
+//GetOrganizationConfigTemplateSwitchProfilePorts Return all the ports of a switch template
+/* Return all the ports of a switch template
 
 @param organizationID organizationId path parameter. Organization ID
 @param configTemplateID configTemplateId path parameter. Config template ID
@@ -3344,8 +3724,8 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePorts(organiza
 
 }
 
-//GetOrganizationConfigTemplateSwitchProfilePort Return a switch profile port
-/* Return a switch profile port
+//GetOrganizationConfigTemplateSwitchProfilePort Return a switch template port
+/* Return a switch template port
 
 @param organizationID organizationId path parameter. Organization ID
 @param configTemplateID configTemplateId path parameter. Config template ID
@@ -3379,6 +3759,42 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePort(organizat
 	}
 
 	result := response.Result().(*ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePort)
+	return result, response, err
+
+}
+
+//GetOrganizationSummarySwitchPowerHistory Returns the total PoE power draw for all switch ports in the organization over the requested timespan (by default the last 24 hours)
+/* Returns the total PoE power draw for all switch ports in the organization over the requested timespan (by default the last 24 hours). The returned array is a newest-first list of intervals. The time between intervals depends on the requested timespan with 20 minute intervals used for timespans up to 1 day, 4 hour intervals used for timespans up to 2 weeks, and 1 day intervals for timespans larger than 2 weeks.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSummarySwitchPowerHistoryQueryParams Filtering parameter
+
+
+*/
+func (s *SwitchService) GetOrganizationSummarySwitchPowerHistory(organizationID string, getOrganizationSummarySwitchPowerHistoryQueryParams *GetOrganizationSummarySwitchPowerHistoryQueryParams) (*ResponseSwitchGetOrganizationSummarySwitchPowerHistory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/summary/switch/power/history"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSummarySwitchPowerHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSwitchGetOrganizationSummarySwitchPowerHistory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSummarySwitchPowerHistory")
+	}
+
+	result := response.Result().(*ResponseSwitchGetOrganizationSummarySwitchPowerHistory)
 	return result, response, err
 
 }
@@ -3497,7 +3913,7 @@ func (s *SwitchService) CreateDeviceSwitchRoutingInterface(serial string, reques
 
 */
 
-func (s *SwitchService) CreateDeviceSwitchRoutingStaticRoute(serial string, requestSwitchCreateDeviceSwitchRoutingStaticRoute *RequestSwitchCreateDeviceSwitchRoutingStaticRoute) (*resty.Response, error) {
+func (s *SwitchService) CreateDeviceSwitchRoutingStaticRoute(serial string, requestSwitchCreateDeviceSwitchRoutingStaticRoute *RequestSwitchCreateDeviceSwitchRoutingStaticRoute) (*ResponseSwitchCreateDeviceSwitchRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -3506,20 +3922,21 @@ func (s *SwitchService) CreateDeviceSwitchRoutingStaticRoute(serial string, requ
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCreateDeviceSwitchRoutingStaticRoute).
-		// SetResult(&ResponseSwitchCreateDeviceSwitchRoutingStaticRoute{}).
+		SetResult(&ResponseSwitchCreateDeviceSwitchRoutingStaticRoute{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateDeviceSwitchRoutingStaticRoute")
+		return nil, response, fmt.Errorf("error with operation CreateDeviceSwitchRoutingStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCreateDeviceSwitchRoutingStaticRoute)
+	return result, response, err
 
 }
 
@@ -3622,7 +4039,6 @@ func (s *SwitchService) CreateNetworkSwitchLinkAggregation(networkID string, req
 	if response.IsError() {
 		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchLinkAggregation")
 	}
-
 	result := response.Result().(*ResponseSwitchCreateNetworkSwitchLinkAggregation)
 	return result, response, err
 
@@ -3636,7 +4052,7 @@ func (s *SwitchService) CreateNetworkSwitchLinkAggregation(networkID string, req
 
 */
 
-func (s *SwitchService) CreateNetworkSwitchPortSchedule(networkID string, requestSwitchCreateNetworkSwitchPortSchedule *RequestSwitchCreateNetworkSwitchPortSchedule) (*resty.Response, error) {
+func (s *SwitchService) CreateNetworkSwitchPortSchedule(networkID string, requestSwitchCreateNetworkSwitchPortSchedule *RequestSwitchCreateNetworkSwitchPortSchedule) (*ResponseSwitchCreateNetworkSwitchPortSchedule, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/portSchedules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3645,20 +4061,21 @@ func (s *SwitchService) CreateNetworkSwitchPortSchedule(networkID string, reques
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCreateNetworkSwitchPortSchedule).
-		// SetResult(&ResponseSwitchCreateNetworkSwitchPortSchedule{}).
+		SetResult(&ResponseSwitchCreateNetworkSwitchPortSchedule{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkSwitchPortSchedule")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchPortSchedule")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCreateNetworkSwitchPortSchedule)
+	return result, response, err
 
 }
 
@@ -3732,15 +4149,15 @@ func (s *SwitchService) CreateNetworkSwitchRoutingMulticastRendezvousPoint(netwo
 
 }
 
-//CreateNetworkSwitchStack Create a stack
-/* Create a stack
+//CreateNetworkSwitchStack Create a switch stack
+/* Create a switch stack
 
 @param networkID networkId path parameter. Network ID
 
 
 */
 
-func (s *SwitchService) CreateNetworkSwitchStack(networkID string, requestSwitchCreateNetworkSwitchStack *RequestSwitchCreateNetworkSwitchStack) (*resty.Response, error) {
+func (s *SwitchService) CreateNetworkSwitchStack(networkID string, requestSwitchCreateNetworkSwitchStack *RequestSwitchCreateNetworkSwitchStack) (*ResponseSwitchCreateNetworkSwitchStack, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3749,20 +4166,21 @@ func (s *SwitchService) CreateNetworkSwitchStack(networkID string, requestSwitch
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCreateNetworkSwitchStack).
-		// SetResult(&ResponseSwitchCreateNetworkSwitchStack{}).
+		SetResult(&ResponseSwitchCreateNetworkSwitchStack{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkSwitchStack")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchStack")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCreateNetworkSwitchStack)
+	return result, response, err
 
 }
 
@@ -3812,7 +4230,7 @@ func (s *SwitchService) AddNetworkSwitchStack(networkID string, switchStackID st
 
 */
 
-func (s *SwitchService) RemoveNetworkSwitchStack(networkID string, switchStackID string, requestSwitchRemoveNetworkSwitchStack *RequestSwitchRemoveNetworkSwitchStack) (*resty.Response, error) {
+func (s *SwitchService) RemoveNetworkSwitchStack(networkID string, switchStackID string, requestSwitchRemoveNetworkSwitchStack *RequestSwitchRemoveNetworkSwitchStack) (*ResponseSwitchRemoveNetworkSwitchStack, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/remove"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3822,20 +4240,21 @@ func (s *SwitchService) RemoveNetworkSwitchStack(networkID string, switchStackID
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchRemoveNetworkSwitchStack).
-		// SetResult(&ResponseSwitchRemoveNetworkSwitchStack{}).
+		SetResult(&ResponseSwitchRemoveNetworkSwitchStack{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation RemoveNetworkSwitchStack")
+		return nil, response, fmt.Errorf("error with operation RemoveNetworkSwitchStack")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchRemoveNetworkSwitchStack)
+	return result, response, err
 
 }
 
@@ -3848,7 +4267,7 @@ func (s *SwitchService) RemoveNetworkSwitchStack(networkID string, switchStackID
 
 */
 
-func (s *SwitchService) CreateNetworkSwitchStackRoutingInterface(networkID string, switchStackID string, requestSwitchCreateNetworkSwitchStackRoutingInterface *RequestSwitchCreateNetworkSwitchStackRoutingInterface) (*resty.Response, error) {
+func (s *SwitchService) CreateNetworkSwitchStackRoutingInterface(networkID string, switchStackID string, requestSwitchCreateNetworkSwitchStackRoutingInterface *RequestSwitchCreateNetworkSwitchStackRoutingInterface) (*ResponseSwitchCreateNetworkSwitchStackRoutingInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3858,20 +4277,21 @@ func (s *SwitchService) CreateNetworkSwitchStackRoutingInterface(networkID strin
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCreateNetworkSwitchStackRoutingInterface).
-		// SetResult(&ResponseSwitchCreateNetworkSwitchStackRoutingInterface{}).
+		SetResult(&ResponseSwitchCreateNetworkSwitchStackRoutingInterface{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkSwitchStackRoutingInterface")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchStackRoutingInterface")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCreateNetworkSwitchStackRoutingInterface)
+	return result, response, err
 
 }
 
@@ -3884,7 +4304,7 @@ func (s *SwitchService) CreateNetworkSwitchStackRoutingInterface(networkID strin
 
 */
 
-func (s *SwitchService) CreateNetworkSwitchStackRoutingStaticRoute(networkID string, switchStackID string, requestSwitchCreateNetworkSwitchStackRoutingStaticRoute *RequestSwitchCreateNetworkSwitchStackRoutingStaticRoute) (*resty.Response, error) {
+func (s *SwitchService) CreateNetworkSwitchStackRoutingStaticRoute(networkID string, switchStackID string, requestSwitchCreateNetworkSwitchStackRoutingStaticRoute *RequestSwitchCreateNetworkSwitchStackRoutingStaticRoute) (*ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -3894,20 +4314,21 @@ func (s *SwitchService) CreateNetworkSwitchStackRoutingStaticRoute(networkID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCreateNetworkSwitchStackRoutingStaticRoute).
-		// SetResult(&ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute{}).
+		SetResult(&ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkSwitchStackRoutingStaticRoute")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchStackRoutingStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute)
+	return result, response, err
 
 }
 
@@ -4019,7 +4440,7 @@ func (s *SwitchService) UpdateDeviceSwitchRoutingInterface(serial string, interf
 @param serial serial path parameter.
 @param interfaceID interfaceId path parameter. Interface ID
 */
-func (s *SwitchService) UpdateDeviceSwitchRoutingInterfaceDhcp(serial string, interfaceID string, requestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp *RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp) (*resty.Response, error) {
+func (s *SwitchService) UpdateDeviceSwitchRoutingInterfaceDhcp(serial string, interfaceID string, requestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp *RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp) (*ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcp, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/interfaces/{interfaceId}/dhcp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -4029,19 +4450,21 @@ func (s *SwitchService) UpdateDeviceSwitchRoutingInterfaceDhcp(serial string, in
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp).
+		SetResult(&ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcp{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceSwitchRoutingInterfaceDhcp")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceSwitchRoutingInterfaceDhcp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcp)
+	return result, response, err
 
 }
 
@@ -4051,7 +4474,7 @@ func (s *SwitchService) UpdateDeviceSwitchRoutingInterfaceDhcp(serial string, in
 @param serial serial path parameter.
 @param staticRouteID staticRouteId path parameter. Static route ID
 */
-func (s *SwitchService) UpdateDeviceSwitchRoutingStaticRoute(serial string, staticRouteID string, requestSwitchUpdateDeviceSwitchRoutingStaticRoute *RequestSwitchUpdateDeviceSwitchRoutingStaticRoute) (*resty.Response, error) {
+func (s *SwitchService) UpdateDeviceSwitchRoutingStaticRoute(serial string, staticRouteID string, requestSwitchUpdateDeviceSwitchRoutingStaticRoute *RequestSwitchUpdateDeviceSwitchRoutingStaticRoute) (*ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -4061,19 +4484,21 @@ func (s *SwitchService) UpdateDeviceSwitchRoutingStaticRoute(serial string, stat
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateDeviceSwitchRoutingStaticRoute).
+		SetResult(&ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceSwitchRoutingStaticRoute")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceSwitchRoutingStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute)
+	return result, response, err
 
 }
 
@@ -4082,7 +4507,7 @@ func (s *SwitchService) UpdateDeviceSwitchRoutingStaticRoute(serial string, stat
 
 @param serial serial path parameter.
 */
-func (s *SwitchService) UpdateDeviceSwitchWarmSpare(serial string, requestSwitchUpdateDeviceSwitchWarmSpare *RequestSwitchUpdateDeviceSwitchWarmSpare) (*resty.Response, error) {
+func (s *SwitchService) UpdateDeviceSwitchWarmSpare(serial string, requestSwitchUpdateDeviceSwitchWarmSpare *RequestSwitchUpdateDeviceSwitchWarmSpare) (*ResponseSwitchUpdateDeviceSwitchWarmSpare, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/warmSpare"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -4091,19 +4516,21 @@ func (s *SwitchService) UpdateDeviceSwitchWarmSpare(serial string, requestSwitch
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateDeviceSwitchWarmSpare).
+		SetResult(&ResponseSwitchUpdateDeviceSwitchWarmSpare{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceSwitchWarmSpare")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceSwitchWarmSpare")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateDeviceSwitchWarmSpare)
+	return result, response, err
 
 }
 
@@ -4208,7 +4635,7 @@ func (s *SwitchService) UpdateNetworkSwitchAlternateManagementInterface(networkI
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchDhcpServerPolicy(networkID string, requestSwitchUpdateNetworkSwitchDhcpServerPolicy *RequestSwitchUpdateNetworkSwitchDhcpServerPolicy) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchDhcpServerPolicy(networkID string, requestSwitchUpdateNetworkSwitchDhcpServerPolicy *RequestSwitchUpdateNetworkSwitchDhcpServerPolicy) (*ResponseSwitchUpdateNetworkSwitchDhcpServerPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dhcpServerPolicy"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4217,19 +4644,21 @@ func (s *SwitchService) UpdateNetworkSwitchDhcpServerPolicy(networkID string, re
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchDhcpServerPolicy).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchDhcpServerPolicy{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchDhcpServerPolicy")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchDhcpServerPolicy")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchDhcpServerPolicy)
+	return result, response, err
 
 }
 
@@ -4365,7 +4794,7 @@ func (s *SwitchService) UpdateNetworkSwitchMtu(networkID string, requestSwitchUp
 @param networkID networkId path parameter. Network ID
 @param portScheduleID portScheduleId path parameter. Port schedule ID
 */
-func (s *SwitchService) UpdateNetworkSwitchPortSchedule(networkID string, portScheduleID string, requestSwitchUpdateNetworkSwitchPortSchedule *RequestSwitchUpdateNetworkSwitchPortSchedule) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchPortSchedule(networkID string, portScheduleID string, requestSwitchUpdateNetworkSwitchPortSchedule *RequestSwitchUpdateNetworkSwitchPortSchedule) (*ResponseSwitchUpdateNetworkSwitchPortSchedule, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/portSchedules/{portScheduleId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4375,19 +4804,21 @@ func (s *SwitchService) UpdateNetworkSwitchPortSchedule(networkID string, portSc
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchPortSchedule).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchPortSchedule{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchPortSchedule")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchPortSchedule")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchPortSchedule)
+	return result, response, err
 
 }
 
@@ -4458,7 +4889,7 @@ func (s *SwitchService) UpdateNetworkSwitchQosRule(networkID string, qosRuleID s
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchRoutingMulticast(networkID string, requestSwitchUpdateNetworkSwitchRoutingMulticast *RequestSwitchUpdateNetworkSwitchRoutingMulticast) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchRoutingMulticast(networkID string, requestSwitchUpdateNetworkSwitchRoutingMulticast *RequestSwitchUpdateNetworkSwitchRoutingMulticast) (*ResponseSwitchUpdateNetworkSwitchRoutingMulticast, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/multicast"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4467,19 +4898,21 @@ func (s *SwitchService) UpdateNetworkSwitchRoutingMulticast(networkID string, re
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchRoutingMulticast).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchRoutingMulticast{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingMulticast")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingMulticast")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchRoutingMulticast)
+	return result, response, err
 
 }
 
@@ -4489,7 +4922,7 @@ func (s *SwitchService) UpdateNetworkSwitchRoutingMulticast(networkID string, re
 @param networkID networkId path parameter. Network ID
 @param rendezvousPointID rendezvousPointId path parameter. Rendezvous point ID
 */
-func (s *SwitchService) UpdateNetworkSwitchRoutingMulticastRendezvousPoint(networkID string, rendezvousPointID string, requestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint *RequestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchRoutingMulticastRendezvousPoint(networkID string, rendezvousPointID string, requestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint *RequestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint) (*ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/multicast/rendezvousPoints/{rendezvousPointId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4499,19 +4932,21 @@ func (s *SwitchService) UpdateNetworkSwitchRoutingMulticastRendezvousPoint(netwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingMulticastRendezvousPoint")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingMulticastRendezvousPoint")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint)
+	return result, response, err
 
 }
 
@@ -4584,7 +5019,7 @@ func (s *SwitchService) UpdateNetworkSwitchSettings(networkID string, requestSwi
 @param switchStackID switchStackId path parameter. Switch stack ID
 @param interfaceID interfaceId path parameter. Interface ID
 */
-func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterface(networkID string, switchStackID string, interfaceID string, requestSwitchUpdateNetworkSwitchStackRoutingInterface *RequestSwitchUpdateNetworkSwitchStackRoutingInterface) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterface(networkID string, switchStackID string, interfaceID string, requestSwitchUpdateNetworkSwitchStackRoutingInterface *RequestSwitchUpdateNetworkSwitchStackRoutingInterface) (*ResponseSwitchUpdateNetworkSwitchStackRoutingInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4595,19 +5030,21 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterface(networkID strin
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchStackRoutingInterface).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchStackRoutingInterface{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingInterface")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingInterface")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchStackRoutingInterface)
+	return result, response, err
 
 }
 
@@ -4618,7 +5055,7 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterface(networkID strin
 @param switchStackID switchStackId path parameter. Switch stack ID
 @param interfaceID interfaceId path parameter. Interface ID
 */
-func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterfaceDhcp(networkID string, switchStackID string, interfaceID string, requestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp *RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterfaceDhcp(networkID string, switchStackID string, interfaceID string, requestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp *RequestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp) (*ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}/dhcp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4629,19 +5066,21 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterfaceDhcp(networkID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingInterfaceDhcp")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingInterfaceDhcp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcp)
+	return result, response, err
 
 }
 
@@ -4652,7 +5091,7 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingInterfaceDhcp(networkID s
 @param switchStackID switchStackId path parameter. Switch stack ID
 @param staticRouteID staticRouteId path parameter. Static route ID
 */
-func (s *SwitchService) UpdateNetworkSwitchStackRoutingStaticRoute(networkID string, switchStackID string, staticRouteID string, requestSwitchUpdateNetworkSwitchStackRoutingStaticRoute *RequestSwitchUpdateNetworkSwitchStackRoutingStaticRoute) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchStackRoutingStaticRoute(networkID string, switchStackID string, staticRouteID string, requestSwitchUpdateNetworkSwitchStackRoutingStaticRoute *RequestSwitchUpdateNetworkSwitchStackRoutingStaticRoute) (*ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4663,19 +5102,21 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingStaticRoute(networkID str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchStackRoutingStaticRoute).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingStaticRoute")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchStackRoutingStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute)
+	return result, response, err
 
 }
 
@@ -4684,7 +5125,7 @@ func (s *SwitchService) UpdateNetworkSwitchStackRoutingStaticRoute(networkID str
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchStormControl(networkID string, requestSwitchUpdateNetworkSwitchStormControl *RequestSwitchUpdateNetworkSwitchStormControl) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchStormControl(networkID string, requestSwitchUpdateNetworkSwitchStormControl *RequestSwitchUpdateNetworkSwitchStormControl) (*ResponseSwitchUpdateNetworkSwitchStormControl, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stormControl"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4693,19 +5134,21 @@ func (s *SwitchService) UpdateNetworkSwitchStormControl(networkID string, reques
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchStormControl).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchStormControl{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchStormControl")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchStormControl")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchStormControl)
+	return result, response, err
 
 }
 
@@ -4739,8 +5182,8 @@ func (s *SwitchService) UpdateNetworkSwitchStp(networkID string, requestSwitchUp
 
 }
 
-//UpdateOrganizationConfigTemplateSwitchProfilePort Update a switch profile port
-/* Update a switch profile port
+//UpdateOrganizationConfigTemplateSwitchProfilePort Update a switch template port
+/* Update a switch template port
 
 @param organizationID organizationId path parameter. Organization ID
 @param configTemplateID configTemplateId path parameter. Config template ID

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -219,6 +219,7 @@ type GetNetworkWirelessUsageHistoryQueryParams struct {
 	Band           string  `url:"band,omitempty"`           //Filter results by band (either '2.4', '5' or '6').
 	SSID           int     `url:"ssid,omitempty"`           //Filter results by SSID number.
 }
+
 type GetOrganizationWirelessDevicesEthernetStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 100.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -226,6 +227,20 @@ type GetOrganizationWirelessDevicesEthernetStatusesQueryParams struct {
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //A list of Meraki network IDs to filter results to contain only specified networks. E.g.: networkIds[]=N_12345678&networkIds[]=L_3456
 }
 
+type ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6 struct {
+	Addresses *[]ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6Addresses `json:"addresses,omitempty"` // configured alternate management interface addresses
+}
+type ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6Addresses struct {
+	Address        string                                                                                    `json:"address,omitempty"`        // The IP address configured for the alternate management interface
+	AssignmentMode string                                                                                    `json:"assignmentMode,omitempty"` // The type of address assignment. Either static or dynamic.
+	Gateway        string                                                                                    `json:"gateway,omitempty"`        // The gateway address configured for the alternate managment interface
+	Nameservers    *ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6AddressesNameservers `json:"nameservers,omitempty"`    // The DNS servers settings for this address.
+	Prefix         string                                                                                    `json:"prefix,omitempty"`         // The IPv6 prefix of the interface. Required if IPv6 object is included.
+	Protocol       string                                                                                    `json:"protocol,omitempty"`       // The IP protocol used for the address
+}
+type ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6AddressesNameservers struct {
+	Addresses []string `json:"addresses,omitempty"` // Up to 2 nameserver addresses to use, ordered in priority from highest to lowest priority.
+}
 type ResponseWirelessGetDeviceWirelessBluetoothSettings struct {
 	Major *int   `json:"major,omitempty"` // Desired major value of the beacon. If the value is set to null it will reset to Dashboard's automatically generated value.
 	Minor *int   `json:"minor,omitempty"` // Desired minor value of the beacon. If the value is set to null it will reset to Dashboard's automatically generated value.
@@ -293,19 +308,19 @@ type ResponseWirelessGetDeviceWirelessRadioSettingsTwoFourGhzSettings struct {
 }
 type ResponseWirelessUpdateDeviceWirelessRadioSettings interface{}
 type ResponseWirelessGetDeviceWirelessStatus struct {
-	BasicServiceSets *[]ResponseWirelessGetDeviceWirelessStatusBasicServiceSets `json:"basicServiceSets,omitempty"` //
+	BasicServiceSets *[]ResponseWirelessGetDeviceWirelessStatusBasicServiceSets `json:"basicServiceSets,omitempty"` // SSID status list
 }
 type ResponseWirelessGetDeviceWirelessStatusBasicServiceSets struct {
-	Band         string `json:"band,omitempty"`         //
-	Broadcasting *bool  `json:"broadcasting,omitempty"` //
-	Bssid        string `json:"bssid,omitempty"`        //
-	Channel      *int   `json:"channel,omitempty"`      //
-	ChannelWidth string `json:"channelWidth,omitempty"` //
-	Enabled      *bool  `json:"enabled,omitempty"`      //
-	Power        string `json:"power,omitempty"`        //
-	SSIDName     string `json:"ssidName,omitempty"`     //
-	SSIDNumber   *int   `json:"ssidNumber,omitempty"`   //
-	Visible      *bool  `json:"visible,omitempty"`      //
+	Band         string `json:"band,omitempty"`         // Frequency range used by wireless network
+	Broadcasting *bool  `json:"broadcasting,omitempty"` // Whether the SSID is broadcasting based on an availability schedule
+	Bssid        string `json:"bssid,omitempty"`        // Unique identifier of wireless access point
+	Channel      *int   `json:"channel,omitempty"`      // Frequency channel used by wireless network
+	ChannelWidth string `json:"channelWidth,omitempty"` // Width of frequency channel used by wireless network
+	Enabled      *bool  `json:"enabled,omitempty"`      // Status of wireless network
+	Power        string `json:"power,omitempty"`        // Strength of wireless signal
+	SSIDName     string `json:"ssidName,omitempty"`     // Name of wireless network
+	SSIDNumber   *int   `json:"ssidNumber,omitempty"`   // Unique identifier of wireless network
+	Visible      *bool  `json:"visible,omitempty"`      // Whether the SSID is advertised or hidden
 }
 type ResponseWirelessGetNetworkWirelessAirMarshal []ResponseItemWirelessGetNetworkWirelessAirMarshal // Array of ResponseWirelessGetNetworkWirelessAirMarshal
 type ResponseItemWirelessGetNetworkWirelessAirMarshal struct {
@@ -343,20 +358,33 @@ type ResponseWirelessGetNetworkWirelessAlternateManagementInterfaceAccessPoints 
 }
 type ResponseWirelessUpdateNetworkWirelessAlternateManagementInterface interface{}
 type ResponseWirelessGetNetworkWirelessBilling struct {
-	Currency string                                            `json:"currency,omitempty"` //
-	Plans    *[]ResponseWirelessGetNetworkWirelessBillingPlans `json:"plans,omitempty"`    //
+	Currency string                                            `json:"currency,omitempty"` // The currency code of this node group's billing plans
+	Plans    *[]ResponseWirelessGetNetworkWirelessBillingPlans `json:"plans,omitempty"`    // Array of billing plans in the node group. (Can configure a maximum of 5)
 }
 type ResponseWirelessGetNetworkWirelessBillingPlans struct {
-	BandwidthLimits *ResponseWirelessGetNetworkWirelessBillingPlansBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	ID              string                                                         `json:"id,omitempty"`              //
-	Price           *float64                                                       `json:"price,omitempty"`           //
-	TimeLimit       string                                                         `json:"timeLimit,omitempty"`       //
+	BandwidthLimits *ResponseWirelessGetNetworkWirelessBillingPlansBandwidthLimits `json:"bandwidthLimits,omitempty"` // The uplink bandwidth settings for the pricing plan.
+	ID              string                                                         `json:"id,omitempty"`              // The id of the pricing plan to update.
+	Price           *float64                                                       `json:"price,omitempty"`           // The price of the billing plan.
+	TimeLimit       string                                                         `json:"timeLimit,omitempty"`       // The time limit of the pricing plan in minutes.
 }
 type ResponseWirelessGetNetworkWirelessBillingPlansBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
 }
-type ResponseWirelessUpdateNetworkWirelessBilling interface{}
+type ResponseWirelessUpdateNetworkWirelessBilling struct {
+	Currency string                                               `json:"currency,omitempty"` // The currency code of this node group's billing plans
+	Plans    *[]ResponseWirelessUpdateNetworkWirelessBillingPlans `json:"plans,omitempty"`    // Array of billing plans in the node group. (Can configure a maximum of 5)
+}
+type ResponseWirelessUpdateNetworkWirelessBillingPlans struct {
+	BandwidthLimits *ResponseWirelessUpdateNetworkWirelessBillingPlansBandwidthLimits `json:"bandwidthLimits,omitempty"` // The uplink bandwidth settings for the pricing plan.
+	ID              string                                                            `json:"id,omitempty"`              // The id of the pricing plan to update.
+	Price           *float64                                                          `json:"price,omitempty"`           // The price of the billing plan.
+	TimeLimit       string                                                            `json:"timeLimit,omitempty"`       // The time limit of the pricing plan in minutes.
+}
+type ResponseWirelessUpdateNetworkWirelessBillingPlansBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
+}
 type ResponseWirelessGetNetworkWirelessBluetoothSettings struct {
 	AdvertisingEnabled       *bool  `json:"advertisingEnabled,omitempty"`       // Whether APs will advertise beacons.
 	EslEnabled               *bool  `json:"eslEnabled,omitempty"`               // Whether ESL is enabled on this network.
@@ -461,75 +489,75 @@ type ResponseItemWirelessGetNetworkWirelessClientConnectivityEventsEventData str
 }
 type ResponseWirelessGetNetworkWirelessClientLatencyHistory []ResponseItemWirelessGetNetworkWirelessClientLatencyHistory // Array of ResponseWirelessGetNetworkWirelessClientLatencyHistory
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistory struct {
-	LatencyBinsByCategory *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategory `json:"latencyBinsByCategory,omitempty"` //
-	T0                    *int                                                                             `json:"t0,omitempty"`                    //
-	T1                    *int                                                                             `json:"t1,omitempty"`                    //
+	LatencyBinsByCategory *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategory `json:"latencyBinsByCategory,omitempty"` // The latency buckets by category
+	T0                    *int                                                                             `json:"t0,omitempty"`                    // The latency history bucket start time in seconds
+	T1                    *int                                                                             `json:"t1,omitempty"`                    // The latency history bucket end time in seconds
 }
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategory struct {
-	BackgroundTraffic *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBackgroundTraffic `json:"backgroundTraffic,omitempty"` //
-	BestEffortTraffic *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBestEffortTraffic `json:"bestEffortTraffic,omitempty"` //
-	VideoTraffic      *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVideoTraffic      `json:"videoTraffic,omitempty"`      //
-	VoiceTraffic      *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVoiceTraffic      `json:"voiceTraffic,omitempty"`      //
+	BackgroundTraffic *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBackgroundTraffic `json:"backgroundTraffic,omitempty"` // The time bucket's background traffic latency history
+	BestEffortTraffic *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBestEffortTraffic `json:"bestEffortTraffic,omitempty"` // The time bucket's best effort traffic latency history
+	VideoTraffic      *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVideoTraffic      `json:"videoTraffic,omitempty"`      // The time bucket's video traffic latency history
+	VoiceTraffic      *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVoiceTraffic      `json:"voiceTraffic,omitempty"`      // The time bucket's voice traffic latency history
 }
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBackgroundTraffic struct {
-	Status05    *int `json:"0.5,omitempty"`    //
-	Status10    *int `json:"1.0,omitempty"`    //
-	Status10240 *int `json:"1024.0,omitempty"` //
-	Status1280  *int `json:"128.0,omitempty"`  //
-	Status160   *int `json:"16.0,omitempty"`   //
-	Status20    *int `json:"2.0,omitempty"`    //
-	Status20480 *int `json:"2048.0,omitempty"` //
-	Status2560  *int `json:"256.0,omitempty"`  //
-	Status320   *int `json:"32.0,omitempty"`   //
-	Status40    *int `json:"4.0,omitempty"`    //
-	Status5120  *int `json:"512.0,omitempty"`  //
-	Status640   *int `json:"64.0,omitempty"`   //
-	Status80    *int `json:"8.0,omitempty"`    //
+	Status05    *int `json:"0.5,omitempty"`    // The latency bucket for background traffic in 0.5 seconds
+	Status10    *int `json:"1.0,omitempty"`    // The latency bucket for background traffic in 1.0 seconds
+	Status10240 *int `json:"1024.0,omitempty"` // The latency bucket for background traffic in 1024.0 seconds
+	Status1280  *int `json:"128.0,omitempty"`  // The latency bucket for background traffic in 128.0 seconds
+	Status160   *int `json:"16.0,omitempty"`   // The latency bucket for background traffic in 16.0 seconds
+	Status20    *int `json:"2.0,omitempty"`    // The latency bucket for background traffic in 2.0 seconds
+	Status20480 *int `json:"2048.0,omitempty"` // The latency bucket for background traffic in 2048.0 seconds
+	Status2560  *int `json:"256.0,omitempty"`  // The latency bucket for background traffic in 256.0 seconds
+	Status320   *int `json:"32.0,omitempty"`   // The latency bucket for background traffic in 32.0 seconds
+	Status40    *int `json:"4.0,omitempty"`    // The latency bucket for background traffic in 4.0 seconds
+	Status5120  *int `json:"512.0,omitempty"`  // The latency bucket for background traffic in 512.0 seconds
+	Status640   *int `json:"64.0,omitempty"`   // The latency bucket for background traffic in 64.0 seconds
+	Status80    *int `json:"8.0,omitempty"`    // The latency bucket for background traffic in 8.0 seconds
 }
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryBestEffortTraffic struct {
-	Status05    *int `json:"0.5,omitempty"`    //
-	Status10    *int `json:"1.0,omitempty"`    //
-	Status10240 *int `json:"1024.0,omitempty"` //
-	Status1280  *int `json:"128.0,omitempty"`  //
-	Status160   *int `json:"16.0,omitempty"`   //
-	Status20    *int `json:"2.0,omitempty"`    //
-	Status20480 *int `json:"2048.0,omitempty"` //
-	Status2560  *int `json:"256.0,omitempty"`  //
-	Status320   *int `json:"32.0,omitempty"`   //
-	Status40    *int `json:"4.0,omitempty"`    //
-	Status5120  *int `json:"512.0,omitempty"`  //
-	Status640   *int `json:"64.0,omitempty"`   //
-	Status80    *int `json:"8.0,omitempty"`    //
+	Status05    *int `json:"0.5,omitempty"`    // The latency bucket for best effort traffic in 0.5 seconds
+	Status10    *int `json:"1.0,omitempty"`    // The latency bucket for best effort traffic in 1.0 seconds
+	Status10240 *int `json:"1024.0,omitempty"` // The latency bucket for best effort traffic in 1024.0 seconds
+	Status1280  *int `json:"128.0,omitempty"`  // The latency bucket for best effort traffic in 128.0 seconds
+	Status160   *int `json:"16.0,omitempty"`   // The latency bucket for best effort traffic in 16.0 seconds
+	Status20    *int `json:"2.0,omitempty"`    // The latency bucket for best effort traffic in 2.0 seconds
+	Status20480 *int `json:"2048.0,omitempty"` // The latency bucket for best effort traffic in 2048.0 seconds
+	Status2560  *int `json:"256.0,omitempty"`  // The latency bucket for best effort traffic in 256.0 seconds
+	Status320   *int `json:"32.0,omitempty"`   // The latency bucket for best effort traffic in 32.0 seconds
+	Status40    *int `json:"4.0,omitempty"`    // The latency bucket for best effort traffic in 4.0 seconds
+	Status5120  *int `json:"512.0,omitempty"`  // The latency bucket for best effort traffic in 512.0 seconds
+	Status640   *int `json:"64.0,omitempty"`   // The latency bucket for best effort traffic in 64.0 seconds
+	Status80    *int `json:"8.0,omitempty"`    // The latency bucket for best effort traffic in 8.0 seconds
 }
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVideoTraffic struct {
-	Status05    *int `json:"0.5,omitempty"`    //
-	Status10    *int `json:"1.0,omitempty"`    //
-	Status10240 *int `json:"1024.0,omitempty"` //
-	Status1280  *int `json:"128.0,omitempty"`  //
-	Status160   *int `json:"16.0,omitempty"`   //
-	Status20    *int `json:"2.0,omitempty"`    //
-	Status20480 *int `json:"2048.0,omitempty"` //
-	Status2560  *int `json:"256.0,omitempty"`  //
-	Status320   *int `json:"32.0,omitempty"`   //
-	Status40    *int `json:"4.0,omitempty"`    //
-	Status5120  *int `json:"512.0,omitempty"`  //
-	Status640   *int `json:"64.0,omitempty"`   //
-	Status80    *int `json:"8.0,omitempty"`    //
+	Status05    *int `json:"0.5,omitempty"`    // The latency bucket for video traffic in 0.5 seconds
+	Status10    *int `json:"1.0,omitempty"`    // The latency bucket for video traffic in 1.0 seconds
+	Status10240 *int `json:"1024.0,omitempty"` // The latency bucket for video traffic in 1024.0 seconds
+	Status1280  *int `json:"128.0,omitempty"`  // The latency bucket for video traffic in 128.0 seconds
+	Status160   *int `json:"16.0,omitempty"`   // The latency bucket for video traffic in 16.0 seconds
+	Status20    *int `json:"2.0,omitempty"`    // The latency bucket for video traffic in 2.0 seconds
+	Status20480 *int `json:"2048.0,omitempty"` // The latency bucket for video traffic in 2048.0 seconds
+	Status2560  *int `json:"256.0,omitempty"`  // The latency bucket for video traffic in 256.0 seconds
+	Status320   *int `json:"32.0,omitempty"`   // The latency bucket for video traffic in 32.0 seconds
+	Status40    *int `json:"4.0,omitempty"`    // The latency bucket for video traffic in 4.0 seconds
+	Status5120  *int `json:"512.0,omitempty"`  // The latency bucket for video traffic in 512.0 seconds
+	Status640   *int `json:"64.0,omitempty"`   // The latency bucket for video traffic in 64.0 seconds
+	Status80    *int `json:"8.0,omitempty"`    // The latency bucket for video traffic in 8.0 seconds
 }
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategoryVoiceTraffic struct {
-	Status05    *int `json:"0.5,omitempty"`    //
-	Status10    *int `json:"1.0,omitempty"`    //
-	Status10240 *int `json:"1024.0,omitempty"` //
-	Status1280  *int `json:"128.0,omitempty"`  //
-	Status160   *int `json:"16.0,omitempty"`   //
-	Status20    *int `json:"2.0,omitempty"`    //
-	Status20480 *int `json:"2048.0,omitempty"` //
-	Status2560  *int `json:"256.0,omitempty"`  //
-	Status320   *int `json:"32.0,omitempty"`   //
-	Status40    *int `json:"4.0,omitempty"`    //
-	Status5120  *int `json:"512.0,omitempty"`  //
-	Status640   *int `json:"64.0,omitempty"`   //
-	Status80    *int `json:"8.0,omitempty"`    //
+	Status05    *int `json:"0.5,omitempty"`    // The latency bucket for voice traffic in 0.5 seconds
+	Status10    *int `json:"1.0,omitempty"`    // The latency bucket for voice traffic in 1.0 seconds
+	Status10240 *int `json:"1024.0,omitempty"` // The latency bucket for voice traffic in 1024.0 seconds
+	Status1280  *int `json:"128.0,omitempty"`  // The latency bucket for voice traffic in 128.0 seconds
+	Status160   *int `json:"16.0,omitempty"`   // The latency bucket for voice traffic in 16.0 seconds
+	Status20    *int `json:"2.0,omitempty"`    // The latency bucket for voice traffic in 2.0 seconds
+	Status20480 *int `json:"2048.0,omitempty"` // The latency bucket for voice traffic in 2048.0 seconds
+	Status2560  *int `json:"256.0,omitempty"`  // The latency bucket for voice traffic in 256.0 seconds
+	Status320   *int `json:"32.0,omitempty"`   // The latency bucket for voice traffic in 32.0 seconds
+	Status40    *int `json:"4.0,omitempty"`    // The latency bucket for voice traffic in 4.0 seconds
+	Status5120  *int `json:"512.0,omitempty"`  // The latency bucket for voice traffic in 512.0 seconds
+	Status640   *int `json:"64.0,omitempty"`   // The latency bucket for voice traffic in 64.0 seconds
+	Status80    *int `json:"8.0,omitempty"`    // The latency bucket for voice traffic in 8.0 seconds
 }
 type ResponseWirelessGetNetworkWirelessClientLatencyStats struct {
 	LatencyStats *ResponseWirelessGetNetworkWirelessClientLatencyStatsLatencyStats `json:"latencyStats,omitempty"` //
@@ -617,6 +645,90 @@ type ResponseItemWirelessGetNetworkWirelessDevicesLatencyStatsLatencyStatsBackgr
 	Status64   *int `json:"64,omitempty"`   //
 	Status8    *int `json:"8,omitempty"`    //
 }
+type ResponseWirelessGetNetworkWirelessEthernetPortsProfiles []ResponseItemWirelessGetNetworkWirelessEthernetPortsProfiles // Array of ResponseWirelessGetNetworkWirelessEthernetPortsProfiles
+type ResponseItemWirelessGetNetworkWirelessEthernetPortsProfiles struct {
+	IsDefault *bool                                                                  `json:"isDefault,omitempty"` // Is default profile
+	Name      string                                                                 `json:"name,omitempty"`      // AP port profile name
+	Ports     *[]ResponseItemWirelessGetNetworkWirelessEthernetPortsProfilesPorts    `json:"ports,omitempty"`     // Ports config
+	ProfileID string                                                                 `json:"profileId,omitempty"` // AP port profile ID
+	UsbPorts  *[]ResponseItemWirelessGetNetworkWirelessEthernetPortsProfilesUsbPorts `json:"usbPorts,omitempty"`  // Usb ports config
+}
+type ResponseItemWirelessGetNetworkWirelessEthernetPortsProfilesPorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // Enabled
+	Name       string `json:"name,omitempty"`       // Name
+	Number     *int   `json:"number,omitempty"`     // Number
+	PskGroupID string `json:"pskGroupId,omitempty"` // PSK Group number
+	SSID       *int   `json:"ssid,omitempty"`       // Ssid number
+}
+type ResponseItemWirelessGetNetworkWirelessEthernetPortsProfilesUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Enabled
+	Name    string `json:"name,omitempty"`    // Name
+	SSID    *int   `json:"ssid,omitempty"`    // Ssid number
+}
+type ResponseWirelessCreateNetworkWirelessEthernetPortsProfile struct {
+	IsDefault *bool                                                                `json:"isDefault,omitempty"` // Is default profile
+	Name      string                                                               `json:"name,omitempty"`      // AP port profile name
+	Ports     *[]ResponseWirelessCreateNetworkWirelessEthernetPortsProfilePorts    `json:"ports,omitempty"`     // Ports config
+	ProfileID string                                                               `json:"profileId,omitempty"` // AP port profile ID
+	UsbPorts  *[]ResponseWirelessCreateNetworkWirelessEthernetPortsProfileUsbPorts `json:"usbPorts,omitempty"`  // Usb ports config
+}
+type ResponseWirelessCreateNetworkWirelessEthernetPortsProfilePorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // Enabled
+	Name       string `json:"name,omitempty"`       // Name
+	Number     *int   `json:"number,omitempty"`     // Number
+	PskGroupID string `json:"pskGroupId,omitempty"` // PSK Group number
+	SSID       *int   `json:"ssid,omitempty"`       // Ssid number
+}
+type ResponseWirelessCreateNetworkWirelessEthernetPortsProfileUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Enabled
+	Name    string `json:"name,omitempty"`    // Name
+	SSID    *int   `json:"ssid,omitempty"`    // Ssid number
+}
+type ResponseWirelessAssignNetworkWirelessEthernetPortsProfiles struct {
+	ProfileID string   `json:"profileId,omitempty"` // AP profile ID
+	Serials   []string `json:"serials,omitempty"`   // List of updated AP serials
+}
+type ResponseWirelessSetNetworkWirelessEthernetPortsProfilesDefault struct {
+	ProfileID string `json:"profileId,omitempty"` // AP profile ID
+}
+type ResponseWirelessGetNetworkWirelessEthernetPortsProfile struct {
+	IsDefault *bool                                                             `json:"isDefault,omitempty"` // Is default profile
+	Name      string                                                            `json:"name,omitempty"`      // AP port profile name
+	Ports     *[]ResponseWirelessGetNetworkWirelessEthernetPortsProfilePorts    `json:"ports,omitempty"`     // Ports config
+	ProfileID string                                                            `json:"profileId,omitempty"` // AP port profile ID
+	UsbPorts  *[]ResponseWirelessGetNetworkWirelessEthernetPortsProfileUsbPorts `json:"usbPorts,omitempty"`  // Usb ports config
+}
+type ResponseWirelessGetNetworkWirelessEthernetPortsProfilePorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // Enabled
+	Name       string `json:"name,omitempty"`       // Name
+	Number     *int   `json:"number,omitempty"`     // Number
+	PskGroupID string `json:"pskGroupId,omitempty"` // PSK Group number
+	SSID       *int   `json:"ssid,omitempty"`       // Ssid number
+}
+type ResponseWirelessGetNetworkWirelessEthernetPortsProfileUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Enabled
+	Name    string `json:"name,omitempty"`    // Name
+	SSID    *int   `json:"ssid,omitempty"`    // Ssid number
+}
+type ResponseWirelessUpdateNetworkWirelessEthernetPortsProfile struct {
+	IsDefault *bool                                                                `json:"isDefault,omitempty"` // Is default profile
+	Name      string                                                               `json:"name,omitempty"`      // AP port profile name
+	Ports     *[]ResponseWirelessUpdateNetworkWirelessEthernetPortsProfilePorts    `json:"ports,omitempty"`     // Ports config
+	ProfileID string                                                               `json:"profileId,omitempty"` // AP port profile ID
+	UsbPorts  *[]ResponseWirelessUpdateNetworkWirelessEthernetPortsProfileUsbPorts `json:"usbPorts,omitempty"`  // Usb ports config
+}
+type ResponseWirelessUpdateNetworkWirelessEthernetPortsProfilePorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // Enabled
+	Name       string `json:"name,omitempty"`       // Name
+	Number     *int   `json:"number,omitempty"`     // Number
+	PskGroupID string `json:"pskGroupId,omitempty"` // PSK Group number
+	SSID       *int   `json:"ssid,omitempty"`       // Ssid number
+}
+type ResponseWirelessUpdateNetworkWirelessEthernetPortsProfileUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Enabled
+	Name    string `json:"name,omitempty"`    // Name
+	SSID    *int   `json:"ssid,omitempty"`    // Ssid number
+}
 type ResponseWirelessGetNetworkWirelessFailedConnections []ResponseItemWirelessGetNetworkWirelessFailedConnections // Array of ResponseWirelessGetNetworkWirelessFailedConnections
 type ResponseItemWirelessGetNetworkWirelessFailedConnections struct {
 	ClientMac   string `json:"clientMac,omitempty"`   // Client Mac
@@ -658,167 +770,232 @@ type ResponseWirelessGetNetworkWirelessLatencyStatsBackgroundTrafficRawDistribut
 	Status64   *int `json:"64,omitempty"`   //
 	Status8    *int `json:"8,omitempty"`    //
 }
-type ResponseWirelessGetNetworkWirelessMeshStatuses struct {
-	LatestMeshPerformance *ResponseWirelessGetNetworkWirelessMeshStatusesLatestMeshPerformance `json:"latestMeshPerformance,omitempty"` //
-	MeshRoute             []string                                                             `json:"meshRoute,omitempty"`             //
-	Serial                string                                                               `json:"serial,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessMeshStatuses []ResponseItemWirelessGetNetworkWirelessMeshStatuses // Array of ResponseWirelessGetNetworkWirelessMeshStatuses
+type ResponseItemWirelessGetNetworkWirelessMeshStatuses struct {
+	LatestMeshPerformance *ResponseItemWirelessGetNetworkWirelessMeshStatusesLatestMeshPerformance `json:"latestMeshPerformance,omitempty"` // Current metrics on how the mesh is performing.
+	MeshRoute             []string                                                                 `json:"meshRoute,omitempty"`             // List of device serials that make up the mesh.
+	Serial                string                                                                   `json:"serial,omitempty"`                // The serial number for the device.
 }
-type ResponseWirelessGetNetworkWirelessMeshStatusesLatestMeshPerformance struct {
-	Mbps            *int   `json:"mbps,omitempty"`            //
-	Metric          *int   `json:"metric,omitempty"`          //
-	UsagePercentage string `json:"usagePercentage,omitempty"` //
+type ResponseItemWirelessGetNetworkWirelessMeshStatusesLatestMeshPerformance struct {
+	Mbps            *int   `json:"mbps,omitempty"`            // Average Mbps.
+	Metric          *int   `json:"metric,omitempty"`          // Represents the quality of the entire route from the repeater access point to its gateway access point.
+	UsagePercentage string `json:"usagePercentage,omitempty"` // Mesh utilization as a percentage.
 }
-type ResponseWirelessGetNetworkWirelessRfProfiles []ResponseItemWirelessGetNetworkWirelessRfProfiles // Array of ResponseWirelessGetNetworkWirelessRfProfiles
-type ResponseItemWirelessGetNetworkWirelessRfProfiles struct {
-	AfcEnabled             *bool                                                               `json:"afcEnabled,omitempty"`             //
-	ApBandSettings         *ResponseItemWirelessGetNetworkWirelessRfProfilesApBandSettings     `json:"apBandSettings,omitempty"`         //
-	BandSelectionType      string                                                              `json:"bandSelectionType,omitempty"`      //
-	ClientBalancingEnabled *bool                                                               `json:"clientBalancingEnabled,omitempty"` //
-	FiveGhzSettings        *ResponseItemWirelessGetNetworkWirelessRfProfilesFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        //
-	ID                     string                                                              `json:"id,omitempty"`                     //
-	MinBitrateType         string                                                              `json:"minBitrateType,omitempty"`         //
-	Name                   string                                                              `json:"name,omitempty"`                   //
-	NetworkID              string                                                              `json:"networkId,omitempty"`              //
-	PerSSIDSettings        *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings    `json:"perSsidSettings,omitempty"`        //
-	SixGhzSettings         *ResponseItemWirelessGetNetworkWirelessRfProfilesSixGhzSettings     `json:"sixGhzSettings,omitempty"`         //
-	Transmission           *ResponseItemWirelessGetNetworkWirelessRfProfilesTransmission       `json:"transmission,omitempty"`           //
-	TwoFourGhzSettings     *ResponseItemWirelessGetNetworkWirelessRfProfilesTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     //
+type ResponseWirelessGetNetworkWirelessRfProfiles struct {
+	ApBandSettings         *ResponseWirelessGetNetworkWirelessRfProfilesApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
+	BandSelectionType      string                                                          `json:"bandSelectionType,omitempty"`      // Band selection can be set to either 'ssid' or 'ap'. This param is required on creation.
+	ClientBalancingEnabled *bool                                                           `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
+	FiveGhzSettings        *ResponseWirelessGetNetworkWirelessRfProfilesFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
+	ID                     string                                                          `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	MinBitrateType         string                                                          `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
+	Name                   string                                                          `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
+	NetworkID              string                                                          `json:"networkId,omitempty"`              // The network ID of the RF Profile
+	PerSSIDSettings        *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
+	SixGhzSettings         *ResponseWirelessGetNetworkWirelessRfProfilesSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
+	Transmission           *ResponseWirelessGetNetworkWirelessRfProfilesTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
+	TwoFourGhzSettings     *ResponseWirelessGetNetworkWirelessRfProfilesTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
+type ResponseWirelessGetNetworkWirelessRfProfilesApBandSettings struct {
+	BandOperationMode   string                                                           `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'. Defaults to dual.
+	BandSteeringEnabled *bool                                                            `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesFiveGhzSettings struct {
-	ChannelWidth      string   `json:"channelWidth,omitempty"`      //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+type ResponseWirelessGetNetworkWirelessRfProfilesApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings struct {
-	Status0  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0  `json:"0,omitempty"`  //
-	Status1  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1  `json:"1,omitempty"`  //
-	Status10 *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 `json:"10,omitempty"` //
-	Status11 *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 `json:"11,omitempty"` //
-	Status12 *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 `json:"12,omitempty"` //
-	Status13 *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 `json:"13,omitempty"` //
-	Status14 *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 `json:"14,omitempty"` //
-	Status2  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2  `json:"2,omitempty"`  //
-	Status3  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3  `json:"3,omitempty"`  //
-	Status4  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4  `json:"4,omitempty"`  //
-	Status5  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5  `json:"5,omitempty"`  //
-	Status6  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6  `json:"6,omitempty"`  //
-	Status7  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7  `json:"7,omitempty"`  //
-	Status8  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8  `json:"8,omitempty"`  //
-	Status9  *ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9  `json:"9,omitempty"`  //
+type ResponseWirelessGetNetworkWirelessRfProfilesFiveGhzSettings struct {
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 5Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 5Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 5Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 5Ghz band. Can be one of '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161' or '165'.Defaults to [36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165].
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings struct {
+	Status0  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0  `json:"0,omitempty"`  // Settings for SSID 0
+	Status1  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1  `json:"1,omitempty"`  // Settings for SSID 1
+	Status10 *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 `json:"10,omitempty"` // Settings for SSID 10
+	Status11 *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 `json:"11,omitempty"` // Settings for SSID 11
+	Status12 *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 `json:"12,omitempty"` // Settings for SSID 12
+	Status13 *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 `json:"13,omitempty"` // Settings for SSID 13
+	Status14 *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 `json:"14,omitempty"` // Settings for SSID 14
+	Status2  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2  `json:"2,omitempty"`  // Settings for SSID 2
+	Status3  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3  `json:"3,omitempty"`  // Settings for SSID 3
+	Status4  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4  `json:"4,omitempty"`  // Settings for SSID 4
+	Status5  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5  `json:"5,omitempty"`  // Settings for SSID 5
+	Status6  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6  `json:"6,omitempty"`  // Settings for SSID 6
+	Status7  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7  `json:"7,omitempty"`  // Settings for SSID 7
+	Status8  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8  `json:"8,omitempty"`  // Settings for SSID 8
+	Status9  *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 struct {
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 struct {
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 struct {
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 struct {
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 struct {
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesSixGhzSettings struct {
-	AfcEnabled        *bool    `json:"afcEnabled,omitempty"`        //
-	ChannelWidth      string   `json:"channelWidth,omitempty"`      //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesTransmission struct {
-	Enabled *bool `json:"enabled,omitempty"` //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
-type ResponseItemWirelessGetNetworkWirelessRfProfilesTwoFourGhzSettings struct {
-	AxEnabled         *bool    `json:"axEnabled,omitempty"`         //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9 struct {
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesSixGhzSettings struct {
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 6Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 6Ghz band. Can be one of '1', '5', '9', '13', '17', '21', '25', '29', '33', '37', '41', '45', '49', '53', '57', '61', '65', '69', '73', '77', '81', '85', '89', '93', '97', '101', '105', '109', '113', '117', '121', '125', '129', '133', '137', '141', '145', '149', '153', '157', '161', '165', '169', '173', '177', '181', '185', '189', '193', '197', '201', '205', '209', '213', '217', '221', '225', '229' or '233'. Defaults to auto.
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesTransmission struct {
+	Enabled *bool `json:"enabled,omitempty"` // Toggle for radio transmission. When false, radios will not transmit at all.
+}
+type ResponseWirelessGetNetworkWirelessRfProfilesTwoFourGhzSettings struct {
+	AxEnabled         *bool    `json:"axEnabled,omitempty"`         // Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering. Defaults to true.
+	MaxPower          *int     `json:"maxPower,omitempty"`          // Sets max power (dBm) of 2.4Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *float64 `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 2.4Ghz band. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'. Defaults to 11.
+	MinPower          *int     `json:"minPower,omitempty"`          // Sets min power (dBm) of 2.4Ghz band. Can be integer between 2 and 30. Defaults to 5.
+	Rxsop             *int     `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int   `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 2.4Ghz band. Can be one of '1', '6' or '11'. Defaults to [1, 6, 11].
 }
 type ResponseWirelessCreateNetworkWirelessRfProfile struct {
 	ApBandSettings         *ResponseWirelessCreateNetworkWirelessRfProfileApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
@@ -830,12 +1007,17 @@ type ResponseWirelessCreateNetworkWirelessRfProfile struct {
 	Name                   string                                                            `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                            `json:"networkId,omitempty"`              // The network ID of the RF Profile
 	PerSSIDSettings        *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
+	SixGhzSettings         *ResponseWirelessCreateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
 	Transmission           *ResponseWirelessCreateNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
 	TwoFourGhzSettings     *ResponseWirelessCreateNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'. Defaults to dual.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'. Defaults to dual.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
+}
+type ResponseWirelessCreateNetworkWirelessRfProfileApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -863,94 +1045,162 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status9  *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessCreateNetworkWirelessRfProfileSixGhzSettings struct {
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 6Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 6Ghz band. Can be one of '1', '5', '9', '13', '17', '21', '25', '29', '33', '37', '41', '45', '49', '53', '57', '61', '65', '69', '73', '77', '81', '85', '89', '93', '97', '101', '105', '109', '113', '117', '121', '125', '129', '133', '137', '141', '145', '149', '153', '157', '161', '165', '169', '173', '177', '181', '185', '189', '193', '197', '201', '205', '209', '213', '217', '221', '225', '229' or '233'. Defaults to auto.
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileTransmission struct {
 	Enabled *bool `json:"enabled,omitempty"` // Toggle for radio transmission. When false, radios will not transmit at all.
@@ -964,155 +1214,220 @@ type ResponseWirelessCreateNetworkWirelessRfProfileTwoFourGhzSettings struct {
 	ValidAutoChannels *[]int   `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 2.4Ghz band. Can be one of '1', '6' or '11'. Defaults to [1, 6, 11].
 }
 type ResponseWirelessGetNetworkWirelessRfProfile struct {
-	AfcEnabled             *bool                                                          `json:"afcEnabled,omitempty"`             //
-	ApBandSettings         *ResponseWirelessGetNetworkWirelessRfProfileApBandSettings     `json:"apBandSettings,omitempty"`         //
-	BandSelectionType      string                                                         `json:"bandSelectionType,omitempty"`      //
-	ClientBalancingEnabled *bool                                                          `json:"clientBalancingEnabled,omitempty"` //
-	FiveGhzSettings        *ResponseWirelessGetNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        //
-	ID                     string                                                         `json:"id,omitempty"`                     //
-	MinBitrateType         string                                                         `json:"minBitrateType,omitempty"`         //
-	Name                   string                                                         `json:"name,omitempty"`                   //
-	NetworkID              string                                                         `json:"networkId,omitempty"`              //
-	PerSSIDSettings        *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        //
-	SixGhzSettings         *ResponseWirelessGetNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         //
-	Transmission           *ResponseWirelessGetNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           //
-	TwoFourGhzSettings     *ResponseWirelessGetNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     //
+	ApBandSettings         *ResponseWirelessGetNetworkWirelessRfProfileApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
+	BandSelectionType      string                                                         `json:"bandSelectionType,omitempty"`      // Band selection can be set to either 'ssid' or 'ap'. This param is required on creation.
+	ClientBalancingEnabled *bool                                                          `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
+	FiveGhzSettings        *ResponseWirelessGetNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
+	ID                     string                                                         `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	MinBitrateType         string                                                         `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
+	Name                   string                                                         `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
+	NetworkID              string                                                         `json:"networkId,omitempty"`              // The network ID of the RF Profile
+	PerSSIDSettings        *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
+	SixGhzSettings         *ResponseWirelessGetNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
+	Transmission           *ResponseWirelessGetNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
+	TwoFourGhzSettings     *ResponseWirelessGetNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
 type ResponseWirelessGetNetworkWirelessRfProfileApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
+	BandOperationMode   string                                                          `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'. Defaults to dual.
+	BandSteeringEnabled *bool                                                           `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
+}
+type ResponseWirelessGetNetworkWirelessRfProfileApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfileFiveGhzSettings struct {
-	ChannelWidth      string   `json:"channelWidth,omitempty"`      //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 5Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 5Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 5Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 5Ghz band. Can be one of '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161' or '165'.Defaults to [36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165].
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings struct {
-	Status0  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0  `json:"0,omitempty"`  //
-	Status1  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1  `json:"1,omitempty"`  //
-	Status10 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10 `json:"10,omitempty"` //
-	Status11 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11 `json:"11,omitempty"` //
-	Status12 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12 `json:"12,omitempty"` //
-	Status13 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13 `json:"13,omitempty"` //
-	Status14 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14 `json:"14,omitempty"` //
-	Status2  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2  `json:"2,omitempty"`  //
-	Status3  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3  `json:"3,omitempty"`  //
-	Status4  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4  `json:"4,omitempty"`  //
-	Status5  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5  `json:"5,omitempty"`  //
-	Status6  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6  `json:"6,omitempty"`  //
-	Status7  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7  `json:"7,omitempty"`  //
-	Status8  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8  `json:"8,omitempty"`  //
-	Status9  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  //
+	Status0  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0  `json:"0,omitempty"`  // Settings for SSID 0
+	Status1  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1  `json:"1,omitempty"`  // Settings for SSID 1
+	Status10 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10 `json:"10,omitempty"` // Settings for SSID 10
+	Status11 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11 `json:"11,omitempty"` // Settings for SSID 11
+	Status12 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12 `json:"12,omitempty"` // Settings for SSID 12
+	Status13 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13 `json:"13,omitempty"` // Settings for SSID 13
+	Status14 *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14 `json:"14,omitempty"` // Settings for SSID 14
+	Status2  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2  `json:"2,omitempty"`  // Settings for SSID 2
+	Status3  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3  `json:"3,omitempty"`  // Settings for SSID 3
+	Status4  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4  `json:"4,omitempty"`  // Settings for SSID 4
+	Status5  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5  `json:"5,omitempty"`  // Settings for SSID 5
+	Status6  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6  `json:"6,omitempty"`  // Settings for SSID 6
+	Status7  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7  `json:"7,omitempty"`  // Settings for SSID 7
+	Status8  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8  `json:"8,omitempty"`  // Settings for SSID 8
+	Status9  *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                               `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   //
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` //
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          //
-	Name                string `json:"name,omitempty"`                //
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                              `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessGetNetworkWirelessRfProfileSixGhzSettings struct {
-	AfcEnabled        *bool    `json:"afcEnabled,omitempty"`        //
-	ChannelWidth      string   `json:"channelWidth,omitempty"`      //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 6Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 6Ghz band. Can be one of '1', '5', '9', '13', '17', '21', '25', '29', '33', '37', '41', '45', '49', '53', '57', '61', '65', '69', '73', '77', '81', '85', '89', '93', '97', '101', '105', '109', '113', '117', '121', '125', '129', '133', '137', '141', '145', '149', '153', '157', '161', '165', '169', '173', '177', '181', '185', '189', '193', '197', '201', '205', '209', '213', '217', '221', '225', '229' or '233'. Defaults to auto.
 }
 type ResponseWirelessGetNetworkWirelessRfProfileTransmission struct {
-	Enabled *bool `json:"enabled,omitempty"` //
+	Enabled *bool `json:"enabled,omitempty"` // Toggle for radio transmission. When false, radios will not transmit at all.
 }
 type ResponseWirelessGetNetworkWirelessRfProfileTwoFourGhzSettings struct {
-	AxEnabled         *bool    `json:"axEnabled,omitempty"`         //
-	MaxPower          *int     `json:"maxPower,omitempty"`          //
-	MinBitrate        *int     `json:"minBitrate,omitempty"`        //
-	MinPower          *int     `json:"minPower,omitempty"`          //
-	ValidAutoChannels []string `json:"validAutoChannels,omitempty"` //
+	AxEnabled         *bool    `json:"axEnabled,omitempty"`         // Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering. Defaults to true.
+	MaxPower          *int     `json:"maxPower,omitempty"`          // Sets max power (dBm) of 2.4Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *float64 `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 2.4Ghz band. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'. Defaults to 11.
+	MinPower          *int     `json:"minPower,omitempty"`          // Sets min power (dBm) of 2.4Ghz band. Can be integer between 2 and 30. Defaults to 5.
+	Rxsop             *int     `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int   `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 2.4Ghz band. Can be one of '1', '6' or '11'. Defaults to [1, 6, 11].
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfile struct {
 	ApBandSettings         *ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
@@ -1124,12 +1439,17 @@ type ResponseWirelessUpdateNetworkWirelessRfProfile struct {
 	Name                   string                                                            `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                            `json:"networkId,omitempty"`              // The network ID of the RF Profile
 	PerSSIDSettings        *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
+	SixGhzSettings         *ResponseWirelessUpdateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
 	Transmission           *ResponseWirelessUpdateNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
 	TwoFourGhzSettings     *ResponseWirelessUpdateNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'. Defaults to dual.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'. Defaults to dual.
+	BandSteeringEnabled *bool                                                              `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -1157,94 +1477,162 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status9  *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                 `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                  `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *int   `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
-	Name                string `json:"name,omitempty"`                // Name of SSID
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *int                                                                 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+}
+type ResponseWirelessUpdateNetworkWirelessRfProfileSixGhzSettings struct {
+	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
+	MaxPower          *int   `json:"maxPower,omitempty"`          // Sets max power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 30.
+	MinBitrate        *int   `json:"minBitrate,omitempty"`        // Sets min bitrate (Mbps) of 6Ghz band. Can be one of '6', '9', '12', '18', '24', '36', '48' or '54'. Defaults to 12.
+	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 6Ghz band. Can be integer between 2 and 30. Defaults to 8.
+	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
+	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 6Ghz band. Can be one of '1', '5', '9', '13', '17', '21', '25', '29', '33', '37', '41', '45', '49', '53', '57', '61', '65', '69', '73', '77', '81', '85', '89', '93', '97', '101', '105', '109', '113', '117', '121', '125', '129', '133', '137', '141', '145', '149', '153', '157', '161', '165', '169', '173', '177', '181', '185', '189', '193', '197', '201', '205', '209', '213', '217', '221', '225', '229' or '233'. Defaults to auto.
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileTransmission struct {
 	Enabled *bool `json:"enabled,omitempty"` // Toggle for radio transmission. When false, radios will not transmit at all.
@@ -1258,12 +1646,13 @@ type ResponseWirelessUpdateNetworkWirelessRfProfileTwoFourGhzSettings struct {
 	ValidAutoChannels *[]int   `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 2.4Ghz band. Can be one of '1', '6' or '11'. Defaults to [1, 6, 11].
 }
 type ResponseWirelessGetNetworkWirelessSettings struct {
-	IPv6BridgeEnabled        *bool                                                 `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
-	LedLightsOn              *bool                                                 `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
-	LocationAnalyticsEnabled *bool                                                 `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
-	MeshingEnabled           *bool                                                 `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
-	NamedVLANs               *ResponseWirelessGetNetworkWirelessSettingsNamedVLANs `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
-	Upgradestrategy          string                                                `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	IPv6BridgeEnabled        *bool                                                       `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
+	LedLightsOn              *bool                                                       `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
+	LocationAnalyticsEnabled *bool                                                       `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
+	MeshingEnabled           *bool                                                       `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
+	NamedVLANs               *ResponseWirelessGetNetworkWirelessSettingsNamedVLANs       `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
+	RegulatoryDomain         *ResponseWirelessGetNetworkWirelessSettingsRegulatoryDomain `json:"regulatoryDomain,omitempty"`         // Regulatory domain information for this network.
+	Upgradestrategy          string                                                      `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
 }
 type ResponseWirelessGetNetworkWirelessSettingsNamedVLANs struct {
 	PoolDhcpMonitoring *ResponseWirelessGetNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
@@ -1272,13 +1661,19 @@ type ResponseWirelessGetNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring stru
 	Duration *int  `json:"duration,omitempty"` // The duration in minutes that devices will refrain from using dirty VLANs before adding them back to the pool.
 	Enabled  *bool `json:"enabled,omitempty"`  // Whether or not devices using named VLAN pools should remove dirty VLANs from the pool, thereby preventing clients from being assigned to VLANs where they would be unable to obtain an IP address via DHCP
 }
+type ResponseWirelessGetNetworkWirelessSettingsRegulatoryDomain struct {
+	CountryCode string `json:"countryCode,omitempty"` // The country code of the regulatory domain.
+	Name        string `json:"name,omitempty"`        // The name of the regulatory domain for this network.
+	Permits6E   *bool  `json:"permits6e,omitempty"`   // Whether or not the regulatory domain for this network permits Wifi 6E.
+}
 type ResponseWirelessUpdateNetworkWirelessSettings struct {
-	IPv6BridgeEnabled        *bool                                                    `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
-	LedLightsOn              *bool                                                    `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
-	LocationAnalyticsEnabled *bool                                                    `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
-	MeshingEnabled           *bool                                                    `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
-	NamedVLANs               *ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
-	Upgradestrategy          string                                                   `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	IPv6BridgeEnabled        *bool                                                          `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
+	LedLightsOn              *bool                                                          `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
+	LocationAnalyticsEnabled *bool                                                          `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
+	MeshingEnabled           *bool                                                          `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
+	NamedVLANs               *ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs       `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
+	RegulatoryDomain         *ResponseWirelessUpdateNetworkWirelessSettingsRegulatoryDomain `json:"regulatoryDomain,omitempty"`         // Regulatory domain information for this network.
+	Upgradestrategy          string                                                         `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
 }
 type ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs struct {
 	PoolDhcpMonitoring *ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
@@ -1286,6 +1681,11 @@ type ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs struct {
 type ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring struct {
 	Duration *int  `json:"duration,omitempty"` // The duration in minutes that devices will refrain from using dirty VLANs before adding them back to the pool.
 	Enabled  *bool `json:"enabled,omitempty"`  // Whether or not devices using named VLAN pools should remove dirty VLANs from the pool, thereby preventing clients from being assigned to VLANs where they would be unable to obtain an IP address via DHCP
+}
+type ResponseWirelessUpdateNetworkWirelessSettingsRegulatoryDomain struct {
+	CountryCode string `json:"countryCode,omitempty"` // The country code of the regulatory domain.
+	Name        string `json:"name,omitempty"`        // The name of the regulatory domain for this network.
+	Permits6E   *bool  `json:"permits6e,omitempty"`   // Whether or not the regulatory domain for this network permits Wifi 6E.
 }
 type ResponseWirelessGetNetworkWirelessSignalQualityHistory []ResponseItemWirelessGetNetworkWirelessSignalQualityHistory // Array of ResponseWirelessGetNetworkWirelessSignalQualityHistory
 type ResponseItemWirelessGetNetworkWirelessSignalQualityHistory struct {
@@ -1296,104 +1696,166 @@ type ResponseItemWirelessGetNetworkWirelessSignalQualityHistory struct {
 }
 type ResponseWirelessGetNetworkWirelessSSIDs []ResponseItemWirelessGetNetworkWirelessSSIDs // Array of ResponseWirelessGetNetworkWirelessSsids
 type ResponseItemWirelessGetNetworkWirelessSSIDs struct {
-	AdminSplashURL                  string                                                                `json:"adminSplashUrl,omitempty"`                  //
-	AuthMode                        string                                                                `json:"authMode,omitempty"`                        //
-	AvailabilityTags                []string                                                              `json:"availabilityTags,omitempty"`                //
-	AvailableOnAllAps               *bool                                                                 `json:"availableOnAllAps,omitempty"`               //
-	BandSelection                   string                                                                `json:"bandSelection,omitempty"`                   //
-	Enabled                         *bool                                                                 `json:"enabled,omitempty"`                         //
-	EncryptionMode                  string                                                                `json:"encryptionMode,omitempty"`                  //
-	IPAssignmentMode                string                                                                `json:"ipAssignmentMode,omitempty"`                //
-	MandatoryDhcpEnabled            *bool                                                                 `json:"mandatoryDhcpEnabled,omitempty"`            //
-	MinBitrate                      *int                                                                  `json:"minBitrate,omitempty"`                      //
-	Name                            string                                                                `json:"name,omitempty"`                            //
-	Number                          *int                                                                  `json:"number,omitempty"`                          //
-	PerClientBandwidthLimitDown     *int                                                                  `json:"perClientBandwidthLimitDown,omitempty"`     //
-	PerClientBandwidthLimitUp       *int                                                                  `json:"perClientBandwidthLimitUp,omitempty"`       //
-	PerSSIDBandwidthLimitDown       *int                                                                  `json:"perSsidBandwidthLimitDown,omitempty"`       //
-	PerSSIDBandwidthLimitUp         *int                                                                  `json:"perSsidBandwidthLimitUp,omitempty"`         //
-	RadiusAccountingEnabled         *bool                                                                 `json:"radiusAccountingEnabled,omitempty"`         //
-	RadiusAccountingServers         *[]ResponseItemWirelessGetNetworkWirelessSSIDsRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`         //
-	RadiusAttributeForGroupPolicies string                                                                `json:"radiusAttributeForGroupPolicies,omitempty"` //
-	RadiusEnabled                   *bool                                                                 `json:"radiusEnabled,omitempty"`                   //
-	RadiusFailoverPolicy            string                                                                `json:"radiusFailoverPolicy,omitempty"`            //
-	RadiusLoadBalancingPolicy       string                                                                `json:"radiusLoadBalancingPolicy,omitempty"`       //
-	RadiusServers                   *[]ResponseItemWirelessGetNetworkWirelessSSIDsRadiusServers           `json:"radiusServers,omitempty"`                   //
-	SplashPage                      string                                                                `json:"splashPage,omitempty"`                      //
-	SplashTimeout                   string                                                                `json:"splashTimeout,omitempty"`                   //
-	SSIDAdminAccessible             *bool                                                                 `json:"ssidAdminAccessible,omitempty"`             //
-	Visible                         *bool                                                                 `json:"visible,omitempty"`                         //
-	WalledGardenEnabled             *bool                                                                 `json:"walledGardenEnabled,omitempty"`             //
-	WalledGardenRanges              []string                                                              `json:"walledGardenRanges,omitempty"`              //
-	WpaEncryptionMode               string                                                                `json:"wpaEncryptionMode,omitempty"`               //
+	AdminSplashURL                  string                                                                `json:"adminSplashUrl,omitempty"`                  // URL for the admin splash page
+	AuthMode                        string                                                                `json:"authMode,omitempty"`                        // The association control method for the SSID
+	AvailabilityTags                []string                                                              `json:"availabilityTags,omitempty"`                // List of tags for this SSID. If availableOnAllAps is false, then the SSID is only broadcast by APs with tags matching any of the tags in this list
+	AvailableOnAllAps               *bool                                                                 `json:"availableOnAllAps,omitempty"`               // Whether all APs broadcast the SSID or if it's restricted to APs matching any availability tags
+	BandSelection                   string                                                                `json:"bandSelection,omitempty"`                   // The client-serving radio frequencies of this SSID in the default indoor RF profile
+	Enabled                         *bool                                                                 `json:"enabled,omitempty"`                         // Whether or not the SSID is enabled
+	EncryptionMode                  string                                                                `json:"encryptionMode,omitempty"`                  // The psk encryption mode for the SSID
+	IPAssignmentMode                string                                                                `json:"ipAssignmentMode,omitempty"`                // The client IP assignment mode
+	LocalAuth                       *bool                                                                 `json:"localAuth,omitempty"`                       // Extended local auth flag for Enterprise NAC
+	MandatoryDhcpEnabled            *bool                                                                 `json:"mandatoryDhcpEnabled,omitempty"`            // Whether clients connecting to this SSID must use the IP address assigned by the DHCP server
+	MinBitrate                      *int                                                                  `json:"minBitrate,omitempty"`                      // The minimum bitrate in Mbps of this SSID in the default indoor RF profile
+	Name                            string                                                                `json:"name,omitempty"`                            // The name of the SSID
+	Number                          *int                                                                  `json:"number,omitempty"`                          // Unique identifier of the SSID
+	PerClientBandwidthLimitDown     *int                                                                  `json:"perClientBandwidthLimitDown,omitempty"`     // The download bandwidth limit in Kbps. (0 represents no limit.)
+	PerClientBandwidthLimitUp       *int                                                                  `json:"perClientBandwidthLimitUp,omitempty"`       // The upload bandwidth limit in Kbps. (0 represents no limit.)
+	PerSSIDBandwidthLimitDown       *int                                                                  `json:"perSsidBandwidthLimitDown,omitempty"`       // The total download bandwidth limit in Kbps (0 represents no limit)
+	PerSSIDBandwidthLimitUp         *int                                                                  `json:"perSsidBandwidthLimitUp,omitempty"`         // The total upload bandwidth limit in Kbps (0 represents no limit)
+	RadiusAccountingEnabled         *bool                                                                 `json:"radiusAccountingEnabled,omitempty"`         // Whether or not RADIUS accounting is enabled
+	RadiusAccountingServers         *[]ResponseItemWirelessGetNetworkWirelessSSIDsRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`         // List of RADIUS accounting 802.1X servers to be used for authentication
+	RadiusAttributeForGroupPolicies string                                                                `json:"radiusAttributeForGroupPolicies,omitempty"` // RADIUS attribute used to look up group policies
+	RadiusEnabled                   *bool                                                                 `json:"radiusEnabled,omitempty"`                   // Whether RADIUS authentication is enabled
+	RadiusFailoverPolicy            string                                                                `json:"radiusFailoverPolicy,omitempty"`            // Policy which determines how authentication requests should be handled in the event that all of the configured RADIUS servers are unreachable
+	RadiusLoadBalancingPolicy       string                                                                `json:"radiusLoadBalancingPolicy,omitempty"`       // Policy which determines which RADIUS server will be contacted first in an authentication attempt, and the ordering of any necessary retry attempts
+	RadiusServers                   *[]ResponseItemWirelessGetNetworkWirelessSSIDsRadiusServers           `json:"radiusServers,omitempty"`                   // List of RADIUS 802.1X servers to be used for authentication
+	SplashPage                      string                                                                `json:"splashPage,omitempty"`                      // The type of splash page for the SSID
+	SplashTimeout                   string                                                                `json:"splashTimeout,omitempty"`                   // Splash page timeout
+	SSIDAdminAccessible             *bool                                                                 `json:"ssidAdminAccessible,omitempty"`             // SSID Administrator access status
+	Visible                         *bool                                                                 `json:"visible,omitempty"`                         // Whether the SSID is advertised or hidden by the AP
+	WalledGardenEnabled             *bool                                                                 `json:"walledGardenEnabled,omitempty"`             // Allow users to access a configurable list of IP ranges prior to sign-on
+	WalledGardenRanges              []string                                                              `json:"walledGardenRanges,omitempty"`              // Domain names and IP address ranges available in Walled Garden mode
+	WpaEncryptionMode               string                                                                `json:"wpaEncryptionMode,omitempty"`               // The types of WPA encryption
 }
 type ResponseItemWirelessGetNetworkWirelessSSIDsRadiusAccountingServers struct {
-	CaCertificate            string `json:"caCertificate,omitempty"`            //
-	Host                     string `json:"host,omitempty"`                     //
-	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` //
-	Port                     *int   `json:"port,omitempty"`                     //
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) to which the APs will send RADIUS accounting messages
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // Port on the RADIUS server that is listening for accounting messages
 }
 type ResponseItemWirelessGetNetworkWirelessSSIDsRadiusServers struct {
-	CaCertificate            string `json:"caCertificate,omitempty"`            //
-	Host                     string `json:"host,omitempty"`                     //
-	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` //
-	Port                     *int   `json:"port,omitempty"`                     //
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) of your RADIUS server
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // UDP port the RADIUS server listens on for Access-requests
 }
 type ResponseWirelessGetNetworkWirelessSSID struct {
-	AdminSplashURL                  string                                                           `json:"adminSplashUrl,omitempty"`                  //
-	AuthMode                        string                                                           `json:"authMode,omitempty"`                        //
-	AvailabilityTags                []string                                                         `json:"availabilityTags,omitempty"`                //
-	AvailableOnAllAps               *bool                                                            `json:"availableOnAllAps,omitempty"`               //
-	BandSelection                   string                                                           `json:"bandSelection,omitempty"`                   //
-	Enabled                         *bool                                                            `json:"enabled,omitempty"`                         //
-	EncryptionMode                  string                                                           `json:"encryptionMode,omitempty"`                  //
-	IPAssignmentMode                string                                                           `json:"ipAssignmentMode,omitempty"`                //
-	MandatoryDhcpEnabled            *bool                                                            `json:"mandatoryDhcpEnabled,omitempty"`            //
-	MinBitrate                      *int                                                             `json:"minBitrate,omitempty"`                      //
-	Name                            string                                                           `json:"name,omitempty"`                            //
-	Number                          *int                                                             `json:"number,omitempty"`                          //
-	PerClientBandwidthLimitDown     *int                                                             `json:"perClientBandwidthLimitDown,omitempty"`     //
-	PerClientBandwidthLimitUp       *int                                                             `json:"perClientBandwidthLimitUp,omitempty"`       //
-	PerSSIDBandwidthLimitDown       *int                                                             `json:"perSsidBandwidthLimitDown,omitempty"`       //
-	PerSSIDBandwidthLimitUp         *int                                                             `json:"perSsidBandwidthLimitUp,omitempty"`         //
-	RadiusAccountingEnabled         *bool                                                            `json:"radiusAccountingEnabled,omitempty"`         //
-	RadiusAccountingServers         *[]ResponseWirelessGetNetworkWirelessSSIDRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`         //
-	RadiusAttributeForGroupPolicies string                                                           `json:"radiusAttributeForGroupPolicies,omitempty"` //
-	RadiusEnabled                   *bool                                                            `json:"radiusEnabled,omitempty"`                   //
-	RadiusFailoverPolicy            string                                                           `json:"radiusFailoverPolicy,omitempty"`            //
-	RadiusLoadBalancingPolicy       string                                                           `json:"radiusLoadBalancingPolicy,omitempty"`       //
-	RadiusServers                   *[]ResponseWirelessGetNetworkWirelessSSIDRadiusServers           `json:"radiusServers,omitempty"`                   //
-	SplashPage                      string                                                           `json:"splashPage,omitempty"`                      //
-	SplashTimeout                   string                                                           `json:"splashTimeout,omitempty"`                   //
-	SSIDAdminAccessible             *bool                                                            `json:"ssidAdminAccessible,omitempty"`             //
-	Visible                         *bool                                                            `json:"visible,omitempty"`                         //
-	WalledGardenEnabled             *bool                                                            `json:"walledGardenEnabled,omitempty"`             //
-	WalledGardenRanges              []string                                                         `json:"walledGardenRanges,omitempty"`              //
-	WpaEncryptionMode               string                                                           `json:"wpaEncryptionMode,omitempty"`               //
+	AdminSplashURL                  string                                                           `json:"adminSplashUrl,omitempty"`                  // URL for the admin splash page
+	AuthMode                        string                                                           `json:"authMode,omitempty"`                        // The association control method for the SSID
+	AvailabilityTags                []string                                                         `json:"availabilityTags,omitempty"`                // List of tags for this SSID. If availableOnAllAps is false, then the SSID is only broadcast by APs with tags matching any of the tags in this list
+	AvailableOnAllAps               *bool                                                            `json:"availableOnAllAps,omitempty"`               // Whether all APs broadcast the SSID or if it's restricted to APs matching any availability tags
+	BandSelection                   string                                                           `json:"bandSelection,omitempty"`                   // The client-serving radio frequencies of this SSID in the default indoor RF profile
+	Enabled                         *bool                                                            `json:"enabled,omitempty"`                         // Whether or not the SSID is enabled
+	EncryptionMode                  string                                                           `json:"encryptionMode,omitempty"`                  // The psk encryption mode for the SSID
+	IPAssignmentMode                string                                                           `json:"ipAssignmentMode,omitempty"`                // The client IP assignment mode
+	LocalAuth                       *bool                                                            `json:"localAuth,omitempty"`                       // Extended local auth flag for Enterprise NAC
+	MandatoryDhcpEnabled            *bool                                                            `json:"mandatoryDhcpEnabled,omitempty"`            // Whether clients connecting to this SSID must use the IP address assigned by the DHCP server
+	MinBitrate                      *int                                                             `json:"minBitrate,omitempty"`                      // The minimum bitrate in Mbps of this SSID in the default indoor RF profile
+	Name                            string                                                           `json:"name,omitempty"`                            // The name of the SSID
+	Number                          *int                                                             `json:"number,omitempty"`                          // Unique identifier of the SSID
+	PerClientBandwidthLimitDown     *int                                                             `json:"perClientBandwidthLimitDown,omitempty"`     // The download bandwidth limit in Kbps. (0 represents no limit.)
+	PerClientBandwidthLimitUp       *int                                                             `json:"perClientBandwidthLimitUp,omitempty"`       // The upload bandwidth limit in Kbps. (0 represents no limit.)
+	PerSSIDBandwidthLimitDown       *int                                                             `json:"perSsidBandwidthLimitDown,omitempty"`       // The total download bandwidth limit in Kbps (0 represents no limit)
+	PerSSIDBandwidthLimitUp         *int                                                             `json:"perSsidBandwidthLimitUp,omitempty"`         // The total upload bandwidth limit in Kbps (0 represents no limit)
+	RadiusAccountingEnabled         *bool                                                            `json:"radiusAccountingEnabled,omitempty"`         // Whether or not RADIUS accounting is enabled
+	RadiusAccountingServers         *[]ResponseWirelessGetNetworkWirelessSSIDRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`         // List of RADIUS accounting 802.1X servers to be used for authentication
+	RadiusAttributeForGroupPolicies string                                                           `json:"radiusAttributeForGroupPolicies,omitempty"` // RADIUS attribute used to look up group policies
+	RadiusEnabled                   *bool                                                            `json:"radiusEnabled,omitempty"`                   // Whether RADIUS authentication is enabled
+	RadiusFailoverPolicy            string                                                           `json:"radiusFailoverPolicy,omitempty"`            // Policy which determines how authentication requests should be handled in the event that all of the configured RADIUS servers are unreachable
+	RadiusLoadBalancingPolicy       string                                                           `json:"radiusLoadBalancingPolicy,omitempty"`       // Policy which determines which RADIUS server will be contacted first in an authentication attempt, and the ordering of any necessary retry attempts
+	RadiusServers                   *[]ResponseWirelessGetNetworkWirelessSSIDRadiusServers           `json:"radiusServers,omitempty"`                   // List of RADIUS 802.1X servers to be used for authentication
+	SplashPage                      string                                                           `json:"splashPage,omitempty"`                      // The type of splash page for the SSID
+	SplashTimeout                   string                                                           `json:"splashTimeout,omitempty"`                   // Splash page timeout
+	SSIDAdminAccessible             *bool                                                            `json:"ssidAdminAccessible,omitempty"`             // SSID Administrator access status
+	Visible                         *bool                                                            `json:"visible,omitempty"`                         // Whether the SSID is advertised or hidden by the AP
+	WalledGardenEnabled             *bool                                                            `json:"walledGardenEnabled,omitempty"`             // Allow users to access a configurable list of IP ranges prior to sign-on
+	WalledGardenRanges              []string                                                         `json:"walledGardenRanges,omitempty"`              // Domain names and IP address ranges available in Walled Garden mode
+	WpaEncryptionMode               string                                                           `json:"wpaEncryptionMode,omitempty"`               // The types of WPA encryption
 }
 type ResponseWirelessGetNetworkWirelessSSIDRadiusAccountingServers struct {
-	CaCertificate            string `json:"caCertificate,omitempty"`            //
-	Host                     string `json:"host,omitempty"`                     //
-	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` //
-	Port                     *int   `json:"port,omitempty"`                     //
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) to which the APs will send RADIUS accounting messages
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // Port on the RADIUS server that is listening for accounting messages
 }
 type ResponseWirelessGetNetworkWirelessSSIDRadiusServers struct {
-	CaCertificate            string `json:"caCertificate,omitempty"`            //
-	Host                     string `json:"host,omitempty"`                     //
-	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` //
-	Port                     *int   `json:"port,omitempty"`                     //
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) of your RADIUS server
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // UDP port the RADIUS server listens on for Access-requests
 }
-type ResponseWirelessUpdateNetworkWirelessSSID interface{}
+type ResponseWirelessUpdateNetworkWirelessSSID struct {
+	AdminSplashURL                  string                                                              `json:"adminSplashUrl,omitempty"`                  // URL for the admin splash page
+	AuthMode                        string                                                              `json:"authMode,omitempty"`                        // The association control method for the SSID
+	AvailabilityTags                []string                                                            `json:"availabilityTags,omitempty"`                // List of tags for this SSID. If availableOnAllAps is false, then the SSID is only broadcast by APs with tags matching any of the tags in this list
+	AvailableOnAllAps               *bool                                                               `json:"availableOnAllAps,omitempty"`               // Whether all APs broadcast the SSID or if it's restricted to APs matching any availability tags
+	BandSelection                   string                                                              `json:"bandSelection,omitempty"`                   // The client-serving radio frequencies of this SSID in the default indoor RF profile
+	Enabled                         *bool                                                               `json:"enabled,omitempty"`                         // Whether or not the SSID is enabled
+	EncryptionMode                  string                                                              `json:"encryptionMode,omitempty"`                  // The psk encryption mode for the SSID
+	IPAssignmentMode                string                                                              `json:"ipAssignmentMode,omitempty"`                // The client IP assignment mode
+	LocalAuth                       *bool                                                               `json:"localAuth,omitempty"`                       // Extended local auth flag for Enterprise NAC
+	MandatoryDhcpEnabled            *bool                                                               `json:"mandatoryDhcpEnabled,omitempty"`            // Whether clients connecting to this SSID must use the IP address assigned by the DHCP server
+	MinBitrate                      *int                                                                `json:"minBitrate,omitempty"`                      // The minimum bitrate in Mbps of this SSID in the default indoor RF profile
+	Name                            string                                                              `json:"name,omitempty"`                            // The name of the SSID
+	Number                          *int                                                                `json:"number,omitempty"`                          // Unique identifier of the SSID
+	PerClientBandwidthLimitDown     *int                                                                `json:"perClientBandwidthLimitDown,omitempty"`     // The download bandwidth limit in Kbps. (0 represents no limit.)
+	PerClientBandwidthLimitUp       *int                                                                `json:"perClientBandwidthLimitUp,omitempty"`       // The upload bandwidth limit in Kbps. (0 represents no limit.)
+	PerSSIDBandwidthLimitDown       *int                                                                `json:"perSsidBandwidthLimitDown,omitempty"`       // The total download bandwidth limit in Kbps (0 represents no limit)
+	PerSSIDBandwidthLimitUp         *int                                                                `json:"perSsidBandwidthLimitUp,omitempty"`         // The total upload bandwidth limit in Kbps (0 represents no limit)
+	RadiusAccountingEnabled         *bool                                                               `json:"radiusAccountingEnabled,omitempty"`         // Whether or not RADIUS accounting is enabled
+	RadiusAccountingServers         *[]ResponseWirelessUpdateNetworkWirelessSSIDRadiusAccountingServers `json:"radiusAccountingServers,omitempty"`         // List of RADIUS accounting 802.1X servers to be used for authentication
+	RadiusAttributeForGroupPolicies string                                                              `json:"radiusAttributeForGroupPolicies,omitempty"` // RADIUS attribute used to look up group policies
+	RadiusEnabled                   *bool                                                               `json:"radiusEnabled,omitempty"`                   // Whether RADIUS authentication is enabled
+	RadiusFailoverPolicy            string                                                              `json:"radiusFailoverPolicy,omitempty"`            // Policy which determines how authentication requests should be handled in the event that all of the configured RADIUS servers are unreachable
+	RadiusLoadBalancingPolicy       string                                                              `json:"radiusLoadBalancingPolicy,omitempty"`       // Policy which determines which RADIUS server will be contacted first in an authentication attempt, and the ordering of any necessary retry attempts
+	RadiusServers                   *[]ResponseWirelessUpdateNetworkWirelessSSIDRadiusServers           `json:"radiusServers,omitempty"`                   // List of RADIUS 802.1X servers to be used for authentication
+	SplashPage                      string                                                              `json:"splashPage,omitempty"`                      // The type of splash page for the SSID
+	SplashTimeout                   string                                                              `json:"splashTimeout,omitempty"`                   // Splash page timeout
+	SSIDAdminAccessible             *bool                                                               `json:"ssidAdminAccessible,omitempty"`             // SSID Administrator access status
+	Visible                         *bool                                                               `json:"visible,omitempty"`                         // Whether the SSID is advertised or hidden by the AP
+	WalledGardenEnabled             *bool                                                               `json:"walledGardenEnabled,omitempty"`             // Allow users to access a configurable list of IP ranges prior to sign-on
+	WalledGardenRanges              []string                                                            `json:"walledGardenRanges,omitempty"`              // Domain names and IP address ranges available in Walled Garden mode
+	WpaEncryptionMode               string                                                              `json:"wpaEncryptionMode,omitempty"`               // The types of WPA encryption
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDRadiusAccountingServers struct {
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) to which the APs will send RADIUS accounting messages
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // Port on the RADIUS server that is listening for accounting messages
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDRadiusServers struct {
+	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) of your RADIUS server
+	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server
+	Port                     *int   `json:"port,omitempty"`                     // UDP port the RADIUS server listens on for Access-requests
+}
 type ResponseWirelessGetNetworkWirelessSSIDBonjourForwarding struct {
-	Enabled *bool                                                           `json:"enabled,omitempty"` //
-	Rules   *[]ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingRules `json:"rules,omitempty"`   //
+	Enabled   *bool                                                             `json:"enabled,omitempty"`   // If true, Bonjour forwarding is enabled on the SSID.
+	Exception *ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingException `json:"exception,omitempty"` // Bonjour forwarding exception
+	Rules     *[]ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingRules   `json:"rules,omitempty"`     // Bonjour forwarding rules
+}
+type ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingException struct {
+	Enabled *bool `json:"enabled,omitempty"` // If true, Bonjour forwarding exception is enabled on this SSID. Exception is required to enable L2 isolation and Bonjour forwarding to work together.
 }
 type ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingRules struct {
-	Description string   `json:"description,omitempty"` //
-	Services    []string `json:"services,omitempty"`    //
-	VLANID      string   `json:"vlanId,omitempty"`      //
+	Description string   `json:"description,omitempty"` // Desctiption of the bonjour forwarding rule
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding interface{}
+type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding struct {
+	Enabled   *bool                                                                `json:"enabled,omitempty"`   // If true, Bonjour forwarding is enabled on the SSID.
+	Exception *ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingException `json:"exception,omitempty"` // Bonjour forwarding exception
+	Rules     *[]ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules   `json:"rules,omitempty"`     // Bonjour forwarding rules
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingException struct {
+	Enabled *bool `json:"enabled,omitempty"` // If true, Bonjour forwarding exception is enabled on this SSID. Exception is required to enable L2 isolation and Bonjour forwarding to work together.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules struct {
+	Description string   `json:"description,omitempty"` // Desctiption of the bonjour forwarding rule
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required
+}
 type ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPolicies struct {
 	DeviceTypePolicies *[]ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPoliciesDeviceTypePolicies `json:"deviceTypePolicies,omitempty"` //
 	Enabled            *bool                                                                              `json:"enabled,omitempty"`            //
@@ -1432,25 +1894,41 @@ type ResponseWirelessUpdateNetworkWirelessSSIDEapOverrideIDentity struct {
 	Timeout *int `json:"timeout,omitempty"` // EAP timeout in seconds.
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRules struct {
-	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` //
+	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
-	Comment  string `json:"comment,omitempty"`  //
-	DestCidr string `json:"destCidr,omitempty"` //
-	DestPort string `json:"destPort,omitempty"` //
-	Policy   string `json:"policy,omitempty"`   //
-	Protocol string `json:"protocol,omitempty"` //
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules interface{}
+type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules struct {
+	Rules *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
+	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
+	DestCidr string `json:"destCidr,omitempty"` // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
+	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+}
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRules struct {
-	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` //
+	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules struct {
-	Policy string `json:"policy,omitempty"` //
-	Type   string `json:"type,omitempty"`   //
-	Value  string `json:"value,omitempty"`  //
+	Policy string `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
+	Type   string `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
+	Value  string `json:"value,omitempty"`  // The value of what needs to get blocked. Format of the value varies depending on type of the firewall rule selected.
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules interface{}
+type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules struct {
+	Rules *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules struct {
+	Policy string `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
+	Type   string `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
+	Value  string `json:"value,omitempty"`  // The value of what needs to get blocked. Format of the value varies depending on type of the firewall rule selected.
+}
 type ResponseWirelessGetNetworkWirelessSSIDHotspot20 struct {
 	Domains           []string                                                    `json:"domains,omitempty"`           //
 	Enabled           *bool                                                       `json:"enabled,omitempty"`           //
@@ -1498,7 +1976,15 @@ type ResponseItemWirelessGetNetworkWirelessSSIDIDentityPsks struct {
 	Passphrase            string `json:"passphrase,omitempty"`            // The passphrase for client authentication
 	WifiPersonalNetworkID string `json:"wifiPersonalNetworkId,omitempty"` // The WiFi Personal Network unique identifier
 }
-type ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk interface{}
+type ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk struct {
+	Email                 string `json:"email,omitempty"`                 // The email associated with the System's Manager User
+	ExpiresAt             string `json:"expiresAt,omitempty"`             // Timestamp for when the Identity PSK expires, or 'null' to never expire
+	GroupPolicyID         string `json:"groupPolicyId,omitempty"`         // The group policy to be applied to clients
+	ID                    string `json:"id,omitempty"`                    // The unique identifier of the Identity PSK
+	Name                  string `json:"name,omitempty"`                  // The name of the Identity PSK
+	Passphrase            string `json:"passphrase,omitempty"`            // The passphrase for client authentication
+	WifiPersonalNetworkID string `json:"wifiPersonalNetworkId,omitempty"` // The WiFi Personal Network unique identifier
+}
 type ResponseWirelessGetNetworkWirelessSSIDIDentityPsk struct {
 	Email                 string `json:"email,omitempty"`                 // The email associated with the System's Manager User
 	ExpiresAt             string `json:"expiresAt,omitempty"`             // Timestamp for when the Identity PSK expires, or 'null' to never expire
@@ -1508,7 +1994,15 @@ type ResponseWirelessGetNetworkWirelessSSIDIDentityPsk struct {
 	Passphrase            string `json:"passphrase,omitempty"`            // The passphrase for client authentication
 	WifiPersonalNetworkID string `json:"wifiPersonalNetworkId,omitempty"` // The WiFi Personal Network unique identifier
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk interface{}
+type ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk struct {
+	Email                 string `json:"email,omitempty"`                 // The email associated with the System's Manager User
+	ExpiresAt             string `json:"expiresAt,omitempty"`             // Timestamp for when the Identity PSK expires, or 'null' to never expire
+	GroupPolicyID         string `json:"groupPolicyId,omitempty"`         // The group policy to be applied to clients
+	ID                    string `json:"id,omitempty"`                    // The unique identifier of the Identity PSK
+	Name                  string `json:"name,omitempty"`                  // The name of the Identity PSK
+	Passphrase            string `json:"passphrase,omitempty"`            // The passphrase for client authentication
+	WifiPersonalNetworkID string `json:"wifiPersonalNetworkId,omitempty"` // The WiFi Personal Network unique identifier
+}
 type ResponseWirelessGetNetworkWirelessSSIDSchedules struct {
 	Enabled *bool                                                    `json:"enabled,omitempty"` //
 	Ranges  *[]ResponseWirelessGetNetworkWirelessSSIDSchedulesRanges `json:"ranges,omitempty"`  //
@@ -1536,6 +2030,7 @@ type ResponseWirelessGetNetworkWirelessSSIDSplashSettings struct {
 	SplashTimeout                   *int                                                                    `json:"splashTimeout,omitempty"`                   // Splash timeout in minutes.
 	SplashURL                       string                                                                  `json:"splashUrl,omitempty"`                       // The custom splash URL of the click-through splash page.
 	SSIDNumber                      *int                                                                    `json:"ssidNumber,omitempty"`                      // SSID number
+	ThemeID                         string                                                                  `json:"themeId,omitempty"`                         // The id of the selected splash theme.
 	UseRedirectURL                  *bool                                                                   `json:"useRedirectUrl,omitempty"`                  // The Boolean indicating whether the the user will be redirected to the custom redirect URL after the splash page.
 	UseSplashURL                    *bool                                                                   `json:"useSplashUrl,omitempty"`                    // Boolean indicating whether the users will be redirected to the custom splash url
 	WelcomeMessage                  string                                                                  `json:"welcomeMessage,omitempty"`                  // The welcome message for the users on the splash page.
@@ -1593,6 +2088,7 @@ type ResponseWirelessUpdateNetworkWirelessSSIDSplashSettings struct {
 	SplashTimeout                   *int                                                                       `json:"splashTimeout,omitempty"`                   // Splash timeout in minutes.
 	SplashURL                       string                                                                     `json:"splashUrl,omitempty"`                       // The custom splash URL of the click-through splash page.
 	SSIDNumber                      *int                                                                       `json:"ssidNumber,omitempty"`                      // SSID number
+	ThemeID                         string                                                                     `json:"themeId,omitempty"`                         // The id of the selected splash theme.
 	UseRedirectURL                  *bool                                                                      `json:"useRedirectUrl,omitempty"`                  // The Boolean indicating whether the the user will be redirected to the custom redirect URL after the splash page.
 	UseSplashURL                    *bool                                                                      `json:"useSplashUrl,omitempty"`                    // Boolean indicating whether the users will be redirected to the custom splash url
 	WelcomeMessage                  string                                                                     `json:"welcomeMessage,omitempty"`                  // The welcome message for the users on the splash page.
@@ -1635,29 +2131,51 @@ type ResponseWirelessUpdateNetworkWirelessSSIDSplashSettingsSplashPrepaidFront s
 	Md5       string `json:"md5,omitempty"`       // The MD5 value of the prepaid front image file.
 }
 type ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRules struct {
-	DefaultRulesEnabled   *bool                                                             `json:"defaultRulesEnabled,omitempty"`   //
-	Rules                 *[]ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRules `json:"rules,omitempty"`                 //
-	TrafficShapingEnabled *bool                                                             `json:"trafficShapingEnabled,omitempty"` //
+	DefaultRulesEnabled   *bool                                                             `json:"defaultRulesEnabled,omitempty"`   // Whether default traffic shaping rules are enabled (true) or disabled (false). There are 4 default rules, which can be seen on your network's traffic shaping page. Note that default rules count against the rule limit of 8.
+	Rules                 *[]ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRules `json:"rules,omitempty"`                 //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
+	TrafficShapingEnabled *bool                                                             `json:"trafficShapingEnabled,omitempty"` // Whether traffic shaping rules are applied to clients on your SSID.
 }
 type ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRules struct {
-	Definitions              *[]ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesDefinitions            `json:"definitions,omitempty"`              //
-	DscpTagValue             *int                                                                                    `json:"dscpTagValue,omitempty"`             //
-	PcpTagValue              *int                                                                                    `json:"pcpTagValue,omitempty"`              //
-	PerClientBandwidthLimits *ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //
+	Definitions              *[]ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                    `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                    `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
 }
 type ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesDefinitions struct {
-	Type  string `json:"type,omitempty"`  //
-	Value string `json:"value,omitempty"` //
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
 }
 type ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimits struct {
-	BandwidthLimits *ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` //
-	Settings        string                                                                                                 `json:"settings,omitempty"`        //
+	BandwidthLimits *ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                 `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
 }
 type ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimitsBandwidthLimits struct {
-	LimitDown *int `json:"limitDown,omitempty"` //
-	LimitUp   *int `json:"limitUp,omitempty"`   //
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRules interface{}
+type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRules struct {
+	DefaultRulesEnabled   *bool                                                                `json:"defaultRulesEnabled,omitempty"`   // Whether default traffic shaping rules are enabled (true) or disabled (false). There are 4 default rules, which can be seen on your network's traffic shaping page. Note that default rules count against the rule limit of 8.
+	Rules                 *[]ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRules `json:"rules,omitempty"`                 //     An array of traffic shaping rules. Rules are applied in the order that     they are specified in. An empty list (or null) means no rules. Note that     you are allowed a maximum of 8 rules.
+	TrafficShapingEnabled *bool                                                                `json:"trafficShapingEnabled,omitempty"` // Whether traffic shaping rules are applied to clients on your SSID.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRules struct {
+	Definitions              *[]ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesDefinitions            `json:"definitions,omitempty"`              //     A list of objects describing the definitions of your traffic shaping rule. At least one definition is required.
+	DscpTagValue             *int                                                                                       `json:"dscpTagValue,omitempty"`             //     The DSCP tag applied by your rule. null means 'Do not change DSCP tag'.     For a list of possible tag values, use the trafficShaping/dscpTaggingOptions endpoint.
+	PcpTagValue              *int                                                                                       `json:"pcpTagValue,omitempty"`              //     The PCP tag applied by your rule. Can be 0 (lowest priority) through 7 (highest priority).     null means 'Do not set PCP tag'.
+	PerClientBandwidthLimits *ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimits `json:"perClientBandwidthLimits,omitempty"` //     An object describing the bandwidth settings for your rule.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesDefinitions struct {
+	Type  string `json:"type,omitempty"`  // The type of definition. Can be one of 'application', 'applicationCategory', 'host', 'port', 'ipRange' or 'localNet'.
+	Value string `json:"value,omitempty"` //     If "type" is 'host', 'port', 'ipRange' or 'localNet', then "value" must be a string, matching either     a hostname (e.g. "somesite.com"), a port (e.g. 8080), or an IP range ("192.1.0.0",     "192.1.0.0/16", or "10.1.0.0/16:80"). 'localNet' also supports CIDR notation, excluding     custom ports.      If "type" is 'application' or 'applicationCategory', then "value" must be an object     with the structure { "id": "meraki:layer7/..." }, where "id" is the application category or     application ID (for a list of IDs for your network, use the trafficShaping/applicationCategories     endpoint).
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimits struct {
+	BandwidthLimits *ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimitsBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying the upload ('limitUp') and download ('limitDown') speed in Kbps. These are only enforced if 'settings' is set to 'custom'.
+	Settings        string                                                                                                    `json:"settings,omitempty"`        // How bandwidth limits are applied by your rule. Can be one of 'network default', 'ignore' or 'custom'.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRulesRulesPerClientBandwidthLimitsBandwidthLimits struct {
+	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps).
+	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps).
+}
 type ResponseWirelessGetNetworkWirelessSSIDVpn struct {
 	Concentrator *ResponseWirelessGetNetworkWirelessSSIDVpnConcentrator `json:"concentrator,omitempty"` //
 	Failover     *ResponseWirelessGetNetworkWirelessSSIDVpnFailover     `json:"failover,omitempty"`     //
@@ -1692,6 +2210,106 @@ type ResponseItemWirelessGetNetworkWirelessUsageHistory struct {
 	SentKbps     *int   `json:"sentKbps,omitempty"`     // Sent kilobytes-per-second
 	StartTs      string `json:"startTs,omitempty"`      // The start time of the query range
 	TotalKbps    *int   `json:"totalKbps,omitempty"`    // Total usage in kilobytes-per-second
+}
+type ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
+	ByBand  *[]ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Mac     string                                                                                `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                                `json:"serial,omitempty"`  // The serial number for the device.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand struct {
+	Band    string                                                                                     `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork []ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork // Array of ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork struct {
+	ByBand  *[]ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Network *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand struct {
+	Band    string                                                                                      `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval []ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval // Array of ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval struct {
+	ByBand  *[]ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                 `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Mac     string                                                                                                 `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                                                 `json:"serial,omitempty"`  // The serial number for the device.
+	StartTs string                                                                                                 `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand struct {
+	Band    string                                                                                                      `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
+}
+type ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval []ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval // Array of ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval struct {
+	ByBand  *[]ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                  `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Network *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	StartTs string                                                                                                  `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand struct {
+	Band    string                                                                                                       `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi struct {
+	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
 }
 type ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses []ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatuses // Array of ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatuses struct {
@@ -1731,6 +2349,91 @@ type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPowerAc s
 }
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPowerPoe struct {
 	IsConnected *bool `json:"isConnected,omitempty"` // PoE power connected
+}
+type ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient []ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClient // Array of ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClient struct {
+	Client     *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientClient     `json:"client,omitempty"`     // Client.
+	Downstream *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientClient struct {
+	ID  string `json:"id,omitempty"`  // Client ID.
+	Mac string `json:"mac,omitempty"` // MAC address.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByClientUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
+type ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice []ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDevice // Array of ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDevice struct {
+	Device     *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceDevice     `json:"device,omitempty"`     // Device.
+	Downstream *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceDevice struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address
+	Name   string `json:"name,omitempty"`   // Name
+	Serial string `json:"serial,omitempty"` // Serial Number
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByDeviceUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
+type ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork []ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetwork // Array of ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetwork struct {
+	Downstream *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkDownstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
+	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID.
+	Name string `json:"name,omitempty"` // Name of the network.
+}
+type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkUpstream struct {
+	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
+	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
+	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
+}
+type RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6 struct {
+	Addresses *[]RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6Addresses `json:"addresses,omitempty"` // configured alternate management interface addresses
+}
+type RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6Addresses struct {
+	Address        string                                                                                   `json:"address,omitempty"`        // The IP address configured for the alternate management interface
+	AssignmentMode string                                                                                   `json:"assignmentMode,omitempty"` // The type of address assignment. Either static or dynamic.
+	Gateway        string                                                                                   `json:"gateway,omitempty"`        // The gateway address configured for the alternate managment interface
+	Nameservers    *RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6AddressesNameservers `json:"nameservers,omitempty"`    // The DNS servers settings for this address.
+	Prefix         string                                                                                   `json:"prefix,omitempty"`         // The IPv6 prefix length of the IPv6 interface. Required if IPv6 object is included.
+	Protocol       string                                                                                   `json:"protocol,omitempty"`       // The IP protocol used for the address
+}
+type RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6AddressesNameservers struct {
+	Addresses []string `json:"addresses,omitempty"` // Up to 2 nameserver addresses to use, ordered in priority from highest to lowest priority.
 }
 type RequestWirelessUpdateDeviceWirelessBluetoothSettings struct {
 	Major *int   `json:"major,omitempty"` // Desired major value of the beacon. If the value is set to null it will reset to Dashboard's automatically generated value.
@@ -1787,21 +2490,65 @@ type RequestWirelessUpdateNetworkWirelessBluetoothSettings struct {
 	ScanningEnabled          *bool  `json:"scanningEnabled,omitempty"`          // Whether APs will scan for Bluetooth enabled clients.
 	UUID                     string `json:"uuid,omitempty"`                     // The UUID to be used in the beacon identifier.
 }
+type RequestWirelessCreateNetworkWirelessEthernetPortsProfile struct {
+	Name     string                                                              `json:"name,omitempty"`     // AP port profile name
+	Ports    *[]RequestWirelessCreateNetworkWirelessEthernetPortsProfilePorts    `json:"ports,omitempty"`    // AP ports configuration
+	UsbPorts *[]RequestWirelessCreateNetworkWirelessEthernetPortsProfileUsbPorts `json:"usbPorts,omitempty"` // AP usb ports configuration
+}
+type RequestWirelessCreateNetworkWirelessEthernetPortsProfilePorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // AP port enabled
+	Name       string `json:"name,omitempty"`       // AP port name
+	PskGroupID string `json:"pskGroupId,omitempty"` // AP port PSK Group ID
+	SSID       *int   `json:"ssid,omitempty"`       // AP port ssid number
+}
+type RequestWirelessCreateNetworkWirelessEthernetPortsProfileUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // AP usb port enabled
+	Name    string `json:"name,omitempty"`    // AP usb port name
+	SSID    *int   `json:"ssid,omitempty"`    // AP usb port ssid number
+}
+type RequestWirelessAssignNetworkWirelessEthernetPortsProfiles struct {
+	ProfileID string   `json:"profileId,omitempty"` // AP profile ID
+	Serials   []string `json:"serials,omitempty"`   // List of AP serials
+}
+type RequestWirelessSetNetworkWirelessEthernetPortsProfilesDefault struct {
+	ProfileID string `json:"profileId,omitempty"` // AP profile ID
+}
+type RequestWirelessUpdateNetworkWirelessEthernetPortsProfile struct {
+	Name     string                                                              `json:"name,omitempty"`     // AP port profile name
+	Ports    *[]RequestWirelessUpdateNetworkWirelessEthernetPortsProfilePorts    `json:"ports,omitempty"`    // AP ports configuration
+	UsbPorts *[]RequestWirelessUpdateNetworkWirelessEthernetPortsProfileUsbPorts `json:"usbPorts,omitempty"` // AP usb ports configuration
+}
+type RequestWirelessUpdateNetworkWirelessEthernetPortsProfilePorts struct {
+	Enabled    *bool  `json:"enabled,omitempty"`    // AP port enabled
+	Name       string `json:"name,omitempty"`       // AP port name
+	PskGroupID string `json:"pskGroupId,omitempty"` // AP port PSK Group number
+	SSID       *int   `json:"ssid,omitempty"`       // AP port ssid number
+}
+type RequestWirelessUpdateNetworkWirelessEthernetPortsProfileUsbPorts struct {
+	Enabled *bool  `json:"enabled,omitempty"` // AP usb port enabled
+	Name    string `json:"name,omitempty"`    // AP usb port name
+	SSID    *int   `json:"ssid,omitempty"`    // AP usb port ssid number
+}
 type RequestWirelessCreateNetworkWirelessRfProfile struct {
 	ApBandSettings         *RequestWirelessCreateNetworkWirelessRfProfileApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
 	BandSelectionType      string                                                           `json:"bandSelectionType,omitempty"`      // Band selection can be set to either 'ssid' or 'ap'. This param is required on creation.
 	ClientBalancingEnabled *bool                                                            `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
 	FiveGhzSettings        *RequestWirelessCreateNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
+	FlexRadios             *RequestWirelessCreateNetworkWirelessRfProfileFlexRadios         `json:"flexRadios,omitempty"`             // Flex radio settings.
 	MinBitrateType         string                                                           `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
 	Name                   string                                                           `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	PerSSIDSettings        *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
-	SixGhzSettings         *RequestWirelessCreateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band
+	SixGhzSettings         *RequestWirelessCreateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
 	Transmission           *RequestWirelessCreateNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
 	TwoFourGhzSettings     *RequestWirelessCreateNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
 type RequestWirelessCreateNetworkWirelessRfProfileApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'. Defaults to dual.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'. Defaults to dual.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false. Defaults to true.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
+}
+type RequestWirelessCreateNetworkWirelessRfProfileApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -1810,6 +2557,13 @@ type RequestWirelessCreateNetworkWirelessRfProfileFiveGhzSettings struct {
 	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 5Ghz band. Can be integer between 2 and 30. Defaults to 8.
 	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
 	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 5Ghz band. Can be one of '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161' or '165'.Defaults to [36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165].
+}
+type RequestWirelessCreateNetworkWirelessRfProfileFlexRadios struct {
+	ByModel *[]RequestWirelessCreateNetworkWirelessRfProfileFlexRadiosByModel `json:"byModel,omitempty"` // Flex radios by model.
+}
+type RequestWirelessCreateNetworkWirelessRfProfileFlexRadiosByModel struct {
+	Bands []string `json:"bands,omitempty"` // Band to use for each flex radio. For example, ['6'] will set the AP's first flex radio to 6 GHz
+	Model string   `json:"model,omitempty"` // Model of the AP
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status0  *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0  `json:"0,omitempty"`  // Settings for SSID 0
@@ -1829,79 +2583,139 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status9  *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
 }
 type RequestWirelessCreateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to 0.
@@ -1927,16 +2741,21 @@ type RequestWirelessUpdateNetworkWirelessRfProfile struct {
 	BandSelectionType      string                                                           `json:"bandSelectionType,omitempty"`      // Band selection can be set to either 'ssid' or 'ap'.
 	ClientBalancingEnabled *bool                                                            `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false.
 	FiveGhzSettings        *RequestWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
+	FlexRadios             *RequestWirelessUpdateNetworkWirelessRfProfileFlexRadios         `json:"flexRadios,omitempty"`             // Flex radio settings.
 	MinBitrateType         string                                                           `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'.
 	Name                   string                                                           `json:"name,omitempty"`                   // The name of the new profile. Must be unique.
 	PerSSIDSettings        *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
-	SixGhzSettings         *RequestWirelessUpdateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band
+	SixGhzSettings         *RequestWirelessUpdateNetworkWirelessRfProfileSixGhzSettings     `json:"sixGhzSettings,omitempty"`         // Settings related to 6Ghz band. Only applicable to networks with 6Ghz capable APs
 	Transmission           *RequestWirelessUpdateNetworkWirelessRfProfileTransmission       `json:"transmission,omitempty"`           // Settings related to radio transmission.
 	TwoFourGhzSettings     *RequestWirelessUpdateNetworkWirelessRfProfileTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"`     // Settings related to 2.4Ghz band
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileApBandSettings struct {
-	BandOperationMode   string `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool  `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false.
+	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                             `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
+}
+type RequestWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'.
@@ -1945,6 +2764,13 @@ type RequestWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings struct {
 	MinPower          *int   `json:"minPower,omitempty"`          // Sets min power (dBm) of 5Ghz band. Can be integer between 2 and 30.
 	Rxsop             *int   `json:"rxsop,omitempty"`             // The RX-SOP level controls the sensitivity of the radio. It is strongly recommended to use RX-SOP only after consulting a wireless expert. RX-SOP can be configured in the range of -65 to -95 (dBm). A value of null will reset this to the default.
 	ValidAutoChannels *[]int `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 5Ghz band. Can be one of '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161' or '165'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfileFlexRadios struct {
+	ByModel *[]RequestWirelessUpdateNetworkWirelessRfProfileFlexRadiosByModel `json:"byModel,omitempty"` // Flex radios by model.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfileFlexRadiosByModel struct {
+	Bands []string `json:"bands,omitempty"` // Band to use for each flex radio. For example, ['6'] will set the AP's first flex radio to 6 GHz
+	Model string   `json:"model,omitempty"` // Model of the AP
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status0  *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0  `json:"0,omitempty"`  // Settings for SSID 0
@@ -1964,79 +2790,139 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings struct {
 	Status9  *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9  `json:"9,omitempty"`  // Settings for SSID 9
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                                `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
-	BandOperationMode   string   `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz' or '5ghz'.
-	BandSteeringEnabled *bool    `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
-	MinBitrate          *float64 `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
+	BandSteeringEnabled *bool                                                               `json:"bandSteeringEnabled,omitempty"` // Steers client to most open band between 2.4 GHz and 5 GHz. Can be either true or false.
+	Bands               *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands `json:"bands,omitempty"`               // Settings related to all bands
+	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
+}
+type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'.
@@ -2058,17 +2944,25 @@ type RequestWirelessUpdateNetworkWirelessRfProfileTwoFourGhzSettings struct {
 	ValidAutoChannels *[]int   `json:"validAutoChannels,omitempty"` // Sets valid auto channels for 2.4Ghz band. Can be one of '1', '6' or '11'.
 }
 type RequestWirelessUpdateNetworkWirelessSettings struct {
-	IPv6BridgeEnabled        *bool  `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
-	LedLightsOn              *bool  `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
-	LocationAnalyticsEnabled *bool  `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
-	MeshingEnabled           *bool  `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
-	Upgradestrategy          string `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	IPv6BridgeEnabled        *bool                                                   `json:"ipv6BridgeEnabled,omitempty"`        // Toggle for enabling or disabling IPv6 bridging in a network (Note: if enabled, SSIDs must also be configured to use bridge mode)
+	LedLightsOn              *bool                                                   `json:"ledLightsOn,omitempty"`              // Toggle for enabling or disabling LED lights on all APs in the network (making them run dark)
+	LocationAnalyticsEnabled *bool                                                   `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
+	MeshingEnabled           *bool                                                   `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
+	NamedVLANs               *RequestWirelessUpdateNetworkWirelessSettingsNamedVLANs `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
+	Upgradestrategy          string                                                  `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+}
+type RequestWirelessUpdateNetworkWirelessSettingsNamedVLANs struct {
+	PoolDhcpMonitoring *RequestWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
+}
+type RequestWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring struct {
+	Duration *int  `json:"duration,omitempty"` // The duration in minutes that devices will refrain from using dirty VLANs before adding them back to the pool.
+	Enabled  *bool `json:"enabled,omitempty"`  // Whether or not devices using named VLAN pools should remove dirty VLANs from the pool, thereby preventing clients from being assigned to VLANs where they would be unable to obtain an IP address via DHCP.
 }
 type RequestWirelessUpdateNetworkWirelessSSID struct {
 	ActiveDirectory                  *RequestWirelessUpdateNetworkWirelessSSIDActiveDirectory           `json:"activeDirectory,omitempty"`                  // The current setting for Active Directory. Only valid if splashPage is 'Password-protected with Active Directory'
 	AdultContentFilteringEnabled     *bool                                                              `json:"adultContentFilteringEnabled,omitempty"`     // Boolean indicating whether or not adult content will be blocked
 	ApTagsAndVLANIDs                 *[]RequestWirelessUpdateNetworkWirelessSSIDApTagsAndVLANIDs        `json:"apTagsAndVlanIds,omitempty"`                 // The list of tags and VLAN IDs used for VLAN tagging. This param is only valid when the ipAssignmentMode is 'Bridge mode' or 'Layer 3 roaming'
-	AuthMode                         string                                                             `json:"authMode,omitempty"`                         // The association control method for the SSID ('open', 'open-enhanced', 'psk', 'open-with-radius', 'open-with-nac', '8021x-meraki', '8021x-nac', '8021x-radius', '8021x-google', '8021x-localradius', 'ipsk-with-radius' or 'ipsk-without-radius')
+	AuthMode                         string                                                             `json:"authMode,omitempty"`                         // The association control method for the SSID ('open', 'open-enhanced', 'psk', 'open-with-radius', 'open-with-nac', '8021x-meraki', '8021x-nac', '8021x-radius', '8021x-google', '8021x-localradius', 'ipsk-with-radius', 'ipsk-without-radius' or 'ipsk-with-nac')
 	AvailabilityTags                 []string                                                           `json:"availabilityTags,omitempty"`                 // Accepts a list of tags for this SSID. If availableOnAllAps is false, then the SSID will only be broadcast by APs with tags matching any of the tags in this list.
 	AvailableOnAllAps                *bool                                                              `json:"availableOnAllAps,omitempty"`                // Boolean indicating whether all APs should broadcast the SSID or if it should be restricted to APs matching any availability tags. Can only be false if the SSID has availability tags.
 	BandSelection                    string                                                             `json:"bandSelection,omitempty"`                    // The client-serving radio frequencies of this SSID in the default indoor RF profile. ('Dual band operation', '5 GHz band only' or 'Dual band operation with Band Steering')
@@ -2089,6 +2983,7 @@ type RequestWirelessUpdateNetworkWirelessSSID struct {
 	MandatoryDhcpEnabled             *bool                                                              `json:"mandatoryDhcpEnabled,omitempty"`             // If true, Mandatory DHCP will enforce that clients connecting to this SSID must use the IP address assigned by the DHCP server. Clients who use a static IP address won't be able to associate.
 	MinBitrate                       *float64                                                           `json:"minBitrate,omitempty"`                       // The minimum bitrate in Mbps of this SSID in the default indoor RF profile. ('1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54')
 	Name                             string                                                             `json:"name,omitempty"`                             // The name of the SSID
+	NamedVLANs                       *RequestWirelessUpdateNetworkWirelessSSIDNamedVLANs                `json:"namedVlans,omitempty"`                       // Named VLAN settings.
 	Oauth                            *RequestWirelessUpdateNetworkWirelessSSIDOauth                     `json:"oauth,omitempty"`                            // The OAuth settings of this SSID. Only valid if splashPage is 'Google OAuth'.
 	PerClientBandwidthLimitDown      *int                                                               `json:"perClientBandwidthLimitDown,omitempty"`      // The download bandwidth limit in Kbps. (0 represents no limit.)
 	PerClientBandwidthLimitUp        *int                                                               `json:"perClientBandwidthLimitUp,omitempty"`        // The upload bandwidth limit in Kbps. (0 represents no limit.)
@@ -2133,7 +3028,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDActiveDirectoryCredentials struct {
 	Password  string `json:"password,omitempty"`  // The password to the Active Directory user account.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDActiveDirectoryServers struct {
-	Host string `json:"host,omitempty"` // IP address of your Active Directory server.
+	Host string `json:"host,omitempty"` // IP address (or FQDN) of your Active Directory server.
 	Port *int   `json:"port,omitempty"` // (Optional) UDP port the Active Directory server listens on. By default, uses port 3268.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDApTagsAndVLANIDs struct {
@@ -2173,7 +3068,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDLdapServerCaCertificate struct {
 	Contents string `json:"contents,omitempty"` // The contents of the CA certificate. Must be in PEM or DER format.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDLdapServers struct {
-	Host string `json:"host,omitempty"` // IP address of your LDAP server.
+	Host string `json:"host,omitempty"` // IP address (or FQDN) of your LDAP server.
 	Port *int   `json:"port,omitempty"` // UDP port the LDAP server listens on.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDLocalRadius struct {
@@ -2194,19 +3089,39 @@ type RequestWirelessUpdateNetworkWirelessSSIDLocalRadiusCertificateAuthenticatio
 type RequestWirelessUpdateNetworkWirelessSSIDLocalRadiusPasswordAuthentication struct {
 	Enabled *bool `json:"enabled,omitempty"` // Whether or not to use EAP-TTLS/PAP or PEAP-GTC password-based authentication via LDAP lookup.
 }
+type RequestWirelessUpdateNetworkWirelessSSIDNamedVLANs struct {
+	Radius  *RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsRadius  `json:"radius,omitempty"`  // RADIUS settings. This param is only valid when authMode is 'open-with-radius' and ipAssignmentMode is not 'NAT mode'.
+	Tagging *RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsTagging `json:"tagging,omitempty"` // VLAN tagging settings. This param is only valid when ipAssignmentMode is 'Bridge mode' or 'Layer 3 roaming'.
+}
+type RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsRadius struct {
+	GuestVLAN *RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsRadiusGuestVLAN `json:"guestVlan,omitempty"` // Guest VLAN settings. Used to direct traffic to a guest VLAN when none of the RADIUS servers are reachable or a client receives access-reject from the RADIUS server.
+}
+type RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsRadiusGuestVLAN struct {
+	Enabled *bool  `json:"enabled,omitempty"` // Whether or not RADIUS guest named VLAN is enabled.
+	Name    string `json:"name,omitempty"`    // RADIUS guest VLAN name.
+}
+type RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsTagging struct {
+	ByApTags        *[]RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsTaggingByApTags `json:"byApTags,omitempty"`        // The list of AP tags and VLAN names used for named VLAN tagging. If an AP has a tag matching one in the list, then traffic on this SSID will be directed to use the VLAN name associated to the tag.
+	DefaultVLANName string                                                               `json:"defaultVlanName,omitempty"` // The default VLAN name used to tag traffic in the absence of a matching AP tag.
+	Enabled         *bool                                                                `json:"enabled,omitempty"`         // Whether or not traffic should be directed to use specific VLAN names.
+}
+type RequestWirelessUpdateNetworkWirelessSSIDNamedVLANsTaggingByApTags struct {
+	Tags     []string `json:"tags,omitempty"`     // List of AP tags.
+	VLANName string   `json:"vlanName,omitempty"` // VLAN name that will be used to tag traffic.
+}
 type RequestWirelessUpdateNetworkWirelessSSIDOauth struct {
 	AllowedDomains []string `json:"allowedDomains,omitempty"` // (Optional) The list of domains allowed access to the network.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDRadiusAccountingServers struct {
 	CaCertificate string `json:"caCertificate,omitempty"` // Certificate used for authorization for the RADSEC Server
-	Host          string `json:"host,omitempty"`          // IP address to which the APs will send RADIUS accounting messages
+	Host          string `json:"host,omitempty"`          // IP address (or FQDN) to which the APs will send RADIUS accounting messages
 	Port          *int   `json:"port,omitempty"`          // Port on the RADIUS server that is listening for accounting messages
 	RadsecEnabled *bool  `json:"radsecEnabled,omitempty"` // Use RADSEC (TLS over TCP) to connect to this RADIUS accounting server. Requires radiusProxyEnabled.
 	Secret        string `json:"secret,omitempty"`        // Shared key used to authenticate messages between the APs and RADIUS server
 }
 type RequestWirelessUpdateNetworkWirelessSSIDRadiusServers struct {
 	CaCertificate            string `json:"caCertificate,omitempty"`            // Certificate used for authorization for the RADSEC Server
-	Host                     string `json:"host,omitempty"`                     // IP address of your RADIUS server
+	Host                     string `json:"host,omitempty"`                     // IP address (or FQDN) of your RADIUS server
 	OpenRoamingCertificateID *int   `json:"openRoamingCertificateId,omitempty"` // The ID of the Openroaming Certificate attached to radius server.
 	Port                     *int   `json:"port,omitempty"`                     // UDP port the RADIUS server listens on for Access-requests
 	RadsecEnabled            *bool  `json:"radsecEnabled,omitempty"`            // Use RADSEC (TLS over TCP) to connect to this RADIUS server. Requires radiusProxyEnabled.
@@ -2216,8 +3131,12 @@ type RequestWirelessUpdateNetworkWirelessSSIDSpeedBurst struct {
 	Enabled *bool `json:"enabled,omitempty"` // Boolean indicating whether or not to allow users to temporarily exceed the bandwidth limit for short periods while still keeping them under the bandwidth limit over time.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDBonjourForwarding struct {
-	Enabled *bool                                                             `json:"enabled,omitempty"` // If true, Bonjour forwarding is enabled on this SSID.
-	Rules   *[]RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules `json:"rules,omitempty"`   // List of bonjour forwarding rules.
+	Enabled   *bool                                                               `json:"enabled,omitempty"`   // If true, Bonjour forwarding is enabled on this SSID.
+	Exception *RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingException `json:"exception,omitempty"` // Bonjour forwarding exception
+	Rules     *[]RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules   `json:"rules,omitempty"`     // List of bonjour forwarding rules.
+}
+type RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingException struct {
+	Enabled *bool `json:"enabled,omitempty"` // If true, Bonjour forwarding exception is enabled on this SSID. Exception is required to enable L2 isolation and Bonjour forwarding to work together.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules struct {
 	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
@@ -2249,7 +3168,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDEapOverrideIDentity struct {
 }
 type RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules struct {
 	AllowLanAccess *bool                                                                   `json:"allowLanAccess,omitempty"` // Allow wireless client access to local LAN (boolean value - true allows access and false denies access) (optional)
-	Rules          *[]RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"`          // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule)
+	Rules          *[]RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"`          // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
@@ -2289,12 +3208,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDHotspot20NaiRealmsMethods struct {
 	AuthenticationTypes *RequestWirelessUpdateNetworkWirelessSSIDHotspot20NaiRealmsMethodsAuthenticationTypes `json:"authenticationTypes,omitempty"` // The authentication types for the method. These should be formatted as an object with the EAP method category in camelcase as the key and the list of types as the value (nonEapInnerAuthentication: Reserved, PAP, CHAP, MSCHAP, MSCHAPV2; eapInnerAuthentication: EAP-TLS, EAP-SIM, EAP-AKA, EAP-TTLS with MSCHAPv2; credentials: SIM, USIM, NFC Secure Element, Hardware Token, Softoken, Certificate, username/password, none, Reserved, Vendor Specific; tunneledEapMethodCredentials: SIM, USIM, NFC Secure Element, Hardware Token, Softoken, Certificate, username/password, Reserved, Anonymous, Vendor Specific)
 	ID                  string                                                                                `json:"id,omitempty"`                  // ID of method
 }
-type RequestWirelessUpdateNetworkWirelessSSIDHotspot20NaiRealmsMethodsAuthenticationTypes struct {
-	Credentials                  []string `json:"credentials,omitempty"`                  //
-	EapinnerAuthentication       []string `json:"eapInnerAuthentication,omitempty"`       //
-	NonEapinnerAuthentication    []string `json:"nonEapInnerAuthentication,omitempty"`    //
-	TunneledEapMethodCredentials []string `json:"tunneledEapMethodCredentials,omitempty"` //
-}
+type RequestWirelessUpdateNetworkWirelessSSIDHotspot20NaiRealmsMethodsAuthenticationTypes interface{}
 type RequestWirelessUpdateNetworkWirelessSSIDHotspot20Operator struct {
 	Name string `json:"name,omitempty"` // Operator name
 }
@@ -2342,6 +3256,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDSplashSettings struct {
 	SplashPrepaidFront              *RequestWirelessUpdateNetworkWirelessSSIDSplashSettingsSplashPrepaidFront `json:"splashPrepaidFront,omitempty"`              // The prepaid front image used in the splash page.
 	SplashTimeout                   *int                                                                      `json:"splashTimeout,omitempty"`                   // Splash timeout in minutes. This will determine how often users will see the splash page.
 	SplashURL                       string                                                                    `json:"splashUrl,omitempty"`                       // [optional] The custom splash URL of the click-through splash page. Note that the URL can be configured without necessarily being used. In order to enable the custom URL, see 'useSplashUrl'
+	ThemeID                         string                                                                    `json:"themeId,omitempty"`                         // The id of the selected splash theme.
 	UseRedirectURL                  *bool                                                                     `json:"useRedirectUrl,omitempty"`                  // The Boolean indicating whether the the user will be redirected to the custom redirect URL after the splash page. A custom redirect URL must be set if this is true.
 	UseSplashURL                    *bool                                                                     `json:"useSplashUrl,omitempty"`                    // [optional] Boolean indicating whether the users will be redirected to the custom splash url. A custom splash URL must be set if this is true. Note that depending on your SSID's access control settings, it may not be possible to use the custom splash URL.
 	WelcomeMessage                  string                                                                    `json:"welcomeMessage,omitempty"`                  // The welcome message for the users on the splash page.
@@ -2448,7 +3363,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDVpnSplitTunnelRules struct {
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-bluetooth-settings
 */
 func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*ResponseWirelessGetDeviceWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/bluetooth/settings"
@@ -2482,7 +3397,7 @@ func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*Re
 @param serial serial path parameter.
 @param getDeviceWirelessConnectionStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-connection-stats
 */
 func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDeviceWirelessConnectionStatsQueryParams *GetDeviceWirelessConnectionStatsQueryParams) (*ResponseWirelessGetDeviceWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/connectionStats"
@@ -2518,7 +3433,7 @@ func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDev
 @param serial serial path parameter.
 @param getDeviceWirelessLatencyStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-latency-stats
 */
 func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDeviceWirelessLatencyStatsQueryParams *GetDeviceWirelessLatencyStatsQueryParams) (*ResponseWirelessGetDeviceWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/latencyStats"
@@ -2553,7 +3468,7 @@ func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDevice
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-radio-settings
 */
 func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*ResponseWirelessGetDeviceWirelessRadioSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/radio/settings"
@@ -2586,7 +3501,7 @@ func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*Respon
 
 @param serial serial path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-status
 */
 func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirelessGetDeviceWirelessStatus, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/status"
@@ -2620,7 +3535,7 @@ func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirel
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessAirMarshalQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-air-marshal
 */
 func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetworkWirelessAirMarshalQueryParams *GetNetworkWirelessAirMarshalQueryParams) (*ResponseWirelessGetNetworkWirelessAirMarshal, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/airMarshal"
@@ -2655,7 +3570,7 @@ func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetw
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-alternate-management-interface
 */
 func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(networkID string) (*ResponseWirelessGetNetworkWirelessAlternateManagementInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/alternateManagementInterface"
@@ -2688,7 +3603,7 @@ func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(network
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-billing
 */
 func (s *WirelessService) GetNetworkWirelessBilling(networkID string) (*ResponseWirelessGetNetworkWirelessBilling, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/billing"
@@ -2723,7 +3638,7 @@ Bluetooth settings
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-bluetooth-settings
 */
 func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) (*ResponseWirelessGetNetworkWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/bluetooth/settings"
@@ -2757,7 +3672,7 @@ func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessChannelUtilizationHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-channel-utilization-history
 */
 func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID string, getNetworkWirelessChannelUtilizationHistoryQueryParams *GetNetworkWirelessChannelUtilizationHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessChannelUtilizationHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/channelUtilizationHistory"
@@ -2793,7 +3708,7 @@ func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientCountHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-count-history
 */
 func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string, getNetworkWirelessClientCountHistoryQueryParams *GetNetworkWirelessClientCountHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientCountHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clientCountHistory"
@@ -2829,7 +3744,7 @@ func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string,
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientsConnectionStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-clients-connection-stats
 */
 func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID string, getNetworkWirelessClientsConnectionStatsQueryParams *GetNetworkWirelessClientsConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/connectionStats"
@@ -2865,7 +3780,7 @@ func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientsLatencyStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-clients-latency-stats
 */
 func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string, getNetworkWirelessClientsLatencyStatsQueryParams *GetNetworkWirelessClientsLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/latencyStats"
@@ -2902,7 +3817,7 @@ func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientConnectionStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-connection-stats
 */
 func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID string, clientID string, getNetworkWirelessClientConnectionStatsQueryParams *GetNetworkWirelessClientConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectionStats"
@@ -2940,7 +3855,7 @@ func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID stri
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientConnectivityEventsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-connectivity-events
 */
 func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID string, clientID string, getNetworkWirelessClientConnectivityEventsQueryParams *GetNetworkWirelessClientConnectivityEventsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectivityEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectivityEvents"
@@ -2978,7 +3893,7 @@ func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID s
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientLatencyHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-latency-history
 */
 func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID string, clientID string, getNetworkWirelessClientLatencyHistoryQueryParams *GetNetworkWirelessClientLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyHistory"
@@ -3016,7 +3931,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID strin
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientLatencyStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-latency-stats
 */
 func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string, clientID string, getNetworkWirelessClientLatencyStatsQueryParams *GetNetworkWirelessClientLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyStats"
@@ -3053,7 +3968,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string,
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessConnectionStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-connection-stats
 */
 func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, getNetworkWirelessConnectionStatsQueryParams *GetNetworkWirelessConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/connectionStats"
@@ -3089,7 +4004,7 @@ func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, ge
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDataRateHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-data-rate-history
 */
 func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, getNetworkWirelessDataRateHistoryQueryParams *GetNetworkWirelessDataRateHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessDataRateHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/dataRateHistory"
@@ -3125,7 +4040,7 @@ func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, ge
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDevicesConnectionStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-devices-connection-stats
 */
 func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID string, getNetworkWirelessDevicesConnectionStatsQueryParams *GetNetworkWirelessDevicesConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/connectionStats"
@@ -3161,7 +4076,7 @@ func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDevicesLatencyStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-devices-latency-stats
 */
 func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string, getNetworkWirelessDevicesLatencyStatsQueryParams *GetNetworkWirelessDevicesLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/latencyStats"
@@ -3191,13 +4106,81 @@ func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string
 
 }
 
+//GetNetworkWirelessEthernetPortsProfiles List the AP port profiles for this network
+/* List the AP port profiles for this network
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ethernet-ports-profiles
+*/
+func (s *WirelessService) GetNetworkWirelessEthernetPortsProfiles(networkID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfiles, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseWirelessGetNetworkWirelessEthernetPortsProfiles{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkWirelessEthernetPortsProfiles")
+	}
+
+	result := response.Result().(*ResponseWirelessGetNetworkWirelessEthernetPortsProfiles)
+	return result, response, err
+
+}
+
+//GetNetworkWirelessEthernetPortsProfile Show the AP port profile by ID for this network
+/* Show the AP port profile by ID for this network
+
+@param networkID networkId path parameter. Network ID
+@param profileID profileId path parameter. Profile ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ethernet-ports-profile
+*/
+func (s *WirelessService) GetNetworkWirelessEthernetPortsProfile(networkID string, profileID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{profileId}", fmt.Sprintf("%v", profileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseWirelessGetNetworkWirelessEthernetPortsProfile{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkWirelessEthernetPortsProfile")
+	}
+
+	result := response.Result().(*ResponseWirelessGetNetworkWirelessEthernetPortsProfile)
+	return result, response, err
+
+}
+
 //GetNetworkWirelessFailedConnections List of all failed client connection events on this network in a given time range
 /* List of all failed client connection events on this network in a given time range
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessFailedConnectionsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-failed-connections
 */
 func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, getNetworkWirelessFailedConnectionsQueryParams *GetNetworkWirelessFailedConnectionsQueryParams) (*ResponseWirelessGetNetworkWirelessFailedConnections, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/failedConnections"
@@ -3233,7 +4216,7 @@ func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessLatencyHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-latency-history
 */
 func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, getNetworkWirelessLatencyHistoryQueryParams *GetNetworkWirelessLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyHistory"
@@ -3269,7 +4252,7 @@ func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, get
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessLatencyStatsQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-latency-stats
 */
 func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNetworkWirelessLatencyStatsQueryParams *GetNetworkWirelessLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyStats"
@@ -3305,7 +4288,7 @@ func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNe
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessMeshStatusesQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-mesh-statuses
 */
 func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNetworkWirelessMeshStatusesQueryParams *GetNetworkWirelessMeshStatusesQueryParams) (*ResponseWirelessGetNetworkWirelessMeshStatuses, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/meshStatuses"
@@ -3335,13 +4318,13 @@ func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNe
 
 }
 
-//GetNetworkWirelessRfProfiles List the non-basic RF profiles for this network
-/* List the non-basic RF profiles for this network
+//GetNetworkWirelessRfProfiles List RF profiles for this network
+/* List RF profiles for this network
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessRfProfilesQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-rf-profiles
 */
 func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetworkWirelessRfProfilesQueryParams *GetNetworkWirelessRfProfilesQueryParams) (*ResponseWirelessGetNetworkWirelessRfProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles"
@@ -3377,7 +4360,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetw
 @param networkID networkId path parameter. Network ID
 @param rfProfileID rfProfileId path parameter. Rf profile ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-rf-profile
 */
 func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfileID string) (*ResponseWirelessGetNetworkWirelessRfProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles/{rfProfileId}"
@@ -3411,7 +4394,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfil
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-settings
 */
 func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*ResponseWirelessGetNetworkWirelessSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/settings"
@@ -3445,7 +4428,7 @@ func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*Respons
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessSignalQualityHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-signal-quality-history
 */
 func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID string, getNetworkWirelessSignalQualityHistoryQueryParams *GetNetworkWirelessSignalQualityHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessSignalQualityHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/signalQualityHistory"
@@ -3480,7 +4463,7 @@ func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID strin
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssids
 */
 func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWirelessGetNetworkWirelessSSIDs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids"
@@ -3514,7 +4497,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWi
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid
 */
 func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSID, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}"
@@ -3549,7 +4532,7 @@ func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-bonjour-forwarding
 */
 func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDBonjourForwarding, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding"
@@ -3584,7 +4567,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID stri
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-device-type-group-policies
 */
 func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPolicies, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/deviceTypeGroupPolicies"
@@ -3619,7 +4602,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-eap-override
 */
 func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDEapOverride, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/eapOverride"
@@ -3654,7 +4637,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, nu
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-firewall-l3-firewall-rules
 */
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules"
@@ -3689,7 +4672,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-firewall-l7-firewall-rules
 */
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules"
@@ -3724,7 +4707,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-hotspot20
 */
 func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDHotspot20, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/hotspot20"
@@ -3759,7 +4742,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, numb
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-identity-psks
 */
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsks, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks"
@@ -3795,7 +4778,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, n
 @param number number path parameter.
 @param identityPskID identityPskId path parameter. Identity psk ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-identity-psk
 */
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}"
@@ -3831,7 +4814,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, nu
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-schedules
 */
 func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/schedules"
@@ -3866,7 +4849,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, numb
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-splash-settings
 */
 func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSplashSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/splash/settings"
@@ -3901,7 +4884,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string,
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-traffic-shaping-rules
 */
 func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules"
@@ -3936,7 +4919,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID st
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-vpn
 */
 func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDVpn, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/vpn"
@@ -3971,7 +4954,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessUsageHistoryQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-usage-history
 */
 func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNetworkWirelessUsageHistoryQueryParams *GetNetworkWirelessUsageHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/usageHistory"
@@ -4001,13 +4984,157 @@ func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNe
 
 }
 
-//GetOrganizationWirelessDevicesEthernetStatuses Endpoint to see power status for wireless devices
-/* Endpoint to see power status for wireless devices
+//GetOrganizationWirelessDevicesChannelUtilizationByDevice Get average channel utilization for all bands in a network, split by AP
+/* Get average channel utilization for all bands in a network, split by AP
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-device
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationByNetwork Get average channel utilization across all bands for all networks in the organization
+/* Get average channel utilization across all bands for all networks in the organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-network
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByNetwork")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval Get a time-series of average channel utilization for all bands, segmented by device.
+/* Get a time-series of average channel utilization for all bands, segmented by device.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-device-by-interval
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval Get a time-series of average channel utilization for all bands
+/* Get a time-series of average channel utilization for all bands
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-network-by-interval
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesEthernetStatuses List the most recent Ethernet link speed, duplex, aggregation and power mode and status information for wireless devices.
+/* List the most recent Ethernet link speed, duplex, aggregation and power mode and status information for wireless devices.
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesEthernetStatusesQueryParams Filtering parameter
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-ethernet-statuses
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organizationID string, getOrganizationWirelessDevicesEthernetStatusesQueryParams *GetOrganizationWirelessDevicesEthernetStatusesQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/ethernet/statuses"
@@ -4037,12 +5164,225 @@ func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organiz
 
 }
 
+//GetOrganizationWirelessDevicesPacketLossByClient Get average packet loss for the given timespan for all clients in the organization.
+/* Get average packet loss for the given timespan for all clients in the organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByClientQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-client
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByClientQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByClient")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesPacketLossByDevice Get average packet loss for the given timespan for all devices in the organization
+/* Get average packet loss for the given timespan for all devices in the organization. Does not include device's own traffic.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByDeviceQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-device
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessDevicesPacketLossByNetwork Get average packet loss for the given timespan for all networks in the organization.
+/* Get average packet loss for the given timespan for all networks in the organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesPacketLossByNetworkQueryParams Filtering parameter
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-network
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByNetwork")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork)
+	return result, response, err
+
+}
+
+//CreateNetworkWirelessEthernetPortsProfile Create an AP port profile
+/* Create an AP port profile
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-ethernet-ports-profile
+*/
+
+func (s *WirelessService) CreateNetworkWirelessEthernetPortsProfile(networkID string, requestWirelessCreateNetworkWirelessEthernetPortsProfile *RequestWirelessCreateNetworkWirelessEthernetPortsProfile) (*ResponseWirelessCreateNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessCreateNetworkWirelessEthernetPortsProfile).
+		SetResult(&ResponseWirelessCreateNetworkWirelessEthernetPortsProfile{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateNetworkWirelessEthernetPortsProfile")
+	}
+
+	result := response.Result().(*ResponseWirelessCreateNetworkWirelessEthernetPortsProfile)
+	return result, response, err
+
+}
+
+//AssignNetworkWirelessEthernetPortsProfiles Assign AP port profile to list of APs
+/* Assign AP port profile to list of APs
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!assign-network-wireless-ethernet-ports-profiles
+*/
+
+func (s *WirelessService) AssignNetworkWirelessEthernetPortsProfiles(networkID string, requestWirelessAssignNetworkWirelessEthernetPortsProfiles *RequestWirelessAssignNetworkWirelessEthernetPortsProfiles) (*ResponseWirelessAssignNetworkWirelessEthernetPortsProfiles, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/assign"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessAssignNetworkWirelessEthernetPortsProfiles).
+		SetResult(&ResponseWirelessAssignNetworkWirelessEthernetPortsProfiles{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation AssignNetworkWirelessEthernetPortsProfiles")
+	}
+
+	result := response.Result().(*ResponseWirelessAssignNetworkWirelessEthernetPortsProfiles)
+	return result, response, err
+
+}
+
+//SetNetworkWirelessEthernetPortsProfilesDefault Set the AP port profile to be default for this network
+/* Set the AP port profile to be default for this network
+
+@param networkID networkId path parameter. Network ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!set-network-wireless-ethernet-ports-profiles-default
+*/
+
+func (s *WirelessService) SetNetworkWirelessEthernetPortsProfilesDefault(networkID string, requestWirelessSetNetworkWirelessEthernetPortsProfilesDefault *RequestWirelessSetNetworkWirelessEthernetPortsProfilesDefault) (*ResponseWirelessSetNetworkWirelessEthernetPortsProfilesDefault, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/setDefault"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessSetNetworkWirelessEthernetPortsProfilesDefault).
+		SetResult(&ResponseWirelessSetNetworkWirelessEthernetPortsProfilesDefault{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation SetNetworkWirelessEthernetPortsProfilesDefault")
+	}
+
+	result := response.Result().(*ResponseWirelessSetNetworkWirelessEthernetPortsProfilesDefault)
+	return result, response, err
+
+}
+
 //CreateNetworkWirelessRfProfile Creates new RF profile for this network
 /* Creates new RF profile for this network
 
 @param networkID networkId path parameter. Network ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-rf-profile
 */
 
 func (s *WirelessService) CreateNetworkWirelessRfProfile(networkID string, requestWirelessCreateNetworkWirelessRfProfile *RequestWirelessCreateNetworkWirelessRfProfile) (*ResponseWirelessCreateNetworkWirelessRfProfile, *resty.Response, error) {
@@ -4078,10 +5418,10 @@ func (s *WirelessService) CreateNetworkWirelessRfProfile(networkID string, reque
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-ssid-identity-psk
 */
 
-func (s *WirelessService) CreateNetworkWirelessSSIDIDentityPsk(networkID string, number string, requestWirelessCreateNetworkWirelessSsidIdentityPsk *RequestWirelessCreateNetworkWirelessSSIDIDentityPsk) (*resty.Response, error) {
+func (s *WirelessService) CreateNetworkWirelessSSIDIDentityPsk(networkID string, number string, requestWirelessCreateNetworkWirelessSsidIdentityPsk *RequestWirelessCreateNetworkWirelessSSIDIDentityPsk) (*ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4091,20 +5431,53 @@ func (s *WirelessService) CreateNetworkWirelessSSIDIDentityPsk(networkID string,
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessCreateNetworkWirelessSsidIdentityPsk).
-		// SetResult(&ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk{}).
+		SetResult(&ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkWirelessSsidIdentityPsk")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkWirelessSsidIdentityPsk")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk)
+	return result, response, err
+
+}
+
+//UpdateDeviceWirelessAlternateManagementInterfaceIPv6 Update alternate management interface IPv6 address
+/* Update alternate management interface IPv6 address
+
+@param serial serial path parameter.
+*/
+func (s *WirelessService) UpdateDeviceWirelessAlternateManagementInterfaceIPv6(serial string, requestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIpv6 *RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6) (*ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/wireless/alternateManagementInterface/ipv6"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIpv6).
+		SetResult(&ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceWirelessAlternateManagementInterfaceIpv6")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6)
+	return result, response, err
 
 }
 
@@ -4205,7 +5578,7 @@ func (s *WirelessService) UpdateNetworkWirelessAlternateManagementInterface(netw
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *WirelessService) UpdateNetworkWirelessBilling(networkID string, requestWirelessUpdateNetworkWirelessBilling *RequestWirelessUpdateNetworkWirelessBilling) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessBilling(networkID string, requestWirelessUpdateNetworkWirelessBilling *RequestWirelessUpdateNetworkWirelessBilling) (*ResponseWirelessUpdateNetworkWirelessBilling, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/billing"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4214,19 +5587,21 @@ func (s *WirelessService) UpdateNetworkWirelessBilling(networkID string, request
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessBilling).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessBilling{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessBilling")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessBilling")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessBilling)
+	return result, response, err
 
 }
 
@@ -4260,6 +5635,40 @@ func (s *WirelessService) UpdateNetworkWirelessBluetoothSettings(networkID strin
 	}
 
 	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessBluetoothSettings)
+	return result, response, err
+
+}
+
+//UpdateNetworkWirelessEthernetPortsProfile Update the AP port profile by ID for this network
+/* Update the AP port profile by ID for this network
+
+@param networkID networkId path parameter. Network ID
+@param profileID profileId path parameter. Profile ID
+*/
+func (s *WirelessService) UpdateNetworkWirelessEthernetPortsProfile(networkID string, profileID string, requestWirelessUpdateNetworkWirelessEthernetPortsProfile *RequestWirelessUpdateNetworkWirelessEthernetPortsProfile) (*ResponseWirelessUpdateNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{profileId}", fmt.Sprintf("%v", profileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateNetworkWirelessEthernetPortsProfile).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessEthernetPortsProfile{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessEthernetPortsProfile")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessEthernetPortsProfile)
 	return result, response, err
 
 }
@@ -4336,7 +5745,7 @@ func (s *WirelessService) UpdateNetworkWirelessSettings(networkID string, reques
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSID(networkID string, number string, requestWirelessUpdateNetworkWirelessSsid *RequestWirelessUpdateNetworkWirelessSSID) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSID(networkID string, number string, requestWirelessUpdateNetworkWirelessSsid *RequestWirelessUpdateNetworkWirelessSSID) (*ResponseWirelessUpdateNetworkWirelessSSID, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4346,19 +5755,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSID(networkID string, number str
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsid).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSID{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsid")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsid")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSID)
+	return result, response, err
 
 }
 
@@ -4368,7 +5779,7 @@ func (s *WirelessService) UpdateNetworkWirelessSSID(networkID string, number str
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDBonjourForwarding(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidBonjourForwarding *RequestWirelessUpdateNetworkWirelessSSIDBonjourForwarding) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDBonjourForwarding(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidBonjourForwarding *RequestWirelessUpdateNetworkWirelessSSIDBonjourForwarding) (*ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4378,19 +5789,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDBonjourForwarding(networkID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidBonjourForwarding).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidBonjourForwarding")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidBonjourForwarding")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding)
+	return result, response, err
 
 }
 
@@ -4466,7 +5879,7 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDEapOverride(networkID string,
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL3FirewallRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidFirewallL3FirewallRules *RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL3FirewallRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidFirewallL3FirewallRules *RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules) (*ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4476,19 +5889,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL3FirewallRules(netwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidFirewallL3FirewallRules).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidFirewallL3FirewallRules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidFirewallL3FirewallRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules)
+	return result, response, err
 
 }
 
@@ -4498,7 +5913,7 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL3FirewallRules(netwo
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL7FirewallRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidFirewallL7FirewallRules *RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL7FirewallRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidFirewallL7FirewallRules *RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules) (*ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4508,19 +5923,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDFirewallL7FirewallRules(netwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidFirewallL7FirewallRules).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidFirewallL7FirewallRules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidFirewallL7FirewallRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules)
+	return result, response, err
 
 }
 
@@ -4563,7 +5980,7 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDHotspot20(networkID string, n
 @param number number path parameter.
 @param identityPskID identityPskId path parameter. Identity psk ID
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string, requestWirelessUpdateNetworkWirelessSsidIdentityPsk *RequestWirelessUpdateNetworkWirelessSSIDIDentityPsk) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string, requestWirelessUpdateNetworkWirelessSsidIdentityPsk *RequestWirelessUpdateNetworkWirelessSSIDIDentityPsk) (*ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4574,19 +5991,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDIDentityPsk(networkID string,
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidIdentityPsk).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidIdentityPsk")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidIdentityPsk")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk)
+	return result, response, err
 
 }
 
@@ -4656,13 +6075,13 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDSplashSettings(networkID stri
 
 }
 
-//UpdateNetworkWirelessSSIDTrafficShapingRules Update the traffic shaping settings for an SSID on an MR network
-/* Update the traffic shaping settings for an SSID on an MR network
+//UpdateNetworkWirelessSSIDTrafficShapingRules Update the traffic shaping rules for an SSID on an MR network.
+/* Update the traffic shaping rules for an SSID on an MR network.
 
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDTrafficShapingRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidTrafficShapingRules *RequestWirelessUpdateNetworkWirelessSSIDTrafficShapingRules) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDTrafficShapingRules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidTrafficShapingRules *RequestWirelessUpdateNetworkWirelessSSIDTrafficShapingRules) (*ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4672,19 +6091,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDTrafficShapingRules(networkID
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidTrafficShapingRules).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidTrafficShapingRules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidTrafficShapingRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDTrafficShapingRules)
+	return result, response, err
 
 }
 
@@ -4720,13 +6141,47 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDVpn(networkID string, number 
 
 }
 
+//DeleteNetworkWirelessEthernetPortsProfile Delete an AP port profile
+/* Delete an AP port profile
+
+@param networkID networkId path parameter. Network ID
+@param profileID profileId path parameter. Profile ID
+
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-ethernet-ports-profile
+*/
+func (s *WirelessService) DeleteNetworkWirelessEthernetPortsProfile(networkID string, profileID string) (*resty.Response, error) {
+	//networkID string,profileID string
+	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{profileId}", fmt.Sprintf("%v", profileID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteNetworkWirelessEthernetPortsProfile")
+	}
+
+	return response, err
+
+}
+
 //DeleteNetworkWirelessRfProfile Delete a RF Profile
 /* Delete a RF Profile
 
 @param networkID networkId path parameter. Network ID
 @param rfProfileID rfProfileId path parameter. Rf profile ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-rf-profile
 */
 func (s *WirelessService) DeleteNetworkWirelessRfProfile(networkID string, rfProfileID string) (*resty.Response, error) {
 	//networkID string,rfProfileID string
@@ -4761,7 +6216,7 @@ func (s *WirelessService) DeleteNetworkWirelessRfProfile(networkID string, rfPro
 @param number number path parameter.
 @param identityPskID identityPskId path parameter. Identity psk ID
 
-
+Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-ssid-identity-psk
 */
 func (s *WirelessService) DeleteNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string) (*resty.Response, error) {
 	//networkID string,number string,identityPskID string


### PR DESCRIPTION
- dashboard-api-go supports now v1.44.1 of Meraki Dashboard API.
- User-agent is now required. Format of string "ApplicationName VendorName".