### PR TITLE
## [3.0.1] - 2024-05-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2024-05-22
+### Changed
+- `ResponseItemNetworksGetNetworkGroupPolicies` add new attribute `Name`.
+- `ResponseNetworksGetNetworkSyslogServersServers` change `Port` to string.
+- `ResponseNetworksUpdateNetworkSyslogServersServers` change `Port` to string.
+
 ## [3.0.0] - 2024-04-16
 - dashboard-api-go supports now v1.44.1 of Meraki Dashboard API.
 - User-agent is now required. Format of string "ApplicationName VendorName".
@@ -1343,4 +1349,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.0.8]: https://github.com/meraki/dashboard-api-go/compare/v2.0.7...2.0.8
 [2.0.9]: https://github.com/meraki/dashboard-api-go/compare/v2.0.8...2.0.9
 [3.0.0]: https://github.com/meraki/dashboard-api-go/compare/v2.0.9...3.0.0
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.0...main
+[3.0.1]: https://github.com/meraki/dashboard-api-go/compare/v3.0.0...3.0.1
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.1...main

--- a/sdk/networks.go
+++ b/sdk/networks.go
@@ -1768,6 +1768,7 @@ type ResponseItemNetworksGetNetworkGroupPolicies struct {
 	Scheduling                *ResponseItemNetworksGetNetworkGroupPoliciesScheduling                `json:"scheduling,omitempty"`                //     The schedule for the group policy. Schedules are applied to days of the week.
 	SplashAuthSettings        string                                                                `json:"splashAuthSettings,omitempty"`        // Whether clients bound to your policy will bypass splash authorization or behave according to the network's rules. Can be one of 'network default' or 'bypass'. Only available if your network has a wireless configuration.
 	VLANTagging               *ResponseItemNetworksGetNetworkGroupPoliciesVLANTagging               `json:"vlanTagging,omitempty"`               // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
+	Name                      string                                                                `json:"name,omitempty"`                      // The VLAN tagging settings for your group policy. Only available if your network has a wireless configuration.
 }
 type ResponseItemNetworksGetNetworkGroupPoliciesBandwidth struct {
 	BandwidthLimits *ResponseItemNetworksGetNetworkGroupPoliciesBandwidthBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth limits object, specifying upload and download speed for clients bound to the group policy. These are only enforced if 'settings' is set to 'custom'.
@@ -2661,7 +2662,7 @@ type ResponseNetworksGetNetworkSyslogServers struct {
 }
 type ResponseNetworksGetNetworkSyslogServersServers struct {
 	Host  string   `json:"host,omitempty"`  // The IP address of the syslog server
-	Port  *int     `json:"port,omitempty"`  // The port of the syslog server
+	Port  string   `json:"port,omitempty"`  // The port of the syslog server
 	Roles []string `json:"roles,omitempty"` // A list of roles for the syslog server. Options (case-insensitive): 'Wireless event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
 }
 type ResponseNetworksUpdateNetworkSyslogServers struct {
@@ -2669,7 +2670,7 @@ type ResponseNetworksUpdateNetworkSyslogServers struct {
 }
 type ResponseNetworksUpdateNetworkSyslogServersServers struct {
 	Host  string   `json:"host,omitempty"`  // The IP address of the syslog server
-	Port  *int     `json:"port,omitempty"`  // The port of the syslog server
+	Port  string   `json:"port,omitempty"`  // The port of the syslog server
 	Roles []string `json:"roles,omitempty"` // A list of roles for the syslog server. Options (case-insensitive): 'Wireless event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
 }
 type ResponseNetworksGetNetworkTopologyLinkLayer struct {


### PR DESCRIPTION
### Changed
- `ResponseItemNetworksGetNetworkGroupPolicies` add new attribute `Name`.
- `ResponseNetworksGetNetworkSyslogServersServers` change `Port` to string.
- `ResponseNetworksUpdateNetworkSyslogServersServers` change `Port` to string.