### PR TITLE
## [3.0.3] - 2024-06-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.3] - 2024-06-13
+### Changed
+- `ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules` add new attribute `IpVer`.
+- `RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules` add new attribute `IpVer`.
+
 ## [3.0.2] - 2024-05-29
 ### Changed
 - `ResponseItemSwitchGetNetworkSwitchAccessPolicies` add new attribute `AccessPolicyNumber`.
@@ -1356,4 +1361,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.0.0]: https://github.com/meraki/dashboard-api-go/compare/v2.0.9...3.0.0
 [3.0.1]: https://github.com/meraki/dashboard-api-go/compare/v3.0.0...3.0.1
 [3.0.2]: https://github.com/meraki/dashboard-api-go/compare/v3.0.1...3.0.2
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.2...main
+[3.0.3]: https://github.com/meraki/dashboard-api-go/compare/v3.0.2...3.0.3
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.3...main

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -1902,6 +1902,7 @@ type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
 	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
 	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	IpVer    string `json:"ipVer,omitempty"`    //
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules struct {
 	Rules *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
@@ -3176,6 +3177,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules struct
 	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
 	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
 	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	IpVer    string `json:"ipVer,omitempty"`    //
 }
 type RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules struct {
 	Rules *[]RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An array of L7 firewall rules for this SSID. Rules will get applied in the same order user has specified in request. Empty array will clear the L7 firewall rule configuration.


### PR DESCRIPTION
### Changed
- `ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules` add new attribute `IpVer`.
- `RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules` add new attribute `IpVer`.