### PR TITLE
add missing request to UpdateOrganizationApplianceVpnThirdPartyVpnpeers

### DIFF
--- a/sdk/appliance.go
+++ b/sdk/appliance.go
@@ -5910,7 +5910,7 @@ func (s *ApplianceService) UpdateOrganizationApplianceSecurityIntrusion(organiza
 
 @param organizationID organizationId path parameter. Organization ID
 */
-func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string) (*resty.Response, error) {
+func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string, requestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers *RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/thirdPartyVPNPeers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5918,6 +5918,7 @@ func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(orga
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers).
 		SetError(&Error).
 		Put(path)
 


### PR DESCRIPTION
Fixes: https://github.com/meraki/dashboard-api-go/issues/32

This PR adds a `RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers` struct parameter to `UpdateOrganizationApplianceVpnThirdPartyVpnpeers` and passes it to the SetBody method in order set the request body to the proper values.