### PR TITLE
## [3.0.8] - 2024-08-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.8] - 2024-08-05
+### Changed
+- update switch.go ResponseItemOrganizationsGetOrganizationDevices.Imei is now a *float64.
+- update wireless.go ResponseWirelessGetDeviceWirelessRadioSettingsFiveGhzSettings.ChannelWidth is now a string.
+
 ## [3.0.7] - 2024-07-23
 ### Changed
 - update switch.go areaId is now an *int.
@@ -1383,4 +1388,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.0.5]: https://github.com/meraki/dashboard-api-go/compare/v3.0.4...3.0.5
 [3.0.6]: https://github.com/meraki/dashboard-api-go/compare/v3.0.5...3.0.6
 [3.0.7]: https://github.com/meraki/dashboard-api-go/compare/v3.0.6...3.0.7
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.7...main
+[3.0.8]: https://github.com/meraki/dashboard-api-go/compare/v3.0.7...3.0.8
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.8...main

--- a/sdk/organizations.go
+++ b/sdk/organizations.go
@@ -1245,7 +1245,7 @@ type ResponseItemOrganizationsGetOrganizationDevices struct {
 	Address     string                                                    `json:"address,omitempty"`     // Physical address of the device
 	Details     *[]ResponseItemOrganizationsGetOrganizationDevicesDetails `json:"details,omitempty"`     // Additional device information
 	Firmware    string                                                    `json:"firmware,omitempty"`    // Firmware version of the device
-	Imei        string                                                    `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	Imei        *float64                                                  `json:"imei,omitempty"`        // IMEI of the device, if applicable
 	LanIP       string                                                    `json:"lanIp,omitempty"`       // LAN IP address of the device
 	Lat         *float64                                                  `json:"lat,omitempty"`         // Latitude of the device
 	Lng         *float64                                                  `json:"lng,omitempty"`         // Longitude of the device

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -299,9 +299,9 @@ type ResponseWirelessGetDeviceWirelessRadioSettings struct {
 	TwoFourGhzSettings *ResponseWirelessGetDeviceWirelessRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` //
 }
 type ResponseWirelessGetDeviceWirelessRadioSettingsFiveGhzSettings struct {
-	Channel      *int `json:"channel,omitempty"`      //
-	ChannelWidth *int `json:"channelWidth,omitempty"` //
-	TargetPower  *int `json:"targetPower,omitempty"`  //
+	Channel      *int   `json:"channel,omitempty"`      //
+	ChannelWidth string `json:"channelWidth,omitempty"` //
+	TargetPower  *int   `json:"targetPower,omitempty"`  //
 }
 type ResponseWirelessGetDeviceWirelessRadioSettingsTwoFourGhzSettings struct {
 	Channel     *int `json:"channel,omitempty"`     //


### PR DESCRIPTION
### Changed
- update switch.go ResponseItemOrganizationsGetOrganizationDevices.Imei is now a *float64.
- update wireless.go ResponseWirelessGetDeviceWirelessRadioSettingsFiveGhzSettings.ChannelWidth is now a string.