### PR TITLE
## [3.0.9] - 2024-08-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.9] - 2024-08-05
+### Changed
+- update wireless.go, RequestWirelessUpdateDeviceWirelessRadioSettingsFiveGhzSettings.ChannelWidth is now string.
+
 ## [3.0.8] - 2024-08-05
 ### Changed
 - update switch.go ResponseItemOrganizationsGetOrganizationDevices.Imei is now a *float64.
@@ -1389,4 +1393,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.0.6]: https://github.com/meraki/dashboard-api-go/compare/v3.0.5...3.0.6
 [3.0.7]: https://github.com/meraki/dashboard-api-go/compare/v3.0.6...3.0.7
 [3.0.8]: https://github.com/meraki/dashboard-api-go/compare/v3.0.7...3.0.8
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.8...main
+[3.0.9]: https://github.com/meraki/dashboard-api-go/compare/v3.0.8...3.0.9
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.9...main

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -2519,9 +2519,9 @@ type RequestWirelessUpdateDeviceWirelessRadioSettings struct {
 	TwoFourGhzSettings *RequestWirelessUpdateDeviceWirelessRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Manual radio settings for 2.4 GHz.
 }
 type RequestWirelessUpdateDeviceWirelessRadioSettingsFiveGhzSettings struct {
-	Channel      *int `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
-	ChannelWidth *int `json:"channelWidth,omitempty"` // Sets a manual channel for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
-	TargetPower  *int `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz. Can be between '8' or '30' or null for using auto power range.
+	Channel      *int   `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
+	ChannelWidth string `json:"channelWidth,omitempty"` // Sets a manual channel for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
+	TargetPower  *int   `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz. Can be between '8' or '30' or null for using auto power range.
 }
 type RequestWirelessUpdateDeviceWirelessRadioSettingsTwoFourGhzSettings struct {
 	Channel     *int `json:"channel,omitempty"`     // Sets a manual channel for 2.4 GHz. Can be '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13' or '14' or null for using auto channel.


### PR DESCRIPTION
### Changed
- update wireless.go, RequestWirelessUpdateDeviceWirelessRadioSettingsFiveGhzSettings.ChannelWidth is now string.