### PR TITLE
## [4.0.0] - 2025-01-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2025-01-20
+### Changed
+- dashboard-api-go supports now v1.53.0 of Meraki Dashboard API.
+- update appliance.go, added new query parameters for GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork.
+- update appliance.go, added new query parameters for GetOrganizationApplianceUplinkStatuses.
+
 ## [3.0.10] - 2024-11-27
 ### Changed
 - update networks.go, GetOrganizationPolicyObjectsGroups returns an array.
@@ -278,6 +284,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - model_create_network_switch_link_aggregation_request_switch_profile_ports_inner service
 - model_create_network_switch_port_schedule_request service
 - model_create_network_switch_port_schedule_request_port_schedule service
+- model_create_network_switch_port_schedule_request_port_schedule_friday service
+- model_create_network_switch_port_schedule_request_port_schedule_monday service
+- model_create_network_switch_port_schedule_request_port_schedule_saturday service
+- model_create_network_switch_port_schedule_request_port_schedule_sunday service
+- model_create_network_switch_port_schedule_request_port_schedule_thursday service
+- model_create_network_switch_port_schedule_request_port_schedule_tuesday service
+- model_create_network_switch_port_schedule_request_port_schedule_wednesday service
 - model_create_network_switch_qos_rule_request service
 - model_create_network_switch_routing_multicast_rendezvous_point_request service
 - model_create_network_switch_stack_request service
@@ -1399,4 +1412,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.0.7]: https://github.com/meraki/dashboard-api-go/compare/v3.0.6...3.0.7
 [3.0.8]: https://github.com/meraki/dashboard-api-go/compare/v3.0.7...3.0.8
 [3.0.9]: https://github.com/meraki/dashboard-api-go/compare/v3.0.8...3.0.9
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v3.0.9...main
+[4.0.0]: https://github.com/meraki/dashboard-api-go/compare/v3.0.10...4.0.0
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v4.0.0...main

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 |--------------|------------------------------------|
 | 2.y.z        |  1.33.0                            |
 | 3.y.z        |  1.44.1                            |
+| 4.y.z        |  1.53.0                            |
 
 
 ## Changelog

--- a/examples/administered/main.go
+++ b/examples/administered/main.go
@@ -12,9 +12,7 @@ var client *meraki.Client
 func main() {
 	var err error
 	fmt.Println("Authenticating")
-	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
-		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true", "AplicationName VendorName")
+	client, err = meraki.NewClient()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/administered/main.go
+++ b/examples/administered/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
 )
 
 // Client is DNA Center API client

--- a/examples/networks/main.go
+++ b/examples/networks/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
 )
 
 var client *meraki.Client

--- a/examples/organizations/main.go
+++ b/examples/organizations/main.go
@@ -11,9 +11,7 @@ var client *meraki.Client
 func main() {
 	var err error
 	fmt.Println("Authenticating")
-	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
-		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true", "AplicationName VendorName")
+	client, err = meraki.NewClient()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/organizations/main.go
+++ b/examples/organizations/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
 )
 
 var client *meraki.Client

--- a/examples/testPagination/main.go
+++ b/examples/testPagination/main.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	meraki "github.com/meraki/dashboard-api-go/v3/sdk"
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
 )
 
 var client *meraki.Client

--- a/examples/testPagination/main.go
+++ b/examples/testPagination/main.go
@@ -20,9 +20,7 @@ func simpleCmp(a, b interface{}) bool {
 func main() {
 	var err error
 	fmt.Println("Authenticating")
-	client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
-		"12f2eb53588c75e28d89e108a05ea0c2487b08cf",
-		"true", "AplicationName VendorName")
+	client, err = meraki.NewClient()
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/meraki/dashboard-api-go/v3
+module github.com/meraki/dashboard-api-go/v4
 
 go 1.21.5
 

--- a/sdk/administered.go
+++ b/sdk/administered.go
@@ -2,7 +2,7 @@ package meraki
 
 import (
 	"fmt"
-	"net/http"
+	"strings"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -33,6 +33,14 @@ type ResponseAdministeredGetAdministeredIDentitiesMeAuthenticationSaml struct {
 type ResponseAdministeredGetAdministeredIDentitiesMeAuthenticationTwoFactor struct {
 	Enabled *bool `json:"enabled,omitempty"` // If twoFactor authentication is enabled for this user
 }
+type ResponseAdministeredGetAdministeredIDentitiesMeAPIKeys []ResponseItemAdministeredGetAdministeredIDentitiesMeAPIKeys // Array of ResponseAdministeredGetAdministeredIdentitiesMeApiKeys
+type ResponseItemAdministeredGetAdministeredIDentitiesMeAPIKeys struct {
+	CreatedAt string `json:"createdAt,omitempty"` // Date that the API key was created
+	Suffix    string `json:"suffix,omitempty"`    // Last 4 characters of the API key
+}
+type ResponseAdministeredGenerateAdministeredIDentitiesMeAPIKeys struct {
+	Key string `json:"key,omitempty"` // API key in plaintext. This value will not be accessible outside of key generation
+}
 
 //GetAdministeredIDentitiesMe Returns the identity of the current user.
 /* Returns the identity of the current user.
@@ -57,13 +65,105 @@ func (s *AdministeredService) GetAdministeredIDentitiesMe() (*ResponseAdminister
 	}
 
 	if response.IsError() {
-		if response.StatusCode() == http.StatusUnauthorized {
-			return s.GetAdministeredIDentitiesMe()
-		}
-		return nil, response, fmt.Errorf("error with operation GetApplications")
+		return nil, response, fmt.Errorf("error with operation GetAdministeredIdentitiesMe")
 	}
 
 	result := response.Result().(*ResponseAdministeredGetAdministeredIDentitiesMe)
 	return result, response, err
+
+}
+
+//GetAdministeredIDentitiesMeAPIKeys List the non-sensitive metadata associated with the API keys that belong to the user
+/* List the non-sensitive metadata associated with the API keys that belong to the user
+
+
+
+ */
+func (s *AdministeredService) GetAdministeredIDentitiesMeAPIKeys() (*ResponseAdministeredGetAdministeredIDentitiesMeAPIKeys, *resty.Response, error) {
+	path := "/api/v1/administered/identities/me/api/keys"
+	s.rateLimiterBucket.Wait(1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseAdministeredGetAdministeredIDentitiesMeAPIKeys{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetAdministeredIdentitiesMeApiKeys")
+	}
+
+	result := response.Result().(*ResponseAdministeredGetAdministeredIDentitiesMeAPIKeys)
+	return result, response, err
+
+}
+
+//GenerateAdministeredIDentitiesMeAPIKeys Generates an API key for an identity
+/* Generates an API key for an identity. For users who have access to more than one organization, the change will take up to five minutes to propagate. If one of the organizations is currently under maintenance, the change may not propagate fully until after the maintenance has been completed.
+
+
+
+ */
+
+func (s *AdministeredService) GenerateAdministeredIDentitiesMeAPIKeys() (*ResponseAdministeredGenerateAdministeredIDentitiesMeAPIKeys, *resty.Response, error) {
+	path := "/api/v1/administered/identities/me/api/keys/generate"
+	s.rateLimiterBucket.Wait(1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseAdministeredGenerateAdministeredIDentitiesMeAPIKeys{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GenerateAdministeredIdentitiesMeApiKeys")
+	}
+
+	result := response.Result().(*ResponseAdministeredGenerateAdministeredIDentitiesMeAPIKeys)
+	return result, response, err
+
+}
+
+//RevokeAdministeredIDentitiesMeAPIKeys Revokes an identity's API key, using the last four characters of the key
+/* Revokes an identity's API key, using the last four characters of the key. For users who have access to more than one organization, the change will take up to five minutes to propagate. If one of the organizations is currently under maintenance, the change may not propagate fully until after the maintenance has been completed.
+
+@param suffix suffix path parameter.
+
+
+*/
+
+func (s *AdministeredService) RevokeAdministeredIDentitiesMeAPIKeys(suffix string) (*resty.Response, error) {
+	path := "/api/v1/administered/identities/me/api/keys/{suffix}/revoke"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{suffix}", fmt.Sprintf("%v", suffix), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation RevokeAdministeredIdentitiesMeApiKeys")
+	}
+
+	return response, err
 
 }

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -19,7 +19,7 @@ const (
 	MERAKI_DASHBOARD_API_KEY    = "MERAKI_DASHBOARD_API_KEY"
 	MERAKI_DEBUG                = "MERAKI_DEBUG"
 	MERAKI_REQUESTS_PER_SECOND  = "MERAKI_REQUESTS_PER_SECOND"
-	DEFAULT_USER_AGENT          = "go-meraki/1.44.1"
+	DEFAULT_USER_AGENT          = "go-meraki/1.53.0"
 	DEFAULT_REQUESTS_PER_SECOND = 10
 )
 
@@ -28,20 +28,21 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// API Services
-	Administered    *AdministeredService
-	Appliance       *ApplianceService
-	Camera          *CameraService
-	CellularGateway *CellularGatewayService
-	Devices         *DevicesService
-	Insight         *InsightService
-	Licensing       *LicensingService
-	Networks        *NetworksService
-	Organizations   *OrganizationsService
-	Sensor          *SensorService
-	Sm              *SmService
-	Switch          *SwitchService
-	Wireless        *WirelessService
-	CustomCall      *CustomCallService
+	Administered       *AdministeredService
+	Appliance          *ApplianceService
+	Camera             *CameraService
+	CellularGateway    *CellularGatewayService
+	Devices            *DevicesService
+	Insight            *InsightService
+	Licensing          *LicensingService
+	Networks           *NetworksService
+	Organizations      *OrganizationsService
+	Sensor             *SensorService
+	Sm                 *SmService
+	Switch             *SwitchService
+	Wireless           *WirelessService
+	WirelessController *WirelessControllerService
+	CustomCall         *CustomCallService
 }
 
 type service struct {
@@ -165,7 +166,7 @@ func SetOptions(baseURL string, dashboardApiKey string, debug string, userAgent 
 	var err error
 
 	if !validateUserAgent(userAgent) {
-		return errors.New("user-agent bad format, expected: `AplicationName VendorName`")
+		return errors.New("user-agent bad format, expected: `AplicationName VendorName Client`")
 	}
 
 	err = os.Setenv(MERAKI_USER_AGENT, userAgent)
@@ -303,6 +304,6 @@ func convertToString(i interface{}) string {
 }
 
 func validateUserAgent(ua string) bool {
-	regex := regexp.MustCompile(`^\S+\s\S+$`)
+	regex := regexp.MustCompile(`^\S+ \S+ \S+$`)
 	return regex.MatchString(ua)
 }

--- a/sdk/api_client_test.go
+++ b/sdk/api_client_test.go
@@ -25,7 +25,7 @@ type result struct{}
 
 // testClient returns a new Client for testing.
 func testClient(t *testing.T) *Client {
-	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound")
+	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound TEST")
 	assert.Equal(t, err, nil)
 	client, err := NewClient()
 	assert.Equal(t, err, nil)
@@ -37,7 +37,7 @@ func testClient(t *testing.T) *Client {
 
 // TestSetOptions tests the Client.SetOptions method.
 func TestSetOptions(t *testing.T) {
-	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound")
+	err := SetOptions(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound TEST")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, os.Getenv(MERAKI_BASE_URL), TEST_MERAKI_BASE_URL)
 	assert.Equal(t, os.Getenv(MERAKI_DASHBOARD_API_KEY), TEST_MERAKI_DASHBOARD_API_KEY)
@@ -46,7 +46,7 @@ func TestSetOptions(t *testing.T) {
 
 // TestSetOptions tests the Client.SetOptionsWithRequests method.
 func TestSetOptionsWithRequests(t *testing.T) {
-	err := SetOptionsWithRequests(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound", TEST_MERAKI_REQUESTS_PER_SECOND)
+	err := SetOptionsWithRequests(TEST_MERAKI_BASE_URL, TEST_MERAKI_DASHBOARD_API_KEY, TEST_MERAKI_DEBUG, "Test Cloverhound TEST", TEST_MERAKI_REQUESTS_PER_SECOND)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, os.Getenv(MERAKI_BASE_URL), TEST_MERAKI_BASE_URL)
 	assert.Equal(t, os.Getenv(MERAKI_DASHBOARD_API_KEY), TEST_MERAKI_DASHBOARD_API_KEY)
@@ -68,7 +68,7 @@ func TestNewClientWithOptions(t *testing.T) {
 	url := "url"
 	key := "key"
 	debug := false
-	client, err := NewClientWithOptions(url, key, strconv.FormatBool(debug), "Test Cloverhound")
+	client, err := NewClientWithOptions(url, key, strconv.FormatBool(debug), "Test Cloverhound TEST")
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, client, nil)
 	assert.Equal(t, client.common.client.HostURL, url)
@@ -82,7 +82,7 @@ func TestNewClientWithOptionsAndRequests(t *testing.T) {
 	key := "key"
 	debug := false
 	requests := 6
-	client, err := NewClientWithOptionsAndRequests(url, key, strconv.FormatBool(debug), "Test Cloverhound", requests)
+	client, err := NewClientWithOptionsAndRequests(url, key, strconv.FormatBool(debug), "Test Cloverhound TEST", requests)
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, client, nil)
 	assert.Equal(t, client.common.client.HostURL, url)

--- a/sdk/appliance.go
+++ b/sdk/appliance.go
@@ -11,6 +11,11 @@ import (
 
 type ApplianceService service
 
+type GetDeviceAppliancePerformanceQueryParams struct {
+	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data. The maximum lookback period is 30 days from today.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 14 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 30 minutes and be less than or equal to 14 days. The default is 30 minutes.
+}
 type GetNetworkApplianceClientSecurityEventsQueryParams struct {
 	T0            string  `url:"t0,omitempty"`            //The beginning of the timespan for the data. Data is gathered after the specified t0 value. The maximum lookback period is 791 days from today.
 	T1            string  `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 791 days after t0.
@@ -361,14 +366,21 @@ type ResponseItemApplianceGetNetworkApplianceClientSecurityEvents struct {
 	URI             string `json:"uri,omitempty"`             //
 }
 type ResponseApplianceGetNetworkApplianceConnectivityMonitoringDestinations struct {
-	Destinations *[]ResponseApplianceGetNetworkApplianceConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` //
+	Destinations *[]ResponseApplianceGetNetworkApplianceConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` // The list of connectivity monitoring destinations
 }
 type ResponseApplianceGetNetworkApplianceConnectivityMonitoringDestinationsDestinations struct {
-	Default     *bool  `json:"default,omitempty"`     //
-	Description string `json:"description,omitempty"` //
-	IP          string `json:"ip,omitempty"`          //
+	Default     *bool  `json:"default,omitempty"`     // Boolean indicating whether this is the default testing destination (true) or not (false). Defaults to false. Only one default is allowed
+	Description string `json:"description,omitempty"` // Description of the testing destination. Optional, defaults to an empty string
+	IP          string `json:"ip,omitempty"`          // The IP address to test connectivity with
 }
-type ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations interface{}
+type ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations struct {
+	Destinations *[]ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` // The list of connectivity monitoring destinations
+}
+type ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinationsDestinations struct {
+	Default     *bool  `json:"default,omitempty"`     // Boolean indicating whether this is the default testing destination (true) or not (false). Defaults to false. Only one default is allowed
+	Description string `json:"description,omitempty"` // Description of the testing destination. Optional, defaults to an empty string
+	IP          string `json:"ip,omitempty"`          // The IP address to test connectivity with
+}
 type ResponseApplianceGetNetworkApplianceContentFiltering struct {
 	AllowedURLPatterns   []string                                                                    `json:"allowedUrlPatterns,omitempty"`   //
 	BlockedURLCategories *[]ResponseApplianceGetNetworkApplianceContentFilteringBlockedURLCategories `json:"blockedUrlCategories,omitempty"` //
@@ -417,19 +429,32 @@ type ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService struct {
 	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of allowed IPs that can access the service
 	Service    string   `json:"service,omitempty"`    // Appliance service name
 }
-type ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules []ResponseItemApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules // Array of ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules
-type ResponseItemApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules struct {
-	Comment       string `json:"comment,omitempty"`       //
-	DestCidr      string `json:"destCidr,omitempty"`      //
-	DestPort      string `json:"destPort,omitempty"`      //
-	Policy        string `json:"policy,omitempty"`        //
-	Protocol      string `json:"protocol,omitempty"`      //
-	SrcCidr       string `json:"srcCidr,omitempty"`       //
-	SrcPort       string `json:"srcPort,omitempty"`       //
-	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` //
+type ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules struct {
+	Rules *[]ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules (not including the default rule)
 }
-type ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules []ResponseItemApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules // Array of ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules
-type ResponseItemApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules interface{}
+type ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRulesRules struct {
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
+}
+type ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRules struct {
+	Rules *[]ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules (not including the default rule)
+}
+type ResponseApplianceUpdateNetworkApplianceFirewallInboundCellularFirewallRulesRules struct {
+	Comment       string `json:"comment,omitempty"`       // Description of the rule (optional)
+	DestCidr      string `json:"destCidr,omitempty"`      // Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or 'any'
+	DestPort      string `json:"destPort,omitempty"`      // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
+	Policy        string `json:"policy,omitempty"`        // 'allow' or 'deny' traffic specified by this rule
+	Protocol      string `json:"protocol,omitempty"`      // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
+	SrcCidr       string `json:"srcCidr,omitempty"`       // Comma-separated list of source IP address(es) (in IP or CIDR notation), or 'any' (note: FQDN not supported for source addresses)
+	SrcPort       string `json:"srcPort,omitempty"`       // Comma-separated list of source port(s) (integer in the range 1-65535), or 'any'
+	SyslogEnabled *bool  `json:"syslogEnabled,omitempty"` // Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)
+}
 type ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRules struct {
 	Rules             *[]ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRulesRules `json:"rules,omitempty"`             // An ordered array of the firewall rules (not including the default rule)
 	SyslogDefaultRule *bool                                                                    `json:"syslogDefaultRule,omitempty"` // Log the special default rule (boolean value - enable only if you've configured a syslog server) (optional)
@@ -564,18 +589,30 @@ type ResponseApplianceGetNetworkApplianceFirewallOneToOneNatRulesRulesAllowedInb
 }
 type ResponseApplianceUpdateNetworkApplianceFirewallOneToOneNatRules interface{}
 type ResponseApplianceGetNetworkApplianceFirewallPortForwardingRules struct {
-	Rules *[]ResponseApplianceGetNetworkApplianceFirewallPortForwardingRulesRules `json:"rules,omitempty"` //
+	Rules *[]ResponseApplianceGetNetworkApplianceFirewallPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding rules
 }
+
 type ResponseApplianceGetNetworkApplianceFirewallPortForwardingRulesRules struct {
-	AllowedIPs []string `json:"allowedIps,omitempty"` //
-	LanIP      string   `json:"lanIp,omitempty"`      //
-	LocalPort  string   `json:"localPort,omitempty"`  //
-	Name       string   `json:"name,omitempty"`       //
-	Protocol   string   `json:"protocol,omitempty"`   //
-	PublicPort string   `json:"publicPort,omitempty"` //
-	Uplink     string   `json:"uplink,omitempty"`     //
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges (or any)
+	LanIP      string   `json:"lanIp,omitempty"`      // IP address of the device subject to port forwarding
+	LocalPort  string   `json:"localPort,omitempty"`  // The port or port range that receives forwarded traffic from the WAN
+	Name       string   `json:"name,omitempty"`       // Name of the rule
+	Protocol   string   `json:"protocol,omitempty"`   // Protocol the rule applies to
+	PublicPort string   `json:"publicPort,omitempty"` // The port or port range forwarded to the host on the LAN
+	Uplink     string   `json:"uplink,omitempty"`     // The physical WAN interface on which the traffic arrives; allowed values vary by appliance model and configuration
 }
-type ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRules interface{}
+type ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRules struct {
+	Rules *[]ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding rules
+}
+type ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRulesRules struct {
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges (or any)
+	LanIP      string   `json:"lanIp,omitempty"`      // IP address of the device subject to port forwarding
+	LocalPort  string   `json:"localPort,omitempty"`  // The port or port range that receives forwarded traffic from the WAN
+	Name       string   `json:"name,omitempty"`       // Name of the rule
+	Protocol   string   `json:"protocol,omitempty"`   // Protocol the rule applies to
+	PublicPort string   `json:"publicPort,omitempty"` // The port or port range forwarded to the host on the LAN
+	Uplink     string   `json:"uplink,omitempty"`     // The physical WAN interface on which the traffic arrives; allowed values vary by appliance model and configuration
+}
 type ResponseApplianceGetNetworkApplianceFirewallSettings struct {
 	SpoofingProtection *ResponseApplianceGetNetworkApplianceFirewallSettingsSpoofingProtection `json:"spoofingProtection,omitempty"` //
 }
@@ -796,6 +833,45 @@ type ResponseApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings struct {
 	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Whether ax radio on 2.4Ghz band is on or off.
 	MinBitrate *float64 `json:"minBitrate,omitempty"` // Min bitrate (Mbps) of 2.4Ghz band.
 }
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPolicies struct {
+	WanTrafficUplinkPreferences *[]ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferences `json:"wanTrafficUplinkPreferences,omitempty"` // policies with respective traffic filters for an MX network
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferences struct {
+	FailOverCriterion string                                                                                                   `json:"failOverCriterion,omitempty"` // WAN failover and failback behavior
+	PerformanceClass  *ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesPerformanceClass `json:"performanceClass,omitempty"`  // Performance class setting for uplink preference rule
+	PreferredUplink   string                                                                                                   `json:"preferredUplink,omitempty"`   // Preferred uplink for uplink preference rule. Must be one of: 'wan1', 'wan2', 'bestForVoIP', 'loadBalancing' or 'defaultUplink'
+	TrafficFilters    *[]ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFilters `json:"trafficFilters,omitempty"`    // Traffic filters
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesPerformanceClass struct {
+	BuiltinPerformanceClassName string `json:"builtinPerformanceClassName,omitempty"` // Name of builtin performance class. Must be present when performanceClass type is 'builtin' and value must be one of: 'VoIP'
+	CustomPerformanceClassID    string `json:"customPerformanceClassId,omitempty"`    // ID of created custom performance class, must be present when performanceClass type is "custom"
+	Type                        string `json:"type,omitempty"`                        // Type of this performance class. Must be one of: 'builtin' or 'custom'
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFilters struct {
+	Type  string                                                                                                      `json:"type,omitempty"`  // Traffic filter type. Must be 'custom', 'major_application', 'application (NBAR)', if type is 'application', you can pass either an NBAR App Category or Application
+	Value *ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValue `json:"value,omitempty"` // Value of traffic filter
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValue struct {
+	Destination *ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestination `json:"destination,omitempty"` // Destination of 'custom' type traffic filter
+	Protocol    string                                                                                                                 `json:"protocol,omitempty"`    // Protocol of the traffic filter. Must be one of: 'tcp', 'udp', 'icmp6' or 'any'
+	Source      *ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueSource      `json:"source,omitempty"`      // Source of traffic filter
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestination struct {
+	Applications *[]ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications `json:"applications,omitempty"` // list of application objects (either majorApplication or nbar)
+	Cidr         string                                                                                                                               `json:"cidr,omitempty"`         // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
+	Port         string                                                                                                                               `json:"port,omitempty"`         // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications struct {
+	ID   string `json:"id,omitempty"`   // Id of the major application, or a list of NBAR Application Category or Application selections
+	Name string `json:"name,omitempty"` // Name of the major application or application category selected
+	Type string `json:"type,omitempty"` // app type (major or nbar)
+}
+type ResponseApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueSource struct {
+	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any". Cannot be used in combination with the "vlan" property
+	Host *int   `json:"host,omitempty"` // Host ID in the VLAN. Should not exceed the VLAN subnet capacity. Must be used along with the "vlan" property and is currently only available under a template network.
+	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+	VLAN *int   `json:"vlan,omitempty"` // VLAN ID of the configured VLAN in the Meraki network. Cannot be used in combination with the "cidr" property and is currently only available under a template network.
+}
 type ResponseApplianceGetNetworkApplianceSecurityEvents []ResponseItemApplianceGetNetworkApplianceSecurityEvents // Array of ResponseApplianceGetNetworkApplianceSecurityEvents
 type ResponseItemApplianceGetNetworkApplianceSecurityEvents struct {
 	Action          string `json:"action,omitempty"`          //
@@ -975,16 +1051,16 @@ type ResponseApplianceUpdateNetworkApplianceSSIDRadiusServers struct {
 }
 type ResponseApplianceGetNetworkApplianceStaticRoutes []ResponseItemApplianceGetNetworkApplianceStaticRoutes // Array of ResponseApplianceGetNetworkApplianceStaticRoutes
 type ResponseItemApplianceGetNetworkApplianceStaticRoutes struct {
-	Enabled            *bool                                                                   `json:"enabled,omitempty"`            //
-	FixedIPAssignments *ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments `json:"fixedIpAssignments,omitempty"` //
-	GatewayIP          string                                                                  `json:"gatewayIp,omitempty"`          //
-	GatewayVLANID      *int                                                                    `json:"gatewayVlanId,omitempty"`      //
-	ID                 string                                                                  `json:"id,omitempty"`                 //
-	IPVersion          *int                                                                    `json:"ipVersion,omitempty"`          //
-	Name               string                                                                  `json:"name,omitempty"`               //
-	NetworkID          string                                                                  `json:"networkId,omitempty"`          //
-	ReservedIPRanges   *[]ResponseItemApplianceGetNetworkApplianceStaticRoutesReservedIPRanges `json:"reservedIpRanges,omitempty"`   //
-	Subnet             string                                                                  `json:"subnet,omitempty"`             //
+	Enabled            *bool                                                                   `json:"enabled,omitempty"`            // Whether the route is enabled or not
+	FixedIPAssignments *ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // Fixed DHCP IP assignments on the route
+	GatewayIP          string                                                                  `json:"gatewayIp,omitempty"`          // Gateway IP address (next hop)
+	GatewayVLANID      *int                                                                    `json:"gatewayVlanId,omitempty"`      // Gateway VLAN ID
+	ID                 string                                                                  `json:"id,omitempty"`                 // Route ID
+	IPVersion          *int                                                                    `json:"ipVersion,omitempty"`          // IP protocol version
+	Name               string                                                                  `json:"name,omitempty"`               // Name of the route
+	NetworkID          string                                                                  `json:"networkId,omitempty"`          // Network ID
+	ReservedIPRanges   *[]ResponseItemApplianceGetNetworkApplianceStaticRoutesReservedIPRanges `json:"reservedIpRanges,omitempty"`   // DHCP reserved IP ranges
+	Subnet             string                                                                  `json:"subnet,omitempty"`             // Subnet of the route
 }
 type ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments struct {
 	Status223344556677 *ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments223344556677 `json:"22:33:44:55:66:77,omitempty"` //
@@ -994,22 +1070,39 @@ type ResponseItemApplianceGetNetworkApplianceStaticRoutesFixedIPAssignments22334
 	Name string `json:"name,omitempty"` //
 }
 type ResponseItemApplianceGetNetworkApplianceStaticRoutesReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` //
-	End     string `json:"end,omitempty"`     //
-	Start   string `json:"start,omitempty"`   //
+	Comment string `json:"comment,omitempty"` // Description of the range
+	End     string `json:"end,omitempty"`     // Last address in the reserved range
+	Start   string `json:"start,omitempty"`   // First address in the reserved range
 }
-type ResponseApplianceCreateNetworkApplianceStaticRoute interface{}
+type ResponseApplianceCreateNetworkApplianceStaticRoute struct {
+	Enabled            *bool                                                                 `json:"enabled,omitempty"`            // Whether the route is enabled or not
+	FixedIPAssignments *ResponseApplianceCreateNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // Fixed DHCP IP assignments on the route
+	GatewayIP          string                                                                `json:"gatewayIp,omitempty"`          // Gateway IP address (next hop)
+	GatewayVLANID      *int                                                                  `json:"gatewayVlanId,omitempty"`      // Gateway VLAN ID
+	ID                 string                                                                `json:"id,omitempty"`                 // Route ID
+	IPVersion          *int                                                                  `json:"ipVersion,omitempty"`          // IP protocol version
+	Name               string                                                                `json:"name,omitempty"`               // Name of the route
+	NetworkID          string                                                                `json:"networkId,omitempty"`          // Network ID
+	ReservedIPRanges   *[]ResponseApplianceCreateNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   // DHCP reserved IP ranges
+	Subnet             string                                                                `json:"subnet,omitempty"`             // Subnet of the route
+}
+type ResponseApplianceCreateNetworkApplianceStaticRouteFixedIPAssignments interface{}
+type ResponseApplianceCreateNetworkApplianceStaticRouteReservedIPRanges struct {
+	Comment string `json:"comment,omitempty"` // Description of the range
+	End     string `json:"end,omitempty"`     // Last address in the reserved range
+	Start   string `json:"start,omitempty"`   // First address in the reserved range
+}
 type ResponseApplianceGetNetworkApplianceStaticRoute struct {
-	Enabled            *bool                                                              `json:"enabled,omitempty"`            //
-	FixedIPAssignments *ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` //
-	GatewayIP          string                                                             `json:"gatewayIp,omitempty"`          //
-	GatewayVLANID      *int                                                               `json:"gatewayVlanId,omitempty"`      //
-	ID                 string                                                             `json:"id,omitempty"`                 //
-	IPVersion          *int                                                               `json:"ipVersion,omitempty"`          //
-	Name               string                                                             `json:"name,omitempty"`               //
-	NetworkID          string                                                             `json:"networkId,omitempty"`          //
-	ReservedIPRanges   *[]ResponseApplianceGetNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   //
-	Subnet             string                                                             `json:"subnet,omitempty"`             //
+	Enabled            *bool                                                              `json:"enabled,omitempty"`            // Whether the route is enabled or not
+	FixedIPAssignments *ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // Fixed DHCP IP assignments on the route
+	GatewayIP          string                                                             `json:"gatewayIp,omitempty"`          // Gateway IP address (next hop)
+	GatewayVLANID      *int                                                               `json:"gatewayVlanId,omitempty"`      // Gateway VLAN ID
+	ID                 string                                                             `json:"id,omitempty"`                 // Route ID
+	IPVersion          *int                                                               `json:"ipVersion,omitempty"`          // IP protocol version
+	Name               string                                                             `json:"name,omitempty"`               // Name of the route
+	NetworkID          string                                                             `json:"networkId,omitempty"`          // Network ID
+	ReservedIPRanges   *[]ResponseApplianceGetNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   // DHCP reserved IP ranges
+	Subnet             string                                                             `json:"subnet,omitempty"`             // Subnet of the route
 }
 type ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments struct {
 	Status223344556677 *ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments223344556677 `json:"22:33:44:55:66:77,omitempty"` //
@@ -1019,11 +1112,28 @@ type ResponseApplianceGetNetworkApplianceStaticRouteFixedIPAssignments2233445566
 	Name string `json:"name,omitempty"` //
 }
 type ResponseApplianceGetNetworkApplianceStaticRouteReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` //
-	End     string `json:"end,omitempty"`     //
-	Start   string `json:"start,omitempty"`   //
+	Comment string `json:"comment,omitempty"` // Description of the range
+	End     string `json:"end,omitempty"`     // Last address in the reserved range
+	Start   string `json:"start,omitempty"`   // First address in the reserved range
 }
-type ResponseApplianceUpdateNetworkApplianceStaticRoute interface{}
+type ResponseApplianceUpdateNetworkApplianceStaticRoute struct {
+	Enabled            *bool                                                                 `json:"enabled,omitempty"`            // Whether the route is enabled or not
+	FixedIPAssignments *ResponseApplianceUpdateNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // Fixed DHCP IP assignments on the route
+	GatewayIP          string                                                                `json:"gatewayIp,omitempty"`          // Gateway IP address (next hop)
+	GatewayVLANID      *int                                                                  `json:"gatewayVlanId,omitempty"`      // Gateway VLAN ID
+	ID                 string                                                                `json:"id,omitempty"`                 // Route ID
+	IPVersion          *int                                                                  `json:"ipVersion,omitempty"`          // IP protocol version
+	Name               string                                                                `json:"name,omitempty"`               // Name of the route
+	NetworkID          string                                                                `json:"networkId,omitempty"`          // Network ID
+	ReservedIPRanges   *[]ResponseApplianceUpdateNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   // DHCP reserved IP ranges
+	Subnet             string                                                                `json:"subnet,omitempty"`             // Subnet of the route
+}
+type ResponseApplianceUpdateNetworkApplianceStaticRouteFixedIPAssignments interface{}
+type ResponseApplianceUpdateNetworkApplianceStaticRouteReservedIPRanges struct {
+	Comment string `json:"comment,omitempty"` // Description of the range
+	End     string `json:"end,omitempty"`     // Last address in the reserved range
+	Start   string `json:"start,omitempty"`   // First address in the reserved range
+}
 type ResponseApplianceGetNetworkApplianceTrafficShaping struct {
 	GlobalBandwidthLimits *ResponseApplianceGetNetworkApplianceTrafficShapingGlobalBandwidthLimits `json:"globalBandwidthLimits,omitempty"` //
 }
@@ -1202,8 +1312,14 @@ type ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTraffic
 	Source      *ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueSource      `json:"source,omitempty"`      // Source of 'custom' type traffic filter
 }
 type ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestination struct {
-	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
-	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+	Applications *[]ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications `json:"applications,omitempty"` // list of application objects (either majorApplication or nbar)
+	Cidr         string                                                                                                                                    `json:"cidr,omitempty"`         // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
+	Port         string                                                                                                                                    `json:"port,omitempty"`         // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+}
+type ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications struct {
+	ID   string `json:"id,omitempty"`   // Id of the major application, or a list of NBAR Application Category or Application selections
+	Name string `json:"name,omitempty"` // Name of the major application or application category selected
+	Type string `json:"type,omitempty"` // app type (major or nbar)
 }
 type ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueSource struct {
 	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any". Cannot be used in combination with the "vlan" property
@@ -1275,8 +1391,14 @@ type ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTraf
 	Source      *ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueSource      `json:"source,omitempty"`      // Source of 'custom' type traffic filter
 }
 type ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestination struct {
-	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
-	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+	Applications *[]ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications `json:"applications,omitempty"` // list of application objects (either majorApplication or nbar)
+	Cidr         string                                                                                                                                       `json:"cidr,omitempty"`         // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
+	Port         string                                                                                                                                       `json:"port,omitempty"`         // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+}
+type ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications struct {
+	ID   string `json:"id,omitempty"`   // Id of the major application, or a list of NBAR Application Category or Application selections
+	Name string `json:"name,omitempty"` // Name of the major application or application category selected
+	Type string `json:"type,omitempty"` // app type (major or nbar)
 }
 type ResponseApplianceUpdateNetworkApplianceTrafficShapingUplinkSelectionWanTrafficUplinkPreferencesTrafficFiltersValueSource struct {
 	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any". Cannot be used in combination with the "vlan" property
@@ -1504,20 +1626,61 @@ type ResponseApplianceUpdateNetworkApplianceVLANReservedIPRanges struct {
 	Start   string `json:"start,omitempty"`   // The first IP in the reserved range
 }
 type ResponseApplianceGetNetworkApplianceVpnBgp struct {
-	AsNumber      *int                                                   `json:"asNumber,omitempty"`      //
-	Enabled       *bool                                                  `json:"enabled,omitempty"`       //
-	IbgpHoldTimer *int                                                   `json:"ibgpHoldTimer,omitempty"` //
-	Neighbors     *[]ResponseApplianceGetNetworkApplianceVpnBgpNeighbors `json:"neighbors,omitempty"`     //
+	AsNumber      *int                                                   `json:"asNumber,omitempty"`      // The number of the Autonomous System to which the appliance belongs
+	Enabled       *bool                                                  `json:"enabled,omitempty"`       // Whether BGP is enabled on the appliance
+	IbgpHoldTimer *int                                                   `json:"ibgpHoldTimer,omitempty"` // The iBGP hold time in seconds
+	Neighbors     *[]ResponseApplianceGetNetworkApplianceVpnBgpNeighbors `json:"neighbors,omitempty"`     // List of eBGP neighbor configurations
 }
 type ResponseApplianceGetNetworkApplianceVpnBgpNeighbors struct {
-	AllowTransit   *bool  `json:"allowTransit,omitempty"`   //
-	EbgpHoldTimer  *int   `json:"ebgpHoldTimer,omitempty"`  //
-	EbgpMultihop   *int   `json:"ebgpMultihop,omitempty"`   //
-	IP             string `json:"ip,omitempty"`             //
-	ReceiveLimit   *int   `json:"receiveLimit,omitempty"`   //
-	RemoteAsNumber *int   `json:"remoteAsNumber,omitempty"` //
+	AllowTransit    *bool                                                              `json:"allowTransit,omitempty"`    // Whether the appliance will advertise routes learned from other Autonomous Systems
+	Authentication  *ResponseApplianceGetNetworkApplianceVpnBgpNeighborsAuthentication `json:"authentication,omitempty"`  // Authentication settings between BGP peers
+	EbgpHoldTimer   *int                                                               `json:"ebgpHoldTimer,omitempty"`   // The eBGP hold time in seconds for the neighbor
+	EbgpMultihop    *int                                                               `json:"ebgpMultihop,omitempty"`    // The number of hops the appliance must traverse to establish a peering relationship with the neighbor
+	IP              string                                                             `json:"ip,omitempty"`              // The IPv4 address of the neighbor
+	IPv6            *ResponseApplianceGetNetworkApplianceVpnBgpNeighborsIPv6           `json:"ipv6,omitempty"`            // Information regarding IPv6 address of the neighbor
+	NextHopIP       string                                                             `json:"nextHopIp,omitempty"`       // The IPv4 address of the neighbor that will establish a TCP session with the appliance
+	ReceiveLimit    *int                                                               `json:"receiveLimit,omitempty"`    // The maximum number of routes that the appliance can receive from the neighbor
+	RemoteAsNumber  *int                                                               `json:"remoteAsNumber,omitempty"`  // Remote AS number of the neighbor
+	SourceInterface string                                                             `json:"sourceInterface,omitempty"` // The output interface the appliance uses to establish a peering relationship with the neighbor
+	TtlSecurity     *ResponseApplianceGetNetworkApplianceVpnBgpNeighborsTtlSecurity    `json:"ttlSecurity,omitempty"`     // Settings for BGP TTL security to protect BGP peering sessions from forged IP attacks
 }
-type ResponseApplianceUpdateNetworkApplianceVpnBgp interface{}
+type ResponseApplianceGetNetworkApplianceVpnBgpNeighborsAuthentication struct {
+	Password string `json:"password,omitempty"` // Password to configure MD5 authentication between BGP peers
+}
+type ResponseApplianceGetNetworkApplianceVpnBgpNeighborsIPv6 struct {
+	Address string `json:"address,omitempty"` // The IPv6 address of the neighbor
+}
+type ResponseApplianceGetNetworkApplianceVpnBgpNeighborsTtlSecurity struct {
+	Enabled *bool `json:"enabled,omitempty"` // Whether BGP TTL security is enabled
+}
+type ResponseApplianceUpdateNetworkApplianceVpnBgp struct {
+	AsNumber      *int                                                      `json:"asNumber,omitempty"`      // The number of the Autonomous System to which the appliance belongs
+	Enabled       *bool                                                     `json:"enabled,omitempty"`       // Whether BGP is enabled on the appliance
+	IbgpHoldTimer *int                                                      `json:"ibgpHoldTimer,omitempty"` // The iBGP hold time in seconds
+	Neighbors     *[]ResponseApplianceUpdateNetworkApplianceVpnBgpNeighbors `json:"neighbors,omitempty"`     // List of eBGP neighbor configurations
+}
+type ResponseApplianceUpdateNetworkApplianceVpnBgpNeighbors struct {
+	AllowTransit    *bool                                                                 `json:"allowTransit,omitempty"`    // Whether the appliance will advertise routes learned from other Autonomous Systems
+	Authentication  *ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsAuthentication `json:"authentication,omitempty"`  // Authentication settings between BGP peers
+	EbgpHoldTimer   *int                                                                  `json:"ebgpHoldTimer,omitempty"`   // The eBGP hold time in seconds for the neighbor
+	EbgpMultihop    *int                                                                  `json:"ebgpMultihop,omitempty"`    // The number of hops the appliance must traverse to establish a peering relationship with the neighbor
+	IP              string                                                                `json:"ip,omitempty"`              // The IPv4 address of the neighbor
+	IPv6            *ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsIPv6           `json:"ipv6,omitempty"`            // Information regarding IPv6 address of the neighbor
+	NextHopIP       string                                                                `json:"nextHopIp,omitempty"`       // The IPv4 address of the neighbor that will establish a TCP session with the appliance
+	ReceiveLimit    *int                                                                  `json:"receiveLimit,omitempty"`    // The maximum number of routes that the appliance can receive from the neighbor
+	RemoteAsNumber  *int                                                                  `json:"remoteAsNumber,omitempty"`  // Remote AS number of the neighbor
+	SourceInterface string                                                                `json:"sourceInterface,omitempty"` // The output interface the appliance uses to establish a peering relationship with the neighbor
+	TtlSecurity     *ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsTtlSecurity    `json:"ttlSecurity,omitempty"`     // Settings for BGP TTL security to protect BGP peering sessions from forged IP attacks
+}
+type ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsAuthentication struct {
+	Password string `json:"password,omitempty"` // Password to configure MD5 authentication between BGP peers
+}
+type ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsIPv6 struct {
+	Address string `json:"address,omitempty"` // The IPv6 address of the neighbor
+}
+type ResponseApplianceUpdateNetworkApplianceVpnBgpNeighborsTtlSecurity struct {
+	Enabled *bool `json:"enabled,omitempty"` // Whether BGP TTL security is enabled
+}
 type ResponseApplianceGetNetworkApplianceVpnSiteToSiteVpn struct {
 	Hubs    *[]ResponseApplianceGetNetworkApplianceVpnSiteToSiteVpnHubs    `json:"hubs,omitempty"`    // The list of VPN hubs, in order of preference.
 	Mode    string                                                         `json:"mode,omitempty"`    // The site-to-site VPN mode.
@@ -1545,23 +1708,53 @@ type ResponseApplianceUpdateNetworkApplianceVpnSiteToSiteVpnSubnets struct {
 	UseVpn      *bool  `json:"useVpn,omitempty"`      // Indicates the presence of the subnet in the VPN
 }
 type ResponseApplianceGetNetworkApplianceWarmSpare struct {
-	Enabled       *bool                                              `json:"enabled,omitempty"`       //
-	PrimarySerial string                                             `json:"primarySerial,omitempty"` //
-	SpareSerial   string                                             `json:"spareSerial,omitempty"`   //
-	UplinkMode    string                                             `json:"uplinkMode,omitempty"`    //
-	Wan1          *ResponseApplianceGetNetworkApplianceWarmSpareWan1 `json:"wan1,omitempty"`          //
-	Wan2          *ResponseApplianceGetNetworkApplianceWarmSpareWan2 `json:"wan2,omitempty"`          //
+	Enabled       *bool                                              `json:"enabled,omitempty"`       // Is the warm spare enabled
+	PrimarySerial string                                             `json:"primarySerial,omitempty"` // Serial number of the primary appliance
+	SpareSerial   string                                             `json:"spareSerial,omitempty"`   // Serial number of the warm spare appliance
+	UplinkMode    string                                             `json:"uplinkMode,omitempty"`    // Uplink mode, either virtual or public
+	Wan1          *ResponseApplianceGetNetworkApplianceWarmSpareWan1 `json:"wan1,omitempty"`          // WAN 1 IP and subnet
+	Wan2          *ResponseApplianceGetNetworkApplianceWarmSpareWan2 `json:"wan2,omitempty"`          // WAN 2 IP and subnet
 }
 type ResponseApplianceGetNetworkApplianceWarmSpareWan1 struct {
-	IP     string `json:"ip,omitempty"`     //
-	Subnet string `json:"subnet,omitempty"` //
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 1
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 1
 }
 type ResponseApplianceGetNetworkApplianceWarmSpareWan2 struct {
-	IP     string `json:"ip,omitempty"`     //
-	Subnet string `json:"subnet,omitempty"` //
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 2
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 2
 }
-type ResponseApplianceUpdateNetworkApplianceWarmSpare interface{}
-type ResponseApplianceSwapNetworkApplianceWarmSpare interface{}
+type ResponseApplianceUpdateNetworkApplianceWarmSpare struct {
+	Enabled       *bool                                                 `json:"enabled,omitempty"`       // Is the warm spare enabled
+	PrimarySerial string                                                `json:"primarySerial,omitempty"` // Serial number of the primary appliance
+	SpareSerial   string                                                `json:"spareSerial,omitempty"`   // Serial number of the warm spare appliance
+	UplinkMode    string                                                `json:"uplinkMode,omitempty"`    // Uplink mode, either virtual or public
+	Wan1          *ResponseApplianceUpdateNetworkApplianceWarmSpareWan1 `json:"wan1,omitempty"`          // WAN 1 IP and subnet
+	Wan2          *ResponseApplianceUpdateNetworkApplianceWarmSpareWan2 `json:"wan2,omitempty"`          // WAN 2 IP and subnet
+}
+type ResponseApplianceUpdateNetworkApplianceWarmSpareWan1 struct {
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 1
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 1
+}
+type ResponseApplianceUpdateNetworkApplianceWarmSpareWan2 struct {
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 2
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 2
+}
+type ResponseApplianceSwapNetworkApplianceWarmSpare struct {
+	Enabled       *bool                                               `json:"enabled,omitempty"`       // Is the warm spare enabled
+	PrimarySerial string                                              `json:"primarySerial,omitempty"` // Serial number of the primary appliance
+	SpareSerial   string                                              `json:"spareSerial,omitempty"`   // Serial number of the warm spare appliance
+	UplinkMode    string                                              `json:"uplinkMode,omitempty"`    // Uplink mode, either virtual or public
+	Wan1          *ResponseApplianceSwapNetworkApplianceWarmSpareWan1 `json:"wan1,omitempty"`          // WAN 1 IP and subnet
+	Wan2          *ResponseApplianceSwapNetworkApplianceWarmSpareWan2 `json:"wan2,omitempty"`          // WAN 2 IP and subnet
+}
+type ResponseApplianceSwapNetworkApplianceWarmSpareWan1 struct {
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 1
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 1
+}
+type ResponseApplianceSwapNetworkApplianceWarmSpareWan2 struct {
+	IP     string `json:"ip,omitempty"`     // IP address used for WAN 2
+	Subnet string `json:"subnet,omitempty"` // Subnet used for WAN 2
+}
 type ResponseApplianceGetOrganizationApplianceSecurityEvents []ResponseItemApplianceGetOrganizationApplianceSecurityEvents // Array of ResponseApplianceGetOrganizationApplianceSecurityEvents
 type ResponseItemApplianceGetOrganizationApplianceSecurityEvents struct {
 	Action          string `json:"action,omitempty"`          //
@@ -1702,35 +1895,37 @@ type ResponseItemApplianceGetOrganizationApplianceVpnStatsMerakiVpnpeersUsageSum
 	ReceivedInKilobytes *int `json:"receivedInKilobytes,omitempty"` //
 	SentInKilobytes     *int `json:"sentInKilobytes,omitempty"`     //
 }
-type ResponseApplianceGetOrganizationApplianceVpnStatuses []ResponseItemApplianceGetOrganizationApplianceVpnStatuses // Array of ResponseApplianceGetOrganizationApplianceVpnStatuses
-type ResponseItemApplianceGetOrganizationApplianceVpnStatuses struct {
-	DeviceSerial       string                                                                        `json:"deviceSerial,omitempty"`       //
-	DeviceStatus       string                                                                        `json:"deviceStatus,omitempty"`       //
-	ExportedSubnets    *[]ResponseItemApplianceGetOrganizationApplianceVpnStatusesExportedSubnets    `json:"exportedSubnets,omitempty"`    //
-	MerakiVpnpeers     *[]ResponseItemApplianceGetOrganizationApplianceVpnStatusesMerakiVpnpeers     `json:"merakiVpnPeers,omitempty"`     //
-	NetworkID          string                                                                        `json:"networkId,omitempty"`          //
-	NetworkName        string                                                                        `json:"networkName,omitempty"`        //
-	ThirdPartyVpnpeers *[]ResponseItemApplianceGetOrganizationApplianceVpnStatusesThirdPartyVpnpeers `json:"thirdPartyVpnPeers,omitempty"` //
-	Uplinks            *[]ResponseItemApplianceGetOrganizationApplianceVpnStatusesUplinks            `json:"uplinks,omitempty"`            //
-	VpnMode            string                                                                        `json:"vpnMode,omitempty"`            //
+type ResponseApplianceGetOrganizationApplianceVpnStatuses struct {
+	Vpnstatusentities *[]ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentities `json:"vpnstatusentities,omitempty"` // The list of VPN Status for networks
 }
-type ResponseItemApplianceGetOrganizationApplianceVpnStatusesExportedSubnets struct {
-	Name   string `json:"name,omitempty"`   //
-	Subnet string `json:"subnet,omitempty"` //
+type ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentities struct {
+	DeviceSerial       string                                                                                     `json:"deviceSerial,omitempty"`       // Serial number of the device
+	DeviceStatus       string                                                                                     `json:"deviceStatus,omitempty"`       // Device Status
+	ExportedSubnets    *[]ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesExportedSubnets    `json:"exportedSubnets,omitempty"`    // List of Exported Subnets
+	MerakiVpnpeers     *[]ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesMerakiVpnpeers     `json:"merakiVpnPeers,omitempty"`     // Meraki VPN Peers
+	NetworkID          string                                                                                     `json:"networkId,omitempty"`          // Network Id
+	NetworkName        string                                                                                     `json:"networkName,omitempty"`        // Network name
+	ThirdPartyVpnpeers *[]ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesThirdPartyVpnpeers `json:"thirdPartyVpnPeers,omitempty"` // Third Party VPN Peers
+	Uplinks            *[]ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesUplinks            `json:"uplinks,omitempty"`            // List of Uplink Information
+	VpnMode            string                                                                                     `json:"vpnMode,omitempty"`            // VPN Mode
 }
-type ResponseItemApplianceGetOrganizationApplianceVpnStatusesMerakiVpnpeers struct {
-	NetworkID    string `json:"networkId,omitempty"`    //
-	NetworkName  string `json:"networkName,omitempty"`  //
-	Reachability string `json:"reachability,omitempty"` //
+type ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesExportedSubnets struct {
+	Name   string `json:"name,omitempty"`   // Name of the subnet
+	Subnet string `json:"subnet,omitempty"` // Subnet
 }
-type ResponseItemApplianceGetOrganizationApplianceVpnStatusesThirdPartyVpnpeers struct {
-	Name         string `json:"name,omitempty"`         //
-	PublicIP     string `json:"publicIp,omitempty"`     //
-	Reachability string `json:"reachability,omitempty"` //
+type ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesMerakiVpnpeers struct {
+	NetworkID    string `json:"networkId,omitempty"`    // Network ID
+	NetworkName  string `json:"networkName,omitempty"`  // Network Name
+	Reachability string `json:"reachability,omitempty"` // Reachability
 }
-type ResponseItemApplianceGetOrganizationApplianceVpnStatusesUplinks struct {
-	Interface string `json:"interface,omitempty"` //
-	PublicIP  string `json:"publicIp,omitempty"`  //
+type ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesThirdPartyVpnpeers struct {
+	Name         string `json:"name,omitempty"`         // Name of the peer
+	PublicIP     string `json:"publicIp,omitempty"`     // Public IP of the peer
+	Reachability string `json:"reachability,omitempty"` // Reachability
+}
+type ResponseApplianceGetOrganizationApplianceVpnStatusesVpnstatusentitiesUplinks struct {
+	Interface string `json:"interface,omitempty"` // Uplink Interface Name
+	PublicIP  string `json:"publicIp,omitempty"`  // Uplink IP address (in IP or CIDR notation)
 }
 type ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeers struct {
 	Peers *[]ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeersPeers `json:"peers,omitempty"` // The list of VPN peers
@@ -1738,7 +1933,7 @@ type ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeers struct {
 type ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeersPeers struct {
 	IkeVersion          string                                                                            `json:"ikeVersion,omitempty"`          // [optional] The IKE version to be used for the IPsec VPN peer configuration. Defaults to '1' when omitted.
 	IPsecPolicies       *ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeersPeersIPsecPolicies `json:"ipsecPolicies,omitempty"`       // Custom IPSec policies for the VPN peer. If not included and a preset has not been chosen, the default preset for IPSec policies will be used.
-	IPsecPoliciesPreset string                                                                            `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure'. If this is provided, the 'ipsecPolicies' parameter is ignored.
+	IPsecPoliciesPreset string                                                                            `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure', 'umbrella', 'zscaler'. If this is provided, the 'ipsecPolicies' parameter is ignored.
 	LocalID             string                                                                            `json:"localId,omitempty"`             // [optional] The local ID is used to identify the MX to the peer. This will apply to all MXs this peer applies to.
 	Name                string                                                                            `json:"name,omitempty"`                // The name of the VPN peer
 	NetworkTags         []string                                                                          `json:"networkTags,omitempty"`         // A list of network tags that will connect with this peer. Use ['all'] for all networks. Use ['none'] for no networks. If not included, the default is ['all'].
@@ -1764,7 +1959,7 @@ type ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers struct {
 type ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeersPeers struct {
 	IkeVersion          string                                                                               `json:"ikeVersion,omitempty"`          // [optional] The IKE version to be used for the IPsec VPN peer configuration. Defaults to '1' when omitted.
 	IPsecPolicies       *ResponseApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeersPeersIPsecPolicies `json:"ipsecPolicies,omitempty"`       // Custom IPSec policies for the VPN peer. If not included and a preset has not been chosen, the default preset for IPSec policies will be used.
-	IPsecPoliciesPreset string                                                                               `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure'. If this is provided, the 'ipsecPolicies' parameter is ignored.
+	IPsecPoliciesPreset string                                                                               `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure', 'umbrella', 'zscaler'. If this is provided, the 'ipsecPolicies' parameter is ignored.
 	LocalID             string                                                                               `json:"localId,omitempty"`             // [optional] The local ID is used to identify the MX to the peer. This will apply to all MXs this peer applies to.
 	Name                string                                                                               `json:"name,omitempty"`                // The name of the VPN peer
 	NetworkTags         []string                                                                             `json:"networkTags,omitempty"`         // A list of network tags that will connect with this peer. Use ['all'] for all networks. Use ['none'] for no networks. If not included, the default is ['all'].
@@ -1818,11 +2013,11 @@ type RequestApplianceUpdateDeviceApplianceRadioSettings struct {
 type RequestApplianceUpdateDeviceApplianceRadioSettingsFiveGhzSettings struct {
 	Channel      *int `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
 	ChannelWidth *int `json:"channelWidth,omitempty"` // Sets a manual channel width for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
-	TargetPower  *int `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz. Can be between '8' or '30' or null for using auto power range.
+	TargetPower  *int `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz (dBm). Enter null for using auto power range.
 }
 type RequestApplianceUpdateDeviceApplianceRadioSettingsTwoFourGhzSettings struct {
 	Channel     *int `json:"channel,omitempty"`     // Sets a manual channel for 2.4 GHz. Can be '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13' or '14' or null for using auto channel.
-	TargetPower *int `json:"targetPower,omitempty"` // Set a manual target power for 2.4 GHz. Can be between '5' or '30' or null for using auto power range.
+	TargetPower *int `json:"targetPower,omitempty"` // Set a manual target power for 2.4 GHz (dBm). Enter null for using auto power range.
 }
 type RequestApplianceUpdateDeviceApplianceUplinksSettings struct {
 	Interfaces *RequestApplianceUpdateDeviceApplianceUplinksSettingsInterfaces `json:"interfaces,omitempty"` // Interface settings.
@@ -2147,6 +2342,45 @@ type RequestApplianceUpdateNetworkApplianceRfProfileTwoFourGhzSettings struct {
 	AxEnabled  *bool    `json:"axEnabled,omitempty"`  // Determines whether ax radio on 2.4Ghz band is on or off. Can be either true or false. If false, we highly recommend disabling band steering.
 	MinBitrate *float64 `json:"minBitrate,omitempty"` // Sets min bitrate (Mbps) of 2.4Ghz band. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPolicies struct {
+	WanTrafficUplinkPreferences *[]RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferences `json:"wanTrafficUplinkPreferences,omitempty"` // policies with respective traffic filters for an MX network
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferences struct {
+	FailOverCriterion string                                                                                                  `json:"failOverCriterion,omitempty"` // WAN failover and failback behavior
+	PerformanceClass  *RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesPerformanceClass `json:"performanceClass,omitempty"`  // Performance class setting for uplink preference rule
+	PreferredUplink   string                                                                                                  `json:"preferredUplink,omitempty"`   // Preferred uplink for uplink preference rule. Must be one of: 'wan1', 'wan2', 'bestForVoIP', 'loadBalancing' or 'defaultUplink'
+	TrafficFilters    *[]RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFilters `json:"trafficFilters,omitempty"`    // Traffic filters
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesPerformanceClass struct {
+	BuiltinPerformanceClassName string `json:"builtinPerformanceClassName,omitempty"` // Name of builtin performance class. Must be present when performanceClass type is 'builtin' and value must be one of: 'VoIP'
+	CustomPerformanceClassID    string `json:"customPerformanceClassId,omitempty"`    // ID of created custom performance class, must be present when performanceClass type is "custom"
+	Type                        string `json:"type,omitempty"`                        // Type of this performance class. Must be one of: 'builtin' or 'custom'
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFilters struct {
+	Type  string                                                                                                     `json:"type,omitempty"`  // Traffic filter type. Must be 'custom', 'major_application', 'application (NBAR)', if type is 'application', you can pass either an NBAR App Category or Application
+	Value *RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValue `json:"value,omitempty"` // Value of traffic filter
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValue struct {
+	Destination *RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestination `json:"destination,omitempty"` // Destination of 'custom' type traffic filter
+	Protocol    string                                                                                                                `json:"protocol,omitempty"`    // Protocol of the traffic filter. Must be one of: 'tcp', 'udp', 'icmp6' or 'any'
+	Source      *RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueSource      `json:"source,omitempty"`      // Source of traffic filter
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestination struct {
+	Applications *[]RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications `json:"applications,omitempty"` // list of application objects (either majorApplication or nbar)
+	Cidr         string                                                                                                                              `json:"cidr,omitempty"`         // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any"
+	Port         string                                                                                                                              `json:"port,omitempty"`         // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueDestinationApplications struct {
+	ID   string `json:"id,omitempty"`   // Id of the major application, or a list of NBAR Application Category or Application selections
+	Name string `json:"name,omitempty"` // Name of the major application or application category selected
+	Type string `json:"type,omitempty"` // app type (major or nbar)
+}
+type RequestApplianceUpdateNetworkApplianceSdwanInternetPoliciesWanTrafficUplinkPreferencesTrafficFiltersValueSource struct {
+	Cidr string `json:"cidr,omitempty"` // CIDR format address (e.g."192.168.10.1", which is the same as "192.168.10.1/32"), or "any". Cannot be used in combination with the "vlan" property
+	Host *int   `json:"host,omitempty"` // Host ID in the VLAN. Should not exceed the VLAN subnet capacity. Must be used along with the "vlan" property and is currently only available under a template network.
+	Port string `json:"port,omitempty"` // E.g.: "any", "0" (also means "any"), "8080", "1-1024"
+	VLAN *int   `json:"vlan,omitempty"` // VLAN ID of the configured VLAN in the Meraki network. Cannot be used in combination with the "cidr" property and is currently only available under a template network.
+}
 type RequestApplianceUpdateNetworkApplianceSecurityIntrusion struct {
 	IDsRulesets       string                                                                    `json:"idsRulesets,omitempty"`       // Set the detection ruleset 'connectivity'/'balanced'/'security' (optional - omitting will leave current config unchanged). Default value is 'balanced' if none currently saved
 	Mode              string                                                                    `json:"mode,omitempty"`              // Set mode to 'disabled'/'detection'/'prevention' (optional - omitting will leave current config unchanged)
@@ -2228,25 +2462,25 @@ type RequestApplianceUpdateNetworkApplianceSSIDRadiusServers struct {
 	Secret string `json:"secret,omitempty"` // The RADIUS client shared secret.
 }
 type RequestApplianceCreateNetworkApplianceStaticRoute struct {
-	GatewayIP     string `json:"gatewayIp,omitempty"`     // The gateway IP (next hop) of the static route
-	GatewayVLANID string `json:"gatewayVlanId,omitempty"` // The gateway IP (next hop) VLAN ID of the static route
-	Name          string `json:"name,omitempty"`          // The name of the new static route
-	Subnet        string `json:"subnet,omitempty"`        // The subnet of the static route
+	GatewayIP     string `json:"gatewayIp,omitempty"`     // Gateway IP address (next hop)
+	GatewayVLANID string `json:"gatewayVlanId,omitempty"` // Gateway VLAN ID
+	Name          string `json:"name,omitempty"`          // Name of the route
+	Subnet        string `json:"subnet,omitempty"`        // Subnet of the route
 }
 type RequestApplianceUpdateNetworkApplianceStaticRoute struct {
-	Enabled            *bool                                                                `json:"enabled,omitempty"`            // The enabled state of the static route
-	FixedIPAssignments *RequestApplianceUpdateNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // The DHCP fixed IP assignments on the static route. This should be an object that contains mappings from MAC addresses to objects that themselves each contain "ip" and "name" string fields. See the sample request/response for more details.
-	GatewayIP          string                                                               `json:"gatewayIp,omitempty"`          // The gateway IP (next hop) of the static route
-	GatewayVLANID      string                                                               `json:"gatewayVlanId,omitempty"`      // The gateway IP (next hop) VLAN ID of the static route
-	Name               string                                                               `json:"name,omitempty"`               // The name of the static route
-	ReservedIPRanges   *[]RequestApplianceUpdateNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   // The DHCP reserved IP ranges on the static route
-	Subnet             string                                                               `json:"subnet,omitempty"`             // The subnet of the static route
+	Enabled            *bool                                                                `json:"enabled,omitempty"`            // Whether the route should be enabled or not
+	FixedIPAssignments *RequestApplianceUpdateNetworkApplianceStaticRouteFixedIPAssignments `json:"fixedIpAssignments,omitempty"` // Fixed DHCP IP assignments on the route
+	GatewayIP          string                                                               `json:"gatewayIp,omitempty"`          // Gateway IP address (next hop)
+	GatewayVLANID      string                                                               `json:"gatewayVlanId,omitempty"`      // Gateway VLAN ID
+	Name               string                                                               `json:"name,omitempty"`               // Name of the route
+	ReservedIPRanges   *[]RequestApplianceUpdateNetworkApplianceStaticRouteReservedIPRanges `json:"reservedIpRanges,omitempty"`   // DHCP reserved IP ranges
+	Subnet             string                                                               `json:"subnet,omitempty"`             // Subnet of the route
 }
 type RequestApplianceUpdateNetworkApplianceStaticRouteFixedIPAssignments interface{}
 type RequestApplianceUpdateNetworkApplianceStaticRouteReservedIPRanges struct {
-	Comment string `json:"comment,omitempty"` // A text comment for the reserved range
-	End     string `json:"end,omitempty"`     // The last IP in the reserved range
-	Start   string `json:"start,omitempty"`   // The first IP in the reserved range
+	Comment string `json:"comment,omitempty"` // Description of the range
+	End     string `json:"end,omitempty"`     // Last address in the reserved range
+	Start   string `json:"start,omitempty"`   // First address in the reserved range
 }
 type RequestApplianceUpdateNetworkApplianceTrafficShaping struct {
 	GlobalBandwidthLimits *RequestApplianceUpdateNetworkApplianceTrafficShapingGlobalBandwidthLimits `json:"globalBandwidthLimits,omitempty"` // Global per-client bandwidth limit
@@ -2396,16 +2630,25 @@ type RequestApplianceUpdateNetworkApplianceTrafficShapingVpnExclusionsMajorAppli
 	Name string `json:"name,omitempty"` // Application's name.
 }
 type RequestApplianceCreateNetworkApplianceVLAN struct {
-	ApplianceIP      string                                                   `json:"applianceIp,omitempty"`      // The local IP of the appliance on the VLAN
-	Cidr             string                                                   `json:"cidr,omitempty"`             // CIDR of the pool of subnets. Applicable only for template network. Each network bound to the template will automatically pick a subnet from this pool to build its own VLAN.
-	GroupPolicyID    string                                                   `json:"groupPolicyId,omitempty"`    // The id of the desired group policy to apply to the VLAN
-	ID               string                                                   `json:"id,omitempty"`               // The VLAN ID of the new VLAN (must be between 1 and 4094)
-	IPv6             *RequestApplianceCreateNetworkApplianceVLANIPv6          `json:"ipv6,omitempty"`             // IPv6 configuration on the VLAN
-	MandatoryDhcp    *RequestApplianceCreateNetworkApplianceVLANMandatoryDhcp `json:"mandatoryDhcp,omitempty"`    // Mandatory DHCP will enforce that clients connecting to this VLAN must use the IP address assigned by the DHCP server. Clients who use a static IP address won't be able to associate. Only available on firmware versions 17.0 and above
-	Mask             *int                                                     `json:"mask,omitempty"`             // Mask used for the subnet of all bound to the template networks. Applicable only for template network.
-	Name             string                                                   `json:"name,omitempty"`             // The name of the new VLAN
-	Subnet           string                                                   `json:"subnet,omitempty"`           // The subnet of the VLAN
-	TemplateVLANType string                                                   `json:"templateVlanType,omitempty"` // Type of subnetting of the VLAN. Applicable only for template network.
+	ApplianceIP            string                                                   `json:"applianceIp,omitempty"`            // The local IP of the appliance on the VLAN
+	Cidr                   string                                                   `json:"cidr,omitempty"`                   // CIDR of the pool of subnets. Applicable only for template network. Each network bound to the template will automatically pick a subnet from this pool to build its own VLAN.
+	DhcpBootOptionsEnabled *bool                                                    `json:"dhcpBootOptionsEnabled,omitempty"` // Use DHCP boot options specified in other properties
+	DhcpHandling           string                                                   `json:"dhcpHandling,omitempty"`           // The appliance's handling of DHCP requests on this VLAN. One of: 'Run a DHCP server', 'Relay DHCP to another server' or 'Do not respond to DHCP requests'
+	DhcpLeaseTime          string                                                   `json:"dhcpLeaseTime,omitempty"`          // The term of DHCP leases if the appliance is running a DHCP server on this VLAN. One of: '30 minutes', '1 hour', '4 hours', '12 hours', '1 day' or '1 week'
+	DhcpOptions            *[]RequestApplianceCreateNetworkApplianceVLANDhcpOptions `json:"dhcpOptions,omitempty"`            // The list of DHCP options that will be included in DHCP responses. Each object in the list should have "code", "type", and "value" properties.
+	GroupPolicyID          string                                                   `json:"groupPolicyId,omitempty"`          // The id of the desired group policy to apply to the VLAN
+	ID                     string                                                   `json:"id,omitempty"`                     // The VLAN ID of the new VLAN (must be between 1 and 4094)
+	IPv6                   *RequestApplianceCreateNetworkApplianceVLANIPv6          `json:"ipv6,omitempty"`                   // IPv6 configuration on the VLAN
+	MandatoryDhcp          *RequestApplianceCreateNetworkApplianceVLANMandatoryDhcp `json:"mandatoryDhcp,omitempty"`          // Mandatory DHCP will enforce that clients connecting to this VLAN must use the IP address assigned by the DHCP server. Clients who use a static IP address won't be able to associate. Only available on firmware versions 17.0 and above
+	Mask                   *int                                                     `json:"mask,omitempty"`                   // Mask used for the subnet of all bound to the template networks. Applicable only for template network.
+	Name                   string                                                   `json:"name,omitempty"`                   // The name of the new VLAN
+	Subnet                 string                                                   `json:"subnet,omitempty"`                 // The subnet of the VLAN
+	TemplateVLANType       string                                                   `json:"templateVlanType,omitempty"`       // Type of subnetting of the VLAN. Applicable only for template network.
+}
+type RequestApplianceCreateNetworkApplianceVLANDhcpOptions struct {
+	Code  string `json:"code,omitempty"`  // The code for the DHCP option. This should be an integer between 2 and 254.
+	Type  string `json:"type,omitempty"`  // The type for the DHCP option. One of: 'text', 'ip', 'hex' or 'integer'
+	Value string `json:"value,omitempty"` // The value for the DHCP option
 }
 type RequestApplianceCreateNetworkApplianceVLANIPv6 struct {
 	Enabled           *bool                                                              `json:"enabled,omitempty"`           // Enable IPv6 on VLAN.
@@ -2491,7 +2734,7 @@ type RequestApplianceUpdateNetworkApplianceVpnBgpNeighbors struct {
 	IP              string                                                               `json:"ip,omitempty"`              // The IPv4 address of the neighbor
 	IPv6            *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsIPv6           `json:"ipv6,omitempty"`            // Information regarding IPv6 address of the neighbor, Required if `ip` is not present.
 	NextHopIP       string                                                               `json:"nextHopIp,omitempty"`       // The IPv4 address of the remote BGP peer that will establish a TCP session with the local MX.
-	ReceiveLimit    *int                                                                 `json:"receiveLimit,omitempty"`    // The receive limit is the maximum number of routes that can be received from any BGP peer. The receive limit must be an integer between 0 and 4294967295. When absent, it defaults to 0.
+	ReceiveLimit    *int                                                                 `json:"receiveLimit,omitempty"`    // The receive limit is the maximum number of routes that can be received from any BGP peer. The receive limit must be an integer between 0 and 2147483647. When absent, it defaults to 0.
 	RemoteAsNumber  *int                                                                 `json:"remoteAsNumber,omitempty"`  // Remote ASN of the neighbor. The remote ASN must be an integer between 1 and 4294967295.
 	SourceInterface string                                                               `json:"sourceInterface,omitempty"` // The output interface for peering with the remote BGP peer. Valid values are: 'wan1', 'wan2' or 'vlan{VLAN ID}'(e.g. 'vlan123').
 	TtlSecurity     *RequestApplianceUpdateNetworkApplianceVpnBgpNeighborsTtlSecurity    `json:"ttlSecurity,omitempty"`     // Settings for BGP TTL security to protect BGP peering sessions from forged IP attacks.
@@ -2538,11 +2781,12 @@ type RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers struct {
 type RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeersPeers struct {
 	IkeVersion          string                                                                              `json:"ikeVersion,omitempty"`          // [optional] The IKE version to be used for the IPsec VPN peer configuration. Defaults to '1' when omitted.
 	IPsecPolicies       *RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeersPeersIPsecPolicies `json:"ipsecPolicies,omitempty"`       // Custom IPSec policies for the VPN peer. If not included and a preset has not been chosen, the default preset for IPSec policies will be used.
-	IPsecPoliciesPreset string                                                                              `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure'. If this is provided, the 'ipsecPolicies' parameter is ignored.
+	IPsecPoliciesPreset string                                                                              `json:"ipsecPoliciesPreset,omitempty"` // One of the following available presets: 'default', 'aws', 'azure', 'umbrella', 'zscaler'. If this is provided, the 'ipsecPolicies' parameter is ignored.
 	LocalID             string                                                                              `json:"localId,omitempty"`             // [optional] The local ID is used to identify the MX to the peer. This will apply to all MXs this peer applies to.
 	Name                string                                                                              `json:"name,omitempty"`                // The name of the VPN peer
 	NetworkTags         []string                                                                            `json:"networkTags,omitempty"`         // A list of network tags that will connect with this peer. Use ['all'] for all networks. Use ['none'] for no networks. If not included, the default is ['all'].
 	PrivateSubnets      []string                                                                            `json:"privateSubnets,omitempty"`      // The list of the private subnets of the VPN peer
+	PublicHostname      string                                                                              `json:"publicHostname,omitempty"`      // [optional] The public hostname of the VPN peer
 	PublicIP            string                                                                              `json:"publicIp,omitempty"`            // [optional] The public IP of the VPN peer
 	RemoteID            string                                                                              `json:"remoteId,omitempty"`            // [optional] The remote ID is used to identify the connecting VPN peer. This can either be a valid IPv4 Address, FQDN or User FQDN.
 	Secret              string                                                                              `json:"secret,omitempty"`              // The shared secret with the VPN peer
@@ -2610,18 +2854,21 @@ func (s *ApplianceService) GetDeviceApplianceDhcpSubnets(serial string) (*Respon
 /* Return the performance score for a single MX. Only primary MX devices supported. If no data is available, a 204 error code is returned.
 
 @param serial serial path parameter.
+@param getDeviceAppliancePerformanceQueryParams Filtering parameter
 
 
 */
-func (s *ApplianceService) GetDeviceAppliancePerformance(serial string) (*ResponseApplianceGetDeviceAppliancePerformance, *resty.Response, error) {
+func (s *ApplianceService) GetDeviceAppliancePerformance(serial string, getDeviceAppliancePerformanceQueryParams *GetDeviceAppliancePerformanceQueryParams) (*ResponseApplianceGetDeviceAppliancePerformance, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/performance"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
 
+	queryString, _ := query.Values(getDeviceAppliancePerformanceQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseApplianceGetDeviceAppliancePerformance{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseApplianceGetDeviceAppliancePerformance{}).
 		SetError(&Error).
 		Get(path)
 
@@ -4709,7 +4956,7 @@ func (s *ApplianceService) CreateNetworkApplianceRfProfile(networkID string, req
 
 */
 
-func (s *ApplianceService) CreateNetworkApplianceStaticRoute(networkID string, requestApplianceCreateNetworkApplianceStaticRoute *RequestApplianceCreateNetworkApplianceStaticRoute) (*resty.Response, error) {
+func (s *ApplianceService) CreateNetworkApplianceStaticRoute(networkID string, requestApplianceCreateNetworkApplianceStaticRoute *RequestApplianceCreateNetworkApplianceStaticRoute) (*ResponseApplianceCreateNetworkApplianceStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4718,20 +4965,21 @@ func (s *ApplianceService) CreateNetworkApplianceStaticRoute(networkID string, r
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceCreateNetworkApplianceStaticRoute).
-		// SetResult(&ResponseApplianceCreateNetworkApplianceStaticRoute{}).
+		SetResult(&ResponseApplianceCreateNetworkApplianceStaticRoute{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkApplianceStaticRoute")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkApplianceStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceCreateNetworkApplianceStaticRoute)
+	return result, response, err
 
 }
 
@@ -4743,7 +4991,7 @@ func (s *ApplianceService) CreateNetworkApplianceStaticRoute(networkID string, r
 
 */
 
-func (s *ApplianceService) CreateNetworkApplianceTrafficShapingCustomPerformanceClass(networkID string, requestApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass *RequestApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass) (*resty.Response, error) {
+func (s *ApplianceService) CreateNetworkApplianceTrafficShapingCustomPerformanceClass(networkID string, requestApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass *RequestApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass) (*ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4752,20 +5000,21 @@ func (s *ApplianceService) CreateNetworkApplianceTrafficShapingCustomPerformance
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass).
-		// SetResult(&ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass{}).
+		SetResult(&ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkApplianceTrafficShapingCustomPerformanceClass")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkApplianceTrafficShapingCustomPerformanceClass")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceCreateNetworkApplianceTrafficShapingCustomPerformanceClass)
+	return result, response, err
 
 }
 
@@ -4812,7 +5061,7 @@ func (s *ApplianceService) CreateNetworkApplianceVLAN(networkID string, requestA
 
 */
 
-func (s *ApplianceService) SwapNetworkApplianceWarmSpare(networkID string) (*resty.Response, error) {
+func (s *ApplianceService) SwapNetworkApplianceWarmSpare(networkID string) (*ResponseApplianceSwapNetworkApplianceWarmSpare, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/warmSpare/swap"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4820,21 +5069,21 @@ func (s *ApplianceService) SwapNetworkApplianceWarmSpare(networkID string) (*res
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-
-		// SetResult(&ResponseApplianceSwapNetworkApplianceWarmSpare{}).
+		SetResult(&ResponseApplianceSwapNetworkApplianceWarmSpare{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation SwapNetworkApplianceWarmSpare")
+		return nil, response, fmt.Errorf("error with operation SwapNetworkApplianceWarmSpare")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceSwapNetworkApplianceWarmSpare)
+	return result, response, err
 
 }
 
@@ -4907,7 +5156,7 @@ func (s *ApplianceService) UpdateDeviceApplianceUplinksSettings(serial string, r
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceConnectivityMonitoringDestinations(networkID string, requestApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations *RequestApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceConnectivityMonitoringDestinations(networkID string, requestApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations *RequestApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations) (*ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/connectivityMonitoringDestinations"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4916,19 +5165,21 @@ func (s *ApplianceService) UpdateNetworkApplianceConnectivityMonitoringDestinati
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceConnectivityMonitoringDestinations")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceConnectivityMonitoringDestinations")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceConnectivityMonitoringDestinations)
+	return result, response, err
 
 }
 
@@ -4998,7 +5249,7 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallCellularFirewallRules(n
 @param networkID networkId path parameter. Network ID
 @param service service path parameter.
 */
-func (s *ApplianceService) UpdateNetworkApplianceFirewallFirewalledService(networkID string, service string, requestApplianceUpdateNetworkApplianceFirewallFirewalledService *RequestApplianceUpdateNetworkApplianceFirewallFirewalledService) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceFirewallFirewalledService(networkID string, service string, requestApplianceUpdateNetworkApplianceFirewallFirewalledService *RequestApplianceUpdateNetworkApplianceFirewallFirewalledService) (*ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/firewalledServices/{service}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5008,19 +5259,21 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallFirewalledService(netwo
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceFirewallFirewalledService).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallFirewalledService")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallFirewalledService")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceFirewallFirewalledService)
+	return result, response, err
 
 }
 
@@ -5213,7 +5466,7 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallOneToOneNatRules(networ
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceFirewallPortForwardingRules(networkID string, requestApplianceUpdateNetworkApplianceFirewallPortForwardingRules *RequestApplianceUpdateNetworkApplianceFirewallPortForwardingRules) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceFirewallPortForwardingRules(networkID string, requestApplianceUpdateNetworkApplianceFirewallPortForwardingRules *RequestApplianceUpdateNetworkApplianceFirewallPortForwardingRules) (*ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/portForwardingRules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5222,19 +5475,21 @@ func (s *ApplianceService) UpdateNetworkApplianceFirewallPortForwardingRules(net
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceFirewallPortForwardingRules).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallPortForwardingRules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceFirewallPortForwardingRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceFirewallPortForwardingRules)
+	return result, response, err
 
 }
 
@@ -5364,6 +5619,38 @@ func (s *ApplianceService) UpdateNetworkApplianceRfProfile(networkID string, rfP
 	}
 
 	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceRfProfile)
+	return result, response, err
+
+}
+
+//UpdateNetworkApplianceSdwanInternetPolicies Update SDWAN internet traffic preferences for an MX network
+/* Update SDWAN internet traffic preferences for an MX network
+
+@param networkID networkId path parameter. Network ID
+*/
+func (s *ApplianceService) UpdateNetworkApplianceSdwanInternetPolicies(networkID string, requestApplianceUpdateNetworkApplianceSdwanInternetPolicies *RequestApplianceUpdateNetworkApplianceSdwanInternetPolicies) (*ResponseApplianceUpdateNetworkApplianceSdwanInternetPolicies, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/appliance/sdwan/internetPolicies"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestApplianceUpdateNetworkApplianceSdwanInternetPolicies).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceSdwanInternetPolicies{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceSdwanInternetPolicies")
+	}
+
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceSdwanInternetPolicies)
 	return result, response, err
 
 }
@@ -5536,7 +5823,7 @@ func (s *ApplianceService) UpdateNetworkApplianceSSID(networkID string, number s
 @param networkID networkId path parameter. Network ID
 @param staticRouteID staticRouteId path parameter. Static route ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceStaticRoute(networkID string, staticRouteID string, requestApplianceUpdateNetworkApplianceStaticRoute *RequestApplianceUpdateNetworkApplianceStaticRoute) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceStaticRoute(networkID string, staticRouteID string, requestApplianceUpdateNetworkApplianceStaticRoute *RequestApplianceUpdateNetworkApplianceStaticRoute) (*ResponseApplianceUpdateNetworkApplianceStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5546,19 +5833,21 @@ func (s *ApplianceService) UpdateNetworkApplianceStaticRoute(networkID string, s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceStaticRoute).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceStaticRoute{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceStaticRoute")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceStaticRoute")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceStaticRoute)
+	return result, response, err
 
 }
 
@@ -5821,7 +6110,7 @@ func (s *ApplianceService) UpdateNetworkApplianceVLAN(networkID string, vlanID s
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceVpnBgp(networkID string, requestApplianceUpdateNetworkApplianceVpnBgp *RequestApplianceUpdateNetworkApplianceVpnBgp) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceVpnBgp(networkID string, requestApplianceUpdateNetworkApplianceVpnBgp *RequestApplianceUpdateNetworkApplianceVpnBgp) (*ResponseApplianceUpdateNetworkApplianceVpnBgp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vpn/bgp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5830,19 +6119,21 @@ func (s *ApplianceService) UpdateNetworkApplianceVpnBgp(networkID string, reques
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceVpnBgp).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceVpnBgp{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceVpnBgp")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceVpnBgp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceVpnBgp)
+	return result, response, err
 
 }
 
@@ -5883,7 +6174,7 @@ func (s *ApplianceService) UpdateNetworkApplianceVpnSiteToSiteVpn(networkID stri
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *ApplianceService) UpdateNetworkApplianceWarmSpare(networkID string, requestApplianceUpdateNetworkApplianceWarmSpare *RequestApplianceUpdateNetworkApplianceWarmSpare) (*resty.Response, error) {
+func (s *ApplianceService) UpdateNetworkApplianceWarmSpare(networkID string, requestApplianceUpdateNetworkApplianceWarmSpare *RequestApplianceUpdateNetworkApplianceWarmSpare) (*ResponseApplianceUpdateNetworkApplianceWarmSpare, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/warmSpare"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5892,19 +6183,21 @@ func (s *ApplianceService) UpdateNetworkApplianceWarmSpare(networkID string, req
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestApplianceUpdateNetworkApplianceWarmSpare).
+		SetResult(&ResponseApplianceUpdateNetworkApplianceWarmSpare{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkApplianceWarmSpare")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkApplianceWarmSpare")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseApplianceUpdateNetworkApplianceWarmSpare)
+	return result, response, err
 
 }
 

--- a/sdk/camera.go
+++ b/sdk/camera.go
@@ -48,50 +48,50 @@ type GetOrganizationCameraOnboardingStatusesQueryParams struct {
 }
 
 type ResponseCameraGetDeviceCameraAnalyticsLive struct {
-	Ts    string                                           `json:"ts,omitempty"`    //
-	Zones *ResponseCameraGetDeviceCameraAnalyticsLiveZones `json:"zones,omitempty"` //
+	Ts    string                                           `json:"ts,omitempty"`    // The current time
+	Zones *ResponseCameraGetDeviceCameraAnalyticsLiveZones `json:"zones,omitempty"` // The zones state
 }
 type ResponseCameraGetDeviceCameraAnalyticsLiveZones struct {
-	Status0 *ResponseCameraGetDeviceCameraAnalyticsLiveZones0 `json:"0,omitempty"` //
+	ZoneID *ResponseCameraGetDeviceCameraAnalyticsLiveZonesZoneID `json:"zoneId,omitempty"` // The zone state, dynamic
 }
-type ResponseCameraGetDeviceCameraAnalyticsLiveZones0 struct {
-	Person *int `json:"person,omitempty"` //
+type ResponseCameraGetDeviceCameraAnalyticsLiveZonesZoneID struct {
+	Person *int `json:"person,omitempty"` // The count per type, dynamic
 }
 type ResponseCameraGetDeviceCameraAnalyticsOverview []ResponseItemCameraGetDeviceCameraAnalyticsOverview // Array of ResponseCameraGetDeviceCameraAnalyticsOverview
 type ResponseItemCameraGetDeviceCameraAnalyticsOverview struct {
-	AverageCount *int   `json:"averageCount,omitempty"` //
-	EndTs        string `json:"endTs,omitempty"`        //
-	Entrances    *int   `json:"entrances,omitempty"`    //
-	StartTs      string `json:"startTs,omitempty"`      //
-	ZoneID       *int   `json:"zoneId,omitempty"`       //
+	AverageCount *float64 `json:"averageCount,omitempty"` // The average count
+	EndTs        string   `json:"endTs,omitempty"`        // The end time
+	Entrances    *int     `json:"entrances,omitempty"`    // The number of sentrances
+	StartTs      string   `json:"startTs,omitempty"`      // The start time
+	ZoneID       *int     `json:"zoneId,omitempty"`       // The zone id
 }
 type ResponseCameraGetDeviceCameraAnalyticsRecent []ResponseItemCameraGetDeviceCameraAnalyticsRecent // Array of ResponseCameraGetDeviceCameraAnalyticsRecent
 type ResponseItemCameraGetDeviceCameraAnalyticsRecent struct {
-	AverageCount *float64 `json:"averageCount,omitempty"` //
-	EndTs        string   `json:"endTs,omitempty"`        //
-	Entrances    *int     `json:"entrances,omitempty"`    //
-	StartTs      string   `json:"startTs,omitempty"`      //
-	ZoneID       *int     `json:"zoneId,omitempty"`       //
+	AverageCount *float64 `json:"averageCount,omitempty"` // The average count
+	EndTs        string   `json:"endTs,omitempty"`        // The end time
+	Entrances    *int     `json:"entrances,omitempty"`    // The number of entrances
+	StartTs      string   `json:"startTs,omitempty"`      // The start time
+	ZoneID       *int     `json:"zoneId,omitempty"`       // The zone id
 }
 type ResponseCameraGetDeviceCameraAnalyticsZones []ResponseItemCameraGetDeviceCameraAnalyticsZones // Array of ResponseCameraGetDeviceCameraAnalyticsZones
 type ResponseItemCameraGetDeviceCameraAnalyticsZones struct {
-	ID               string                                                           `json:"id,omitempty"`               //
-	Label            string                                                           `json:"label,omitempty"`            //
-	RegionOfInterest *ResponseItemCameraGetDeviceCameraAnalyticsZonesRegionOfInterest `json:"regionOfInterest,omitempty"` //
-	Type             string                                                           `json:"type,omitempty"`             //
+	ID               string                                                           `json:"id,omitempty"`               // The zone ID
+	Label            string                                                           `json:"label,omitempty"`            // The zone label
+	RegionOfInterest *ResponseItemCameraGetDeviceCameraAnalyticsZonesRegionOfInterest `json:"regionOfInterest,omitempty"` // The region of interest
+	Type             string                                                           `json:"type,omitempty"`             // The zone type
 }
 type ResponseItemCameraGetDeviceCameraAnalyticsZonesRegionOfInterest struct {
-	X0 string `json:"x0,omitempty"` //
-	X1 string `json:"x1,omitempty"` //
-	Y0 string `json:"y0,omitempty"` //
-	Y1 string `json:"y1,omitempty"` //
+	X0 string `json:"x0,omitempty"` // The x0 coordinate
+	X1 string `json:"x1,omitempty"` // The x1 coordinate
+	Y0 string `json:"y0,omitempty"` // The y0 coordinate
+	Y1 string `json:"y1,omitempty"` // The y1 coordinate
 }
 type ResponseCameraGetDeviceCameraAnalyticsZoneHistory []ResponseItemCameraGetDeviceCameraAnalyticsZoneHistory // Array of ResponseCameraGetDeviceCameraAnalyticsZoneHistory
 type ResponseItemCameraGetDeviceCameraAnalyticsZoneHistory struct {
-	AverageCount *float64 `json:"averageCount,omitempty"` //
-	EndTs        string   `json:"endTs,omitempty"`        //
-	Entrances    *int     `json:"entrances,omitempty"`    //
-	StartTs      string   `json:"startTs,omitempty"`      //
+	AverageCount *float64 `json:"averageCount,omitempty"` // The average count
+	EndTs        string   `json:"endTs,omitempty"`        // The end time
+	Entrances    *int     `json:"entrances,omitempty"`    // The number of entrances
+	StartTs      string   `json:"startTs,omitempty"`      // The start time
 }
 type ResponseCameraGetDeviceCameraCustomAnalytics struct {
 	ArtifactID string                                                    `json:"artifactId,omitempty"` // Custom analytics artifact ID
@@ -111,7 +111,10 @@ type ResponseCameraUpdateDeviceCameraCustomAnalyticsParameters struct {
 	Name  string   `json:"name,omitempty"`  // Name of the parameter
 	Value *float64 `json:"value,omitempty"` // Value of the parameter
 }
-type ResponseCameraGenerateDeviceCameraSnapshot interface{}
+type ResponseCameraGenerateDeviceCameraSnapshot struct {
+	Expiry string `json:"expiry,omitempty"` // Expiration details for snapshot image access
+	URL    string `json:"url,omitempty"`    // Url for the snapshot
+}
 type ResponseCameraGetDeviceCameraQualityAndRetention struct {
 	AudioRecordingEnabled          *bool  `json:"audioRecordingEnabled,omitempty"`          //
 	MotionBasedRetentionEnabled    *bool  `json:"motionBasedRetentionEnabled,omitempty"`    //
@@ -160,17 +163,21 @@ type ResponseCameraGetDeviceCameraWirelessProfilesIDs struct {
 type ResponseCameraUpdateDeviceCameraWirelessProfiles interface{}
 type ResponseCameraGetNetworkCameraQualityRetentionProfiles []ResponseItemCameraGetNetworkCameraQualityRetentionProfiles // Array of ResponseCameraGetNetworkCameraQualityRetentionProfiles
 type ResponseItemCameraGetNetworkCameraQualityRetentionProfiles struct {
-	AudioRecordingEnabled          *bool                                                                    `json:"audioRecordingEnabled,omitempty"`          //
-	CloudArchiveEnabled            *bool                                                                    `json:"cloudArchiveEnabled,omitempty"`            //
-	ID                             string                                                                   `json:"id,omitempty"`                             //
-	MaxRetentionDays               *int                                                                     `json:"maxRetentionDays,omitempty"`               //
-	MotionBasedRetentionEnabled    *bool                                                                    `json:"motionBasedRetentionEnabled,omitempty"`    //
-	MotionDetectorVersion          *int                                                                     `json:"motionDetectorVersion,omitempty"`          //
-	Name                           string                                                                   `json:"name,omitempty"`                           //
-	NetworkID                      string                                                                   `json:"networkId,omitempty"`                      //
-	RestrictedBandwidthModeEnabled *bool                                                                    `json:"restrictedBandwidthModeEnabled,omitempty"` //
-	ScheduleID                     string                                                                   `json:"scheduleId,omitempty"`                     //
-	VideoSettings                  *ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettings `json:"videoSettings,omitempty"`                  //
+	AudioRecordingEnabled          *bool                                                                     `json:"audioRecordingEnabled,omitempty"`          //
+	CloudArchiveEnabled            *bool                                                                     `json:"cloudArchiveEnabled,omitempty"`            //
+	ID                             string                                                                    `json:"id,omitempty"`                             //
+	MaxRetentionDays               *int                                                                      `json:"maxRetentionDays,omitempty"`               //
+	MotionBasedRetentionEnabled    *bool                                                                     `json:"motionBasedRetentionEnabled,omitempty"`    //
+	MotionDetectorVersion          *int                                                                      `json:"motionDetectorVersion,omitempty"`          //
+	Name                           string                                                                    `json:"name,omitempty"`                           //
+	NetworkID                      string                                                                    `json:"networkId,omitempty"`                      //
+	RestrictedBandwidthModeEnabled *bool                                                                     `json:"restrictedBandwidthModeEnabled,omitempty"` //
+	ScheduleID                     string                                                                    `json:"scheduleId,omitempty"`                     //
+	SmartRetention                 *ResponseItemCameraGetNetworkCameraQualityRetentionProfilesSmartRetention `json:"smartRetention,omitempty"`                 //
+	VideoSettings                  *ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettings  `json:"videoSettings,omitempty"`                  //
+}
+type ResponseItemCameraGetNetworkCameraQualityRetentionProfilesSmartRetention struct {
+	Enabled *bool `json:"enabled,omitempty"` //
 }
 type ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettings struct {
 	MV12MV22MV72 *ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettingsMV12MV22MV72 `json:"MV12/MV22/MV72,omitempty"` //
@@ -196,17 +203,21 @@ type ResponseItemCameraGetNetworkCameraQualityRetentionProfilesVideoSettingsMV32
 }
 type ResponseCameraCreateNetworkCameraQualityRetentionProfile interface{}
 type ResponseCameraGetNetworkCameraQualityRetentionProfile struct {
-	AudioRecordingEnabled          *bool                                                               `json:"audioRecordingEnabled,omitempty"`          //
-	CloudArchiveEnabled            *bool                                                               `json:"cloudArchiveEnabled,omitempty"`            //
-	ID                             string                                                              `json:"id,omitempty"`                             //
-	MaxRetentionDays               *int                                                                `json:"maxRetentionDays,omitempty"`               //
-	MotionBasedRetentionEnabled    *bool                                                               `json:"motionBasedRetentionEnabled,omitempty"`    //
-	MotionDetectorVersion          *int                                                                `json:"motionDetectorVersion,omitempty"`          //
-	Name                           string                                                              `json:"name,omitempty"`                           //
-	NetworkID                      string                                                              `json:"networkId,omitempty"`                      //
-	RestrictedBandwidthModeEnabled *bool                                                               `json:"restrictedBandwidthModeEnabled,omitempty"` //
-	ScheduleID                     string                                                              `json:"scheduleId,omitempty"`                     //
-	VideoSettings                  *ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettings `json:"videoSettings,omitempty"`                  //
+	AudioRecordingEnabled          *bool                                                                `json:"audioRecordingEnabled,omitempty"`          //
+	CloudArchiveEnabled            *bool                                                                `json:"cloudArchiveEnabled,omitempty"`            //
+	ID                             string                                                               `json:"id,omitempty"`                             //
+	MaxRetentionDays               *int                                                                 `json:"maxRetentionDays,omitempty"`               //
+	MotionBasedRetentionEnabled    *bool                                                                `json:"motionBasedRetentionEnabled,omitempty"`    //
+	MotionDetectorVersion          *int                                                                 `json:"motionDetectorVersion,omitempty"`          //
+	Name                           string                                                               `json:"name,omitempty"`                           //
+	NetworkID                      string                                                               `json:"networkId,omitempty"`                      //
+	RestrictedBandwidthModeEnabled *bool                                                                `json:"restrictedBandwidthModeEnabled,omitempty"` //
+	ScheduleID                     string                                                               `json:"scheduleId,omitempty"`                     //
+	SmartRetention                 *ResponseCameraGetNetworkCameraQualityRetentionProfileSmartRetention `json:"smartRetention,omitempty"`                 //
+	VideoSettings                  *ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettings  `json:"videoSettings,omitempty"`                  //
+}
+type ResponseCameraGetNetworkCameraQualityRetentionProfileSmartRetention struct {
+	Enabled *bool `json:"enabled,omitempty"` //
 }
 type ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettings struct {
 	MV12MV22MV72 *ResponseCameraGetNetworkCameraQualityRetentionProfileVideoSettingsMV12MV22MV72 `json:"MV12/MV22/MV72,omitempty"` //
@@ -238,39 +249,73 @@ type ResponseItemCameraGetNetworkCameraSchedules struct {
 }
 type ResponseCameraGetNetworkCameraWirelessProfiles []ResponseItemCameraGetNetworkCameraWirelessProfiles // Array of ResponseCameraGetNetworkCameraWirelessProfiles
 type ResponseItemCameraGetNetworkCameraWirelessProfiles struct {
-	AppliedDeviceCount *int                                                        `json:"appliedDeviceCount,omitempty"` //
-	ID                 string                                                      `json:"id,omitempty"`                 //
-	IDentity           *ResponseItemCameraGetNetworkCameraWirelessProfilesIDentity `json:"identity,omitempty"`           //
-	Name               string                                                      `json:"name,omitempty"`               //
-	SSID               *ResponseItemCameraGetNetworkCameraWirelessProfilesSSID     `json:"ssid,omitempty"`               //
+	AppliedDeviceCount *int                                                        `json:"appliedDeviceCount,omitempty"` // The count of the applied devices.
+	ID                 string                                                      `json:"id,omitempty"`                 // The ID of the camera wireless profile.
+	IDentity           *ResponseItemCameraGetNetworkCameraWirelessProfilesIDentity `json:"identity,omitempty"`           // The identity of the wireless profile. Required for creating wireless profiles in 8021x-radius auth mode.
+	Name               string                                                      `json:"name,omitempty"`               // The name of the camera wireless profile.
+	SSID               *ResponseItemCameraGetNetworkCameraWirelessProfilesSSID     `json:"ssid,omitempty"`               // The details of the SSID config.
 }
 type ResponseItemCameraGetNetworkCameraWirelessProfilesIDentity struct {
-	Password string `json:"password,omitempty"` //
-	Username string `json:"username,omitempty"` //
+	Password string `json:"password,omitempty"` // The password of the identity.
+	Username string `json:"username,omitempty"` // The username of the identity.
 }
 type ResponseItemCameraGetNetworkCameraWirelessProfilesSSID struct {
-	AuthMode       string `json:"authMode,omitempty"`       //
-	EncryptionMode string `json:"encryptionMode,omitempty"` //
-	Name           string `json:"name,omitempty"`           //
+	AuthMode       string `json:"authMode,omitempty"`       // The auth mode of the SSID. It can be set to ('psk', '8021x-radius').
+	EncryptionMode string `json:"encryptionMode,omitempty"` // The encryption mode of the SSID.
+	Name           string `json:"name,omitempty"`           // The name of the SSID.
+	Psk            string `json:"psk,omitempty"`            // The pre-shared key of the SSID, if mode is PSK
 }
-type ResponseCameraCreateNetworkCameraWirelessProfile interface{}
+type ResponseCameraCreateNetworkCameraWirelessProfile struct {
+	AppliedDeviceCount *int                                                      `json:"appliedDeviceCount,omitempty"` // The count of the applied devices.
+	ID                 string                                                    `json:"id,omitempty"`                 // The ID of the camera wireless profile.
+	IDentity           *ResponseCameraCreateNetworkCameraWirelessProfileIDentity `json:"identity,omitempty"`           // The identity of the wireless profile. Required for creating wireless profiles in 8021x-radius auth mode.
+	Name               string                                                    `json:"name,omitempty"`               // The name of the camera wireless profile.
+	SSID               *ResponseCameraCreateNetworkCameraWirelessProfileSSID     `json:"ssid,omitempty"`               // The details of the SSID config.
+}
+type ResponseCameraCreateNetworkCameraWirelessProfileIDentity struct {
+	Password string `json:"password,omitempty"` // The password of the identity.
+	Username string `json:"username,omitempty"` // The username of the identity.
+}
+type ResponseCameraCreateNetworkCameraWirelessProfileSSID struct {
+	AuthMode       string `json:"authMode,omitempty"`       // The auth mode of the SSID. It can be set to ('psk', '8021x-radius').
+	EncryptionMode string `json:"encryptionMode,omitempty"` // The encryption mode of the SSID.
+	Name           string `json:"name,omitempty"`           // The name of the SSID.
+	Psk            string `json:"psk,omitempty"`            // The pre-shared key of the SSID, if mode is PSK
+}
 type ResponseCameraGetNetworkCameraWirelessProfile struct {
-	AppliedDeviceCount *int                                                   `json:"appliedDeviceCount,omitempty"` //
-	ID                 string                                                 `json:"id,omitempty"`                 //
-	IDentity           *ResponseCameraGetNetworkCameraWirelessProfileIDentity `json:"identity,omitempty"`           //
-	Name               string                                                 `json:"name,omitempty"`               //
-	SSID               *ResponseCameraGetNetworkCameraWirelessProfileSSID     `json:"ssid,omitempty"`               //
+	AppliedDeviceCount *int                                                   `json:"appliedDeviceCount,omitempty"` // The count of the applied devices.
+	ID                 string                                                 `json:"id,omitempty"`                 // The ID of the camera wireless profile.
+	IDentity           *ResponseCameraGetNetworkCameraWirelessProfileIDentity `json:"identity,omitempty"`           // The identity of the wireless profile. Required for creating wireless profiles in 8021x-radius auth mode.
+	Name               string                                                 `json:"name,omitempty"`               // The name of the camera wireless profile.
+	SSID               *ResponseCameraGetNetworkCameraWirelessProfileSSID     `json:"ssid,omitempty"`               // The details of the SSID config.
 }
 type ResponseCameraGetNetworkCameraWirelessProfileIDentity struct {
-	Password string `json:"password,omitempty"` //
-	Username string `json:"username,omitempty"` //
+	Password string `json:"password,omitempty"` // The password of the identity.
+	Username string `json:"username,omitempty"` // The username of the identity.
 }
 type ResponseCameraGetNetworkCameraWirelessProfileSSID struct {
-	AuthMode       string `json:"authMode,omitempty"`       //
-	EncryptionMode string `json:"encryptionMode,omitempty"` //
-	Name           string `json:"name,omitempty"`           //
+	AuthMode       string `json:"authMode,omitempty"`       // The auth mode of the SSID. It can be set to ('psk', '8021x-radius').
+	EncryptionMode string `json:"encryptionMode,omitempty"` // The encryption mode of the SSID.
+	Name           string `json:"name,omitempty"`           // The name of the SSID.
+	Psk            string `json:"psk,omitempty"`            // The pre-shared key of the SSID, if mode is PSK
 }
-type ResponseCameraUpdateNetworkCameraWirelessProfile interface{}
+type ResponseCameraUpdateNetworkCameraWirelessProfile struct {
+	AppliedDeviceCount *int                                                      `json:"appliedDeviceCount,omitempty"` // The count of the applied devices.
+	ID                 string                                                    `json:"id,omitempty"`                 // The ID of the camera wireless profile.
+	IDentity           *ResponseCameraUpdateNetworkCameraWirelessProfileIDentity `json:"identity,omitempty"`           // The identity of the wireless profile. Required for creating wireless profiles in 8021x-radius auth mode.
+	Name               string                                                    `json:"name,omitempty"`               // The name of the camera wireless profile.
+	SSID               *ResponseCameraUpdateNetworkCameraWirelessProfileSSID     `json:"ssid,omitempty"`               // The details of the SSID config.
+}
+type ResponseCameraUpdateNetworkCameraWirelessProfileIDentity struct {
+	Password string `json:"password,omitempty"` // The password of the identity.
+	Username string `json:"username,omitempty"` // The username of the identity.
+}
+type ResponseCameraUpdateNetworkCameraWirelessProfileSSID struct {
+	AuthMode       string `json:"authMode,omitempty"`       // The auth mode of the SSID. It can be set to ('psk', '8021x-radius').
+	EncryptionMode string `json:"encryptionMode,omitempty"` // The encryption mode of the SSID.
+	Name           string `json:"name,omitempty"`           // The name of the SSID.
+	Psk            string `json:"psk,omitempty"`            // The pre-shared key of the SSID, if mode is PSK
+}
 type ResponseCameraGetOrganizationCameraBoundariesAreasByDevice []ResponseItemCameraGetOrganizationCameraBoundariesAreasByDevice // Array of ResponseCameraGetOrganizationCameraBoundariesAreasByDevice
 type ResponseItemCameraGetOrganizationCameraBoundariesAreasByDevice struct {
 	Boundaries *ResponseItemCameraGetOrganizationCameraBoundariesAreasByDeviceBoundaries `json:"boundaries,omitempty"` // Configured area boundaries of the camera
@@ -472,28 +517,42 @@ type RequestCameraUpdateDeviceCameraWirelessProfilesIDs struct {
 	Secondary string `json:"secondary,omitempty"` // The id of the secondary wireless profile
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfile struct {
-	AudioRecordingEnabled          *bool                                                                 `json:"audioRecordingEnabled,omitempty"`          // Whether or not to record audio. Can be either true or false. Defaults to false.
-	CloudArchiveEnabled            *bool                                                                 `json:"cloudArchiveEnabled,omitempty"`            // Create redundant video backup using Cloud Archive. Can be either true or false. Defaults to false.
-	MaxRetentionDays               *int                                                                  `json:"maxRetentionDays,omitempty"`               // The maximum number of days for which the data will be stored, or 'null' to keep data until storage space runs out. If the former, it can be one of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 30, 60, 90] days.
-	MotionBasedRetentionEnabled    *bool                                                                 `json:"motionBasedRetentionEnabled,omitempty"`    // Deletes footage older than 3 days in which no motion was detected. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
-	MotionDetectorVersion          *int                                                                  `json:"motionDetectorVersion,omitempty"`          // The version of the motion detector that will be used by the camera. Only applies to Gen 2 cameras. Defaults to v2.
-	Name                           string                                                                `json:"name,omitempty"`                           // The name of the new profile. Must be unique. This parameter is required.
-	RestrictedBandwidthModeEnabled *bool                                                                 `json:"restrictedBandwidthModeEnabled,omitempty"` // Disable features that require additional bandwidth such as Motion Recap. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
-	ScheduleID                     string                                                                `json:"scheduleId,omitempty"`                     // Schedule for which this camera will record video, or 'null' to always record.
-	VideoSettings                  *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettings `json:"videoSettings,omitempty"`                  // Video quality and resolution settings for all the camera models.
+	AudioRecordingEnabled          *bool                                                                  `json:"audioRecordingEnabled,omitempty"`          // Whether or not to record audio. Can be either true or false. Defaults to false.
+	CloudArchiveEnabled            *bool                                                                  `json:"cloudArchiveEnabled,omitempty"`            // Create redundant video backup using Cloud Archive. Can be either true or false. Defaults to false.
+	MaxRetentionDays               *int                                                                   `json:"maxRetentionDays,omitempty"`               // The maximum number of days for which the data will be stored, or 'null' to keep data until storage space runs out. If the former, it can be in the range of one to ninety days.
+	MotionBasedRetentionEnabled    *bool                                                                  `json:"motionBasedRetentionEnabled,omitempty"`    // Deletes footage older than 3 days in which no motion was detected. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
+	MotionDetectorVersion          *int                                                                   `json:"motionDetectorVersion,omitempty"`          // The version of the motion detector that will be used by the camera. Only applies to Gen 2 cameras. Defaults to v2.
+	Name                           string                                                                 `json:"name,omitempty"`                           // The name of the new profile. Must be unique. This parameter is required.
+	RestrictedBandwidthModeEnabled *bool                                                                  `json:"restrictedBandwidthModeEnabled,omitempty"` // Disable features that require additional bandwidth such as Motion Recap. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
+	ScheduleID                     string                                                                 `json:"scheduleId,omitempty"`                     // Schedule for which this camera will record video, or 'null' to always record.
+	SmartRetention                 *RequestCameraCreateNetworkCameraQualityRetentionProfileSmartRetention `json:"smartRetention,omitempty"`                 // Smart Retention records footage in two qualities and intelligently retains higher quality when motion, people or vehicles are detected.
+	VideoSettings                  *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettings  `json:"videoSettings,omitempty"`                  // Video quality and resolution settings for all the camera models.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileSmartRetention struct {
+	Enabled *bool `json:"enabled,omitempty"` // Boolean indicating if Smart Retention is enabled(true) or disabled(false).
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettings struct {
 	MV12MV22MV72 *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV12MV22MV72 `json:"MV12/MV22/MV72,omitempty"` // Quality and resolution for MV12/MV22/MV72 camera models.
 	MV12WE       *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV12WE       `json:"MV12WE,omitempty"`         // Quality and resolution for MV12WE camera models.
 	MV13         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV13         `json:"MV13,omitempty"`           // Quality and resolution for MV13 camera models.
+	MV13M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV13M        `json:"MV13M,omitempty"`          // Quality and resolution for MV13M camera models.
 	MV21MV71     *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71     `json:"MV21/MV71,omitempty"`      // Quality and resolution for MV21/MV71 camera models.
 	MV22XMV72X   *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV72X   `json:"MV22X/MV72X,omitempty"`    // Quality and resolution for MV22X/MV72X camera models.
+	MV23         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23         `json:"MV23,omitempty"`           // Quality and resolution for MV23 camera models.
+	MV23M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23M        `json:"MV23M,omitempty"`          // Quality and resolution for MV23M camera models.
+	MV23X        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23X        `json:"MV23X,omitempty"`          // Quality and resolution for MV23X camera models.
 	MV32         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV32         `json:"MV32,omitempty"`           // Quality and resolution for MV32 camera models.
 	MV33         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV33         `json:"MV33,omitempty"`           // Quality and resolution for MV33 camera models.
+	MV33M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV33M        `json:"MV33M,omitempty"`          // Quality and resolution for MV33M camera models.
 	MV52         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV52         `json:"MV52,omitempty"`           // Quality and resolution for MV52 camera models.
 	MV63         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63         `json:"MV63,omitempty"`           // Quality and resolution for MV63 camera models.
+	MV63M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63M        `json:"MV63M,omitempty"`          // Quality and resolution for MV63M camera models.
 	MV63X        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63X        `json:"MV63X,omitempty"`          // Quality and resolution for MV63X camera models.
+	MV73         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73         `json:"MV73,omitempty"`           // Quality and resolution for MV73 camera models.
+	MV73M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73M        `json:"MV73M,omitempty"`          // Quality and resolution for MV73M camera models.
+	MV73X        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73X        `json:"MV73X,omitempty"`          // Quality and resolution for MV73X camera models.
 	MV93         *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93         `json:"MV93,omitempty"`           // Quality and resolution for MV93 camera models.
+	MV93M        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93M        `json:"MV93M,omitempty"`          // Quality and resolution for MV93M camera models.
 	MV93X        *RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93X        `json:"MV93X,omitempty"`          // Quality and resolution for MV93X camera models.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV12MV22MV72 struct {
@@ -508,6 +567,10 @@ type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV13 st
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV13M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720'.
@@ -515,6 +578,18 @@ type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV7
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV72X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720', '1920x1080' or '2688x1512'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23 struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV23X struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV32 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -524,49 +599,87 @@ type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV33 st
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV33M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
+}
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV52 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720', '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080' or '2688x1512'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV63X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73 struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV73X struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
+}
+type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
 type RequestCameraCreateNetworkCameraQualityRetentionProfileVideoSettingsMV93X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfile struct {
-	AudioRecordingEnabled          *bool                                                                 `json:"audioRecordingEnabled,omitempty"`          // Whether or not to record audio. Can be either true or false. Defaults to false.
-	CloudArchiveEnabled            *bool                                                                 `json:"cloudArchiveEnabled,omitempty"`            // Create redundant video backup using Cloud Archive. Can be either true or false. Defaults to false.
-	MaxRetentionDays               *int                                                                  `json:"maxRetentionDays,omitempty"`               // The maximum number of days for which the data will be stored, or 'null' to keep data until storage space runs out. If the former, it can be one of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 30, 60, 90] days.
-	MotionBasedRetentionEnabled    *bool                                                                 `json:"motionBasedRetentionEnabled,omitempty"`    // Deletes footage older than 3 days in which no motion was detected. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
-	MotionDetectorVersion          *int                                                                  `json:"motionDetectorVersion,omitempty"`          // The version of the motion detector that will be used by the camera. Only applies to Gen 2 cameras. Defaults to v2.
-	Name                           string                                                                `json:"name,omitempty"`                           // The name of the new profile. Must be unique.
-	RestrictedBandwidthModeEnabled *bool                                                                 `json:"restrictedBandwidthModeEnabled,omitempty"` // Disable features that require additional bandwidth such as Motion Recap. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
-	ScheduleID                     string                                                                `json:"scheduleId,omitempty"`                     // Schedule for which this camera will record video, or 'null' to always record.
-	VideoSettings                  *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettings `json:"videoSettings,omitempty"`                  // Video quality and resolution settings for all the camera models.
+	AudioRecordingEnabled          *bool                                                                  `json:"audioRecordingEnabled,omitempty"`          // Whether or not to record audio. Can be either true or false. Defaults to false.
+	CloudArchiveEnabled            *bool                                                                  `json:"cloudArchiveEnabled,omitempty"`            // Create redundant video backup using Cloud Archive. Can be either true or false. Defaults to false.
+	MaxRetentionDays               *int                                                                   `json:"maxRetentionDays,omitempty"`               // The maximum number of days for which the data will be stored, or 'null' to keep data until storage space runs out. If the former, it can be in the range of one to ninety days.
+	MotionBasedRetentionEnabled    *bool                                                                  `json:"motionBasedRetentionEnabled,omitempty"`    // Deletes footage older than 3 days in which no motion was detected. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
+	MotionDetectorVersion          *int                                                                   `json:"motionDetectorVersion,omitempty"`          // The version of the motion detector that will be used by the camera. Only applies to Gen 2 cameras. Defaults to v2.
+	Name                           string                                                                 `json:"name,omitempty"`                           // The name of the new profile. Must be unique.
+	RestrictedBandwidthModeEnabled *bool                                                                  `json:"restrictedBandwidthModeEnabled,omitempty"` // Disable features that require additional bandwidth such as Motion Recap. Can be either true or false. Defaults to false. This setting does not apply to MV2 cameras.
+	ScheduleID                     string                                                                 `json:"scheduleId,omitempty"`                     // Schedule for which this camera will record video, or 'null' to always record.
+	SmartRetention                 *RequestCameraUpdateNetworkCameraQualityRetentionProfileSmartRetention `json:"smartRetention,omitempty"`                 // Smart Retention records footage in two qualities and intelligently retains higher quality when motion, people or vehicles are detected.
+	VideoSettings                  *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettings  `json:"videoSettings,omitempty"`                  // Video quality and resolution settings for all the camera models.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileSmartRetention struct {
+	Enabled *bool `json:"enabled,omitempty"` // Boolean indicating if Smart Retention is enabled(true) or disabled(false).
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettings struct {
 	MV12MV22MV72 *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV12MV22MV72 `json:"MV12/MV22/MV72,omitempty"` // Quality and resolution for MV12/MV22/MV72 camera models.
 	MV12WE       *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV12WE       `json:"MV12WE,omitempty"`         // Quality and resolution for MV12WE camera models.
 	MV13         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV13         `json:"MV13,omitempty"`           // Quality and resolution for MV13 camera models.
+	MV13M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV13M        `json:"MV13M,omitempty"`          // Quality and resolution for MV13M camera models.
 	MV21MV71     *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71     `json:"MV21/MV71,omitempty"`      // Quality and resolution for MV21/MV71 camera models.
 	MV22XMV72X   *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV72X   `json:"MV22X/MV72X,omitempty"`    // Quality and resolution for MV22X/MV72X camera models.
+	MV23         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23         `json:"MV23,omitempty"`           // Quality and resolution for MV23 camera models.
+	MV23M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23M        `json:"MV23M,omitempty"`          // Quality and resolution for MV23M camera models.
+	MV23X        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23X        `json:"MV23X,omitempty"`          // Quality and resolution for MV23X camera models.
 	MV32         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV32         `json:"MV32,omitempty"`           // Quality and resolution for MV32 camera models.
 	MV33         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV33         `json:"MV33,omitempty"`           // Quality and resolution for MV33 camera models.
+	MV33M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV33M        `json:"MV33M,omitempty"`          // Quality and resolution for MV33M camera models.
 	MV52         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV52         `json:"MV52,omitempty"`           // Quality and resolution for MV52 camera models.
 	MV63         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63         `json:"MV63,omitempty"`           // Quality and resolution for MV63 camera models.
+	MV63M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63M        `json:"MV63M,omitempty"`          // Quality and resolution for MV63M camera models.
 	MV63X        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63X        `json:"MV63X,omitempty"`          // Quality and resolution for MV63X camera models.
+	MV73         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73         `json:"MV73,omitempty"`           // Quality and resolution for MV73 camera models.
+	MV73M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73M        `json:"MV73M,omitempty"`          // Quality and resolution for MV73M camera models.
+	MV73X        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73X        `json:"MV73X,omitempty"`          // Quality and resolution for MV73X camera models.
 	MV93         *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93         `json:"MV93,omitempty"`           // Quality and resolution for MV93 camera models.
+	MV93M        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93M        `json:"MV93M,omitempty"`          // Quality and resolution for MV93M camera models.
 	MV93X        *RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93X        `json:"MV93X,omitempty"`          // Quality and resolution for MV93X camera models.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV12MV22MV72 struct {
@@ -581,6 +694,10 @@ type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV13 st
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV13M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV71 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720'.
@@ -588,6 +705,18 @@ type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV21MV7
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV22XMV72X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720', '1920x1080' or '2688x1512'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23 struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV23X struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV32 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -597,21 +726,45 @@ type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV33 st
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV33M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
+}
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV52 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1280x720', '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080' or '2688x1512'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV63X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
 	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
 }
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73 struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV73X struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1920x1080', '2688x1512' or '3840x2160'.
+}
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93 struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
-	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080' or '2112x2112'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
+}
+type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93M struct {
+	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
+	Resolution string `json:"resolution,omitempty"` // Resolution of the camera. Can be one of '1080x1080', '2112x2112' or '2880x2880'.
 }
 type RequestCameraUpdateNetworkCameraQualityRetentionProfileVideoSettingsMV93X struct {
 	Quality    string `json:"quality,omitempty"`    // Quality of the camera. Can be one of 'Standard', 'Enhanced' or 'High'.
@@ -697,8 +850,8 @@ type RequestCameraUpdateOrganizationCameraRoleAppliedOrgWide struct {
 	PermissionScopeID string `json:"permissionScopeId,omitempty"` // Permission scope id
 }
 
-//GetDeviceCameraAnalyticsLive Returns live state from camera of analytics zones
-/* Returns live state from camera of analytics zones
+//GetDeviceCameraAnalyticsLive Returns live state from camera analytics zones
+/* Returns live state from camera analytics zones
 
 @param serial serial path parameter.
 
@@ -1632,7 +1785,7 @@ func (s *CameraService) GetOrganizationCameraRole(organizationID string, roleID 
 
 */
 
-func (s *CameraService) GenerateDeviceCameraSnapshot(serial string, requestCameraGenerateDeviceCameraSnapshot *RequestCameraGenerateDeviceCameraSnapshot) (*resty.Response, error) {
+func (s *CameraService) GenerateDeviceCameraSnapshot(serial string, requestCameraGenerateDeviceCameraSnapshot *RequestCameraGenerateDeviceCameraSnapshot) (*ResponseCameraGenerateDeviceCameraSnapshot, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/generateSnapshot"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -1641,20 +1794,21 @@ func (s *CameraService) GenerateDeviceCameraSnapshot(serial string, requestCamer
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraGenerateDeviceCameraSnapshot).
-		// SetResult(&ResponseCameraGenerateDeviceCameraSnapshot{}).
+		SetResult(&ResponseCameraGenerateDeviceCameraSnapshot{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GenerateDeviceCameraSnapshot")
+		return nil, response, fmt.Errorf("error with operation GenerateDeviceCameraSnapshot")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCameraGenerateDeviceCameraSnapshot)
+	return result, response, err
 
 }
 
@@ -1700,7 +1854,7 @@ func (s *CameraService) CreateNetworkCameraQualityRetentionProfile(networkID str
 
 */
 
-func (s *CameraService) CreateNetworkCameraWirelessProfile(networkID string, requestCameraCreateNetworkCameraWirelessProfile *RequestCameraCreateNetworkCameraWirelessProfile) (*resty.Response, error) {
+func (s *CameraService) CreateNetworkCameraWirelessProfile(networkID string, requestCameraCreateNetworkCameraWirelessProfile *RequestCameraCreateNetworkCameraWirelessProfile) (*ResponseCameraCreateNetworkCameraWirelessProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/wirelessProfiles"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1709,20 +1863,21 @@ func (s *CameraService) CreateNetworkCameraWirelessProfile(networkID string, req
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraCreateNetworkCameraWirelessProfile).
-		// SetResult(&ResponseCameraCreateNetworkCameraWirelessProfile{}).
+		SetResult(&ResponseCameraCreateNetworkCameraWirelessProfile{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateNetworkCameraWirelessProfile")
+		return nil, response, fmt.Errorf("error with operation CreateNetworkCameraWirelessProfile")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCameraCreateNetworkCameraWirelessProfile)
+	return result, response, err
 
 }
 
@@ -1987,7 +2142,7 @@ func (s *CameraService) UpdateNetworkCameraQualityRetentionProfile(networkID str
 @param networkID networkId path parameter. Network ID
 @param wirelessProfileID wirelessProfileId path parameter. Wireless profile ID
 */
-func (s *CameraService) UpdateNetworkCameraWirelessProfile(networkID string, wirelessProfileID string, requestCameraUpdateNetworkCameraWirelessProfile *RequestCameraUpdateNetworkCameraWirelessProfile) (*resty.Response, error) {
+func (s *CameraService) UpdateNetworkCameraWirelessProfile(networkID string, wirelessProfileID string, requestCameraUpdateNetworkCameraWirelessProfile *RequestCameraUpdateNetworkCameraWirelessProfile) (*ResponseCameraUpdateNetworkCameraWirelessProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/wirelessProfiles/{wirelessProfileId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -1997,19 +2152,21 @@ func (s *CameraService) UpdateNetworkCameraWirelessProfile(networkID string, wir
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCameraUpdateNetworkCameraWirelessProfile).
+		SetResult(&ResponseCameraUpdateNetworkCameraWirelessProfile{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkCameraWirelessProfile")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkCameraWirelessProfile")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCameraUpdateNetworkCameraWirelessProfile)
+	return result, response, err
 
 }
 

--- a/sdk/cellular_gateway.go
+++ b/sdk/cellular_gateway.go
@@ -10,6 +10,18 @@ import (
 
 type CellularGatewayService service
 
+type GetOrganizationCellularGatewayEsimsInventoryQueryParams struct {
+	Eids []string `url:"eids[],omitempty"` //Optional parameter to filter the results by EID.
+}
+type GetOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams struct {
+	AccountIDs []string `url:"accountIds[],omitempty"` //Optional parameter to filter the results by service provider account IDs.
+}
+type GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams struct {
+	AccountIDs []string `url:"accountIds[],omitempty"` //Account IDs that communication plans will be fetched for
+}
+type GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams struct {
+	AccountIDs []string `url:"accountIds[],omitempty"` //Account IDs that rate plans will be fetched for
+}
 type GetOrganizationCellularGatewayUplinkStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -54,27 +66,45 @@ type ResponseCellularGatewayUpdateDeviceCellularGatewayLanReservedIPRanges struc
 	Start   string `json:"start,omitempty"`   // Starting IP included in the reserved range of IPs
 }
 type ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRules struct {
-	Rules *[]ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` //
+	Rules *[]ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
 }
 type ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules struct {
-	Access     string `json:"access,omitempty"`     //
-	LanIP      string `json:"lanIp,omitempty"`      //
-	LocalPort  string `json:"localPort,omitempty"`  //
-	Name       string `json:"name,omitempty"`       //
-	Protocol   string `json:"protocol,omitempty"`   //
-	PublicPort string `json:"publicPort,omitempty"` //
-	Uplink     string `json:"uplink,omitempty"`     //
+	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
+	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
+	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
+	Name       string   `json:"name,omitempty"`       // A descriptive name for the rule
+	Protocol   string   `json:"protocol,omitempty"`   // TCP or UDP
+	PublicPort string   `json:"publicPort,omitempty"` // A port or port ranges that will be forwarded to the host on the LAN
 }
-type ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules interface{}
+type ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules struct {
+	Rules *[]ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
+}
+type ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules struct {
+	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
+	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
+	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
+	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
+	Name       string   `json:"name,omitempty"`       // A descriptive name for the rule
+	Protocol   string   `json:"protocol,omitempty"`   // TCP or UDP
+	PublicPort string   `json:"publicPort,omitempty"` // A port or port ranges that will be forwarded to the host on the LAN
+}
 type ResponseCellularGatewayGetNetworkCellularGatewayConnectivityMonitoringDestinations struct {
-	Destinations *[]ResponseCellularGatewayGetNetworkCellularGatewayConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` //
+	Destinations *[]ResponseCellularGatewayGetNetworkCellularGatewayConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` // The list of connectivity monitoring destinations
 }
 type ResponseCellularGatewayGetNetworkCellularGatewayConnectivityMonitoringDestinationsDestinations struct {
-	Default     *bool  `json:"default,omitempty"`     //
-	Description string `json:"description,omitempty"` //
-	IP          string `json:"ip,omitempty"`          //
+	Default     *bool  `json:"default,omitempty"`     // Boolean indicating whether this is the default testing destination (true) or not (false). Defaults to false. Only one default is allowed
+	Description string `json:"description,omitempty"` // Description of the testing destination. Optional, defaults to an empty string
+	IP          string `json:"ip,omitempty"`          // The IP address to test connectivity with
 }
-type ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations interface{}
+type ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations struct {
+	Destinations *[]ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinationsDestinations `json:"destinations,omitempty"` // The list of connectivity monitoring destinations
+}
+type ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinationsDestinations struct {
+	Default     *bool  `json:"default,omitempty"`     // Boolean indicating whether this is the default testing destination (true) or not (false). Defaults to false. Only one default is allowed
+	Description string `json:"description,omitempty"` // Description of the testing destination. Optional, defaults to an empty string
+	IP          string `json:"ip,omitempty"`          // The IP address to test connectivity with
+}
 type ResponseCellularGatewayGetNetworkCellularGatewayDhcp struct {
 	DhcpLeaseTime        string   `json:"dhcpLeaseTime,omitempty"`        // DHCP Lease time for all MG in the network.
 	DNSCustomNameservers []string `json:"dnsCustomNameservers,omitempty"` // List of fixed IPs representing the the DNS Name servers when the mode is 'custom'.
@@ -86,18 +116,29 @@ type ResponseCellularGatewayUpdateNetworkCellularGatewayDhcp struct {
 	DNSNameservers       string   `json:"dnsNameservers,omitempty"`       // DNS name servers mode for all MG in the network.
 }
 type ResponseCellularGatewayGetNetworkCellularGatewaySubnetPool struct {
-	Cidr           string                                                               `json:"cidr,omitempty"`           //
-	DeploymentMode string                                                               `json:"deploymentMode,omitempty"` //
-	Mask           *int                                                                 `json:"mask,omitempty"`           //
-	Subnets        *[]ResponseCellularGatewayGetNetworkCellularGatewaySubnetPoolSubnets `json:"subnets,omitempty"`        //
+	Cidr           string                                                               `json:"cidr,omitempty"`           // CIDR of the pool of subnets. Each MG in this network will automatically pick a subnet from this pool.
+	DeploymentMode string                                                               `json:"deploymentMode,omitempty"` // Deployment mode for the cellular gateways in the network. (Passthrough/Routed)
+	Mask           *int                                                                 `json:"mask,omitempty"`           // Mask used for the subnet of all MGs in  this network.
+	Subnets        *[]ResponseCellularGatewayGetNetworkCellularGatewaySubnetPoolSubnets `json:"subnets,omitempty"`        // List of subnets of all MGs in this network.
 }
 type ResponseCellularGatewayGetNetworkCellularGatewaySubnetPoolSubnets struct {
-	ApplianceIP string `json:"applianceIp,omitempty"` //
-	Name        string `json:"name,omitempty"`        //
-	Serial      string `json:"serial,omitempty"`      //
-	Subnet      string `json:"subnet,omitempty"`      //
+	ApplianceIP string `json:"applianceIp,omitempty"` // Appliance IP of the MG device.
+	Name        string `json:"name,omitempty"`        // Name of the MG.
+	Serial      string `json:"serial,omitempty"`      // Serial Number of the MG.
+	Subnet      string `json:"subnet,omitempty"`      // Subnet of MG device.
 }
-type ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool interface{}
+type ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool struct {
+	Cidr           string                                                                  `json:"cidr,omitempty"`           // CIDR of the pool of subnets. Each MG in this network will automatically pick a subnet from this pool.
+	DeploymentMode string                                                                  `json:"deploymentMode,omitempty"` // Deployment mode for the cellular gateways in the network. (Passthrough/Routed)
+	Mask           *int                                                                    `json:"mask,omitempty"`           // Mask used for the subnet of all MGs in  this network.
+	Subnets        *[]ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPoolSubnets `json:"subnets,omitempty"`        // List of subnets of all MGs in this network.
+}
+type ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPoolSubnets struct {
+	ApplianceIP string `json:"applianceIp,omitempty"` // Appliance IP of the MG device.
+	Name        string `json:"name,omitempty"`        // Name of the MG.
+	Serial      string `json:"serial,omitempty"`      // Serial Number of the MG.
+	Subnet      string `json:"subnet,omitempty"`      // Subnet of MG device.
+}
 type ResponseCellularGatewayGetNetworkCellularGatewayUplink struct {
 	BandwidthLimits *ResponseCellularGatewayGetNetworkCellularGatewayUplinkBandwidthLimits `json:"bandwidthLimits,omitempty"` // The bandwidth settings for the 'cellular' uplink
 }
@@ -111,6 +152,219 @@ type ResponseCellularGatewayUpdateNetworkCellularGatewayUplink struct {
 type ResponseCellularGatewayUpdateNetworkCellularGatewayUplinkBandwidthLimits struct {
 	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). 'null' indicates no limit.
 	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). 'null' indicates no limit.
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory []ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventory // Array of ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventory struct {
+	Items *[]ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItems `json:"items,omitempty"` // List of eSIM Devices
+	Meta  *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItems struct {
+	Active        *bool                                                                                   `json:"active,omitempty"`        // Whether eSIM is currently active SIM on Device
+	Device        *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsDevice     `json:"device,omitempty"`        // Meraki Device properties
+	Eid           string                                                                                  `json:"eid,omitempty"`           // eSIM EID
+	LastUpdatedAt string                                                                                  `json:"lastUpdatedAt,omitempty"` // Last update of eSIM
+	Network       *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsNetwork    `json:"network,omitempty"`       // Meraki Network properties
+	Profiles      *[]ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfiles `json:"profiles,omitempty"`      // eSIM Profile Information
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsDevice struct {
+	Model  string `json:"model,omitempty"`  // Device model
+	Name   string `json:"name,omitempty"`   // Device name
+	Serial string `json:"serial,omitempty"` // Device serial number
+	Status string `json:"status,omitempty"` // Device status
+	URL    string `json:"url,omitempty"`    // Device URL
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID for this eSIM
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfiles struct {
+	CustomApns      []string                                                                                             `json:"customApns,omitempty"`      // Available custom APNs for the profile
+	Iccid           string                                                                                               `json:"iccid,omitempty"`           // eSIM profile ID
+	ServiceProvider *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfilesServiceProvider `json:"serviceProvider,omitempty"` // Service Provider information
+	Status          string                                                                                               `json:"status,omitempty"`          // eSIM profile status
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfilesServiceProvider struct {
+	Name  string                                                                                                      `json:"name,omitempty"`  // Service Provider name
+	Plans *[]ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfilesServiceProviderPlans `json:"plans,omitempty"` // Plans currently active on the eSIM
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryItemsProfilesServiceProviderPlans struct {
+	Name string `json:"name,omitempty"` // Plan name
+	Type string `json:"type,omitempty"` // Plan type (communication, rate)
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMeta struct {
+	Counts *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMetaCounts `json:"counts,omitempty"` // Counts of involved entities
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMetaCounts struct {
+	Items *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMetaCountsItems `json:"items,omitempty"` // Count of eSIM Devices available
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsInventoryMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of eSIM Devices
+	Total     *int `json:"total,omitempty"`     // Total number of eSIM Devices
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory struct {
+	Active        *bool                                                                             `json:"active,omitempty"`        // Whether eSIM is currently active SIM on Device
+	Device        *ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryDevice     `json:"device,omitempty"`        // Meraki Device properties
+	Eid           string                                                                            `json:"eid,omitempty"`           // eSIM EID
+	LastUpdatedAt string                                                                            `json:"lastUpdatedAt,omitempty"` // Last update of eSIM
+	Network       *ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryNetwork    `json:"network,omitempty"`       // Meraki Network properties
+	Profiles      *[]ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfiles `json:"profiles,omitempty"`      // eSIM Profile Information
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryDevice struct {
+	Model  string `json:"model,omitempty"`  // Device model
+	Name   string `json:"name,omitempty"`   // Device name
+	Serial string `json:"serial,omitempty"` // Device serial number
+	Status string `json:"status,omitempty"` // Device status
+	URL    string `json:"url,omitempty"`    // Device URL
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryNetwork struct {
+	ID string `json:"id,omitempty"` // Network ID for this eSIM
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfiles struct {
+	CustomApns      []string                                                                                       `json:"customApns,omitempty"`      // Available custom APNs for the profile
+	Iccid           string                                                                                         `json:"iccid,omitempty"`           // eSIM profile ID
+	ServiceProvider *ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfilesServiceProvider `json:"serviceProvider,omitempty"` // Service Provider information
+	Status          string                                                                                         `json:"status,omitempty"`          // eSIM profile status
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfilesServiceProvider struct {
+	Name  string                                                                                                `json:"name,omitempty"`  // Service Provider name
+	Plans *[]ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfilesServiceProviderPlans `json:"plans,omitempty"` // Plans currently active on the eSIM
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventoryProfilesServiceProviderPlans struct {
+	Name string `json:"name,omitempty"` // Plan name
+	Type string `json:"type,omitempty"` // Plan type (communication, rate)
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProviders struct {
+	Items *[]ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItems `json:"items,omitempty"` // List Cellular Service Providers
+	Meta  *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItems struct {
+	IsBootstrap *bool                                                                                 `json:"isBootstrap,omitempty"` // Indicates if service provider is the bootstrap provider.
+	Logo        *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItemsLogo  `json:"logo,omitempty"`        // Service Provider logo data.
+	Name        string                                                                                `json:"name,omitempty"`        // Service provider name.
+	Terms       *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItemsTerms `json:"terms,omitempty"`       // Service provider terms.
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItemsLogo struct {
+	URL string `json:"url,omitempty"` // URL of service provider's logo.
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersItemsTerms struct {
+	Content string `json:"content,omitempty"` // URL of service provider's terms.
+	Name    string `json:"name,omitempty"`    // Label for service provider's terms.
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMeta struct {
+	Counts *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMetaCounts `json:"counts,omitempty"` // Counts of involved entities
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMetaCounts struct {
+	Items *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMetaCountsItems `json:"items,omitempty"` // Service Providers available
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of Service Providers
+	Total     *int `json:"total,omitempty"`     // Total number of Service Providers
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts // Array of ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts struct {
+	Items *[]ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItems `json:"items,omitempty"` // IList of Cellular Service Provider Accounts
+	Meta  *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItems struct {
+	AccountID       string                                                                                                      `json:"accountId,omitempty"`       // Service provider account ID
+	LastUpdatedAt   string                                                                                                      `json:"lastUpdatedAt,omitempty"`   // Last updated at
+	ServiceProvider *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItemsServiceProvider `json:"serviceProvider,omitempty"` // Service provider data.
+	Title           string                                                                                                      `json:"title,omitempty"`           // Service provider account name
+	Username        string                                                                                                      `json:"username,omitempty"`        // Service provider account username
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItemsServiceProvider struct {
+	Logo *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItemsServiceProviderLogo `json:"logo,omitempty"` // Service provider logo data.
+	Name string                                                                                                          `json:"name,omitempty"` // Name of the service provider.
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItemsServiceProviderLogo struct {
+	URL string `json:"url,omitempty"` // Service Provider logo url.
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMeta struct {
+	Counts *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMetaCounts `json:"counts,omitempty"` // Counts of involved entities
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMetaCounts struct {
+	Items *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMetaCountsItems `json:"items,omitempty"` // Count of Cellular Service Providers available
+}
+type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of Cellular Service Providers
+	Total     *int `json:"total,omitempty"`     // Total number of Cellular Service Providers
+}
+type ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount struct {
+	AccountID       string                                                                                               `json:"accountId,omitempty"`       // Service provider account ID
+	LastUpdatedAt   string                                                                                               `json:"lastUpdatedAt,omitempty"`   // Last updated at
+	ServiceProvider *ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider `json:"serviceProvider,omitempty"` // Service provider data.
+	Title           string                                                                                               `json:"title,omitempty"`           // Service provider account name
+	Username        string                                                                                               `json:"username,omitempty"`        // Service provider account username
+}
+type ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider struct {
+	Logo *ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProviderLogo `json:"logo,omitempty"` // Service provider logo data.
+	Name string                                                                                                   `json:"name,omitempty"` // Name of the service provider.
+}
+type ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProviderLogo struct {
+	URL string `json:"url,omitempty"` // Service Provider logo url.
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans struct {
+	Items *[]ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansItems `json:"items,omitempty"` // List of Cellular Service Provider Communication Plans
+	Meta  *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansItems struct {
+	AccountID string                                                                                                           `json:"accountId,omitempty"` // Account ID of plans to be fetched
+	Apns      *[]ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansItemsApns `json:"apns,omitempty"`      // Available APNs
+	Name      string                                                                                                           `json:"name,omitempty"`      // Communication plan name
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansItemsApns struct {
+	Name string `json:"name,omitempty"` // APN name
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMeta struct {
+	Counts *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMetaCounts `json:"counts,omitempty"` // Counts of involved entities
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMetaCounts struct {
+	Items *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMetaCountsItems `json:"items,omitempty"` // Count of Communication Plans available
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of Communication Plans
+	Total     *int `json:"total,omitempty"`     // Total number of Communication Plans
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans struct {
+	Items *[]ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansItems `json:"items,omitempty"` // List of Cellular Service Provider Rate Plans
+	Meta  *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansItems struct {
+	AccountID string `json:"accountId,omitempty"` // Account ID of plans to be fetched
+	Name      string `json:"name,omitempty"`      // Rate plan name
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMeta struct {
+	Counts *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMetaCounts `json:"counts,omitempty"` // Counts of involved entities
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMetaCounts struct {
+	Items *ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMetaCountsItems `json:"items,omitempty"` // Count of Rate Plans available
+}
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of Rate Plans
+	Total     *int `json:"total,omitempty"`     // Total number of Rate Plans
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount struct {
+	AccountID       string                                                                                               `json:"accountId,omitempty"`       // Service provider account ID
+	LastUpdatedAt   string                                                                                               `json:"lastUpdatedAt,omitempty"`   // Last updated at
+	ServiceProvider *ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider `json:"serviceProvider,omitempty"` // Service provider data.
+	Title           string                                                                                               `json:"title,omitempty"`           // Service provider account name
+	Username        string                                                                                               `json:"username,omitempty"`        // Service provider account username
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider struct {
+	Logo *ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProviderLogo `json:"logo,omitempty"` // Service provider logo data.
+	Name string                                                                                                   `json:"name,omitempty"` // Name of the service provider.
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProviderLogo struct {
+	URL string `json:"url,omitempty"` // Service Provider logo url.
+}
+type ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsSwap struct {
+	Eid    string `json:"eid,omitempty"`    // eSIM EID
+	Iccid  string `json:"iccid,omitempty"`  // eSIM ICCID
+	Status string `json:"status,omitempty"` // Swap status
+}
+type ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsSwap struct {
+	Eid    string `json:"eid,omitempty"`    // eSIM EID
+	Iccid  string `json:"iccid,omitempty"`  // eSIM ICCID
+	Status string `json:"status,omitempty"` // Swap status
 }
 type ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses []ResponseItemCellularGatewayGetOrganizationCellularGatewayUplinkStatuses // Array of ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses
 type ResponseItemCellularGatewayGetOrganizationCellularGatewayUplinkStatuses struct {
@@ -189,6 +443,35 @@ type RequestCellularGatewayUpdateNetworkCellularGatewayUplink struct {
 type RequestCellularGatewayUpdateNetworkCellularGatewayUplinkBandwidthLimits struct {
 	LimitDown *int `json:"limitDown,omitempty"` // The maximum download limit (integer, in Kbps). null indicates no limit
 	LimitUp   *int `json:"limitUp,omitempty"`   // The maximum upload limit (integer, in Kbps). null indicates no limit
+}
+type RequestCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory struct {
+	Status string `json:"status,omitempty"` // Status the eSIM will be updated to
+}
+type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount struct {
+	AccountID       string                                                                                              `json:"accountId,omitempty"`       // Service provider account ID
+	APIKey          string                                                                                              `json:"apiKey,omitempty"`          // Service provider account API key
+	ServiceProvider *RequestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider `json:"serviceProvider,omitempty"` // Service Provider information
+	Title           string                                                                                              `json:"title,omitempty"`           // Service provider account name
+	Username        string                                                                                              `json:"username,omitempty"`        // Service provider account username
+}
+type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccountServiceProvider struct {
+	Name string `json:"name,omitempty"` // Service provider name
+}
+type RequestCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount struct {
+	APIKey string `json:"apiKey,omitempty"` // Service provider account API key
+	Title  string `json:"title,omitempty"`  // Service provider account name used on the Meraki UI
+}
+type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwap struct {
+	Swaps *[]RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwapSwaps `json:"swaps,omitempty"` // Each object represents a swap for one eSIM
+}
+type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwapSwaps struct {
+	Eid    string                                                                       `json:"eid,omitempty"`    // eSIM EID
+	Target *RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwapSwapsTarget `json:"target,omitempty"` // Target Profile attributes
+}
+type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwapSwapsTarget struct {
+	AccountID         string `json:"accountId,omitempty"`         // ID of the target account; can be the account currently tied to the eSIM
+	CommunicationPlan string `json:"communicationPlan,omitempty"` // Name of the target communication plan
+	RatePlan          string `json:"ratePlan,omitempty"`          // Name of the target rate plan
 }
 
 //GetDeviceCellularGatewayLan Show the LAN Settings of a MG
@@ -389,6 +672,183 @@ func (s *CellularGatewayService) GetNetworkCellularGatewayUplink(networkID strin
 
 }
 
+//GetOrganizationCellularGatewayEsimsInventory The eSIM inventory of a given organization.
+/* The eSIM inventory of a given organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCellularGatewayEsimsInventoryQueryParams Filtering parameter
+
+
+*/
+func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsInventory(organizationID string, getOrganizationCellularGatewayEsimsInventoryQueryParams *GetOrganizationCellularGatewayEsimsInventoryQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/inventory"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCellularGatewayEsimsInventoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCellularGatewayEsimsInventory")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory)
+	return result, response, err
+
+}
+
+//GetOrganizationCellularGatewayEsimsServiceProviders Service providers customers can add accounts for.
+/* Service providers customers can add accounts for.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProviders(organizationID string) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProviders, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProviders{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCellularGatewayEsimsServiceProviders")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProviders)
+	return result, response, err
+
+}
+
+//GetOrganizationCellularGatewayEsimsServiceProvidersAccounts Inventory of service provider accounts tied to the organization.
+/* Inventory of service provider accounts tied to the organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams Filtering parameter
+
+
+*/
+func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccounts(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCellularGatewayEsimsServiceProvidersAccounts")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts)
+	return result, response, err
+
+}
+
+//GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans The communication plans available for a given provider.
+/* The communication plans available for a given provider.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams Filtering parameter
+
+
+*/
+func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/communicationPlans"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans)
+	return result, response, err
+
+}
+
+//GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans The rate plans available for a given provider.
+/* The rate plans available for a given provider.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams Filtering parameter
+
+
+*/
+func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/ratePlans"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans)
+	return result, response, err
+
+}
+
 //GetOrganizationCellularGatewayUplinkStatuses List the uplink status of every Meraki MG cellular gateway in the organization
 /* List the uplink status of every Meraki MG cellular gateway in the organization
 
@@ -421,6 +881,76 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayUplinkStatuses(or
 	}
 
 	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses)
+	return result, response, err
+
+}
+
+//CreateOrganizationCellularGatewayEsimsServiceProvidersAccount Add a service provider account.
+/* Add a service provider account.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *CellularGatewayService) CreateOrganizationCellularGatewayEsimsServiceProvidersAccount(organizationID string, requestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount *RequestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount) (*ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount).
+		SetResult(&ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationCellularGatewayEsimsServiceProvidersAccount")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsServiceProvidersAccount)
+	return result, response, err
+
+}
+
+//CreateOrganizationCellularGatewayEsimsSwap Swap which profile an eSIM uses.
+/* Swap which profile an eSIM uses.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *CellularGatewayService) CreateOrganizationCellularGatewayEsimsSwap(organizationID string, requestCellularGatewayCreateOrganizationCellularGatewayEsimsSwap *RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwap) (*ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsSwap, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/swap"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCellularGatewayCreateOrganizationCellularGatewayEsimsSwap).
+		SetResult(&ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsSwap{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationCellularGatewayEsimsSwap")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayCreateOrganizationCellularGatewayEsimsSwap)
 	return result, response, err
 
 }
@@ -462,7 +992,7 @@ func (s *CellularGatewayService) UpdateDeviceCellularGatewayLan(serial string, r
 
 @param serial serial path parameter.
 */
-func (s *CellularGatewayService) UpdateDeviceCellularGatewayPortForwardingRules(serial string, requestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules *RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules) (*resty.Response, error) {
+func (s *CellularGatewayService) UpdateDeviceCellularGatewayPortForwardingRules(serial string, requestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules *RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules) (*ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellularGateway/portForwardingRules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -471,19 +1001,21 @@ func (s *CellularGatewayService) UpdateDeviceCellularGatewayPortForwardingRules(
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules).
+		SetResult(&ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceCellularGatewayPortForwardingRules")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceCellularGatewayPortForwardingRules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules)
+	return result, response, err
 
 }
 
@@ -492,7 +1024,7 @@ func (s *CellularGatewayService) UpdateDeviceCellularGatewayPortForwardingRules(
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *CellularGatewayService) UpdateNetworkCellularGatewayConnectivityMonitoringDestinations(networkID string, requestCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations *RequestCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations) (*resty.Response, error) {
+func (s *CellularGatewayService) UpdateNetworkCellularGatewayConnectivityMonitoringDestinations(networkID string, requestCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations *RequestCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations) (*ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/connectivityMonitoringDestinations"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -501,19 +1033,21 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewayConnectivityMonitor
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations).
+		SetResult(&ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkCellularGatewayConnectivityMonitoringDestinations")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkCellularGatewayConnectivityMonitoringDestinations")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCellularGatewayUpdateNetworkCellularGatewayConnectivityMonitoringDestinations)
+	return result, response, err
 
 }
 
@@ -554,7 +1088,7 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewayDhcp(networkID stri
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *CellularGatewayService) UpdateNetworkCellularGatewaySubnetPool(networkID string, requestCellularGatewayUpdateNetworkCellularGatewaySubnetPool *RequestCellularGatewayUpdateNetworkCellularGatewaySubnetPool) (*resty.Response, error) {
+func (s *CellularGatewayService) UpdateNetworkCellularGatewaySubnetPool(networkID string, requestCellularGatewayUpdateNetworkCellularGatewaySubnetPool *RequestCellularGatewayUpdateNetworkCellularGatewaySubnetPool) (*ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/subnetPool"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -563,19 +1097,21 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewaySubnetPool(networkI
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestCellularGatewayUpdateNetworkCellularGatewaySubnetPool).
+		SetResult(&ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkCellularGatewaySubnetPool")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkCellularGatewaySubnetPool")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseCellularGatewayUpdateNetworkCellularGatewaySubnetPool)
+	return result, response, err
 
 }
 
@@ -608,5 +1144,140 @@ func (s *CellularGatewayService) UpdateNetworkCellularGatewayUplink(networkID st
 
 	result := response.Result().(*ResponseCellularGatewayUpdateNetworkCellularGatewayUplink)
 	return result, response, err
+
+}
+
+//UpdateOrganizationCellularGatewayEsimsInventory Toggle the status of an eSIM
+/* Toggle the status of an eSIM
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+*/
+func (s *CellularGatewayService) UpdateOrganizationCellularGatewayEsimsInventory(organizationID string, id string, requestCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory *RequestCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory) (*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/inventory/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory).
+		SetResult(&ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationCellularGatewayEsimsInventory")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsInventory)
+	return result, response, err
+
+}
+
+//UpdateOrganizationCellularGatewayEsimsServiceProvidersAccount Edit service provider account info stored in Meraki's database.
+/* Edit service provider account info stored in Meraki's database.
+
+@param organizationID organizationId path parameter. Organization ID
+@param accountID accountId path parameter. Account ID
+*/
+func (s *CellularGatewayService) UpdateOrganizationCellularGatewayEsimsServiceProvidersAccount(organizationID string, accountID string, requestCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount *RequestCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount) (*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/{accountId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{accountId}", fmt.Sprintf("%v", accountID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount).
+		SetResult(&ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationCellularGatewayEsimsServiceProvidersAccount")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsServiceProvidersAccount)
+	return result, response, err
+
+}
+
+//UpdateOrganizationCellularGatewayEsimsSwap Get the status of a profile swap.
+/* Get the status of a profile swap.
+
+@param id id path parameter. eSIM EID
+@param organizationID organizationId path parameter. Organization ID
+*/
+func (s *CellularGatewayService) UpdateOrganizationCellularGatewayEsimsSwap(id string, organizationID string) (*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsSwap, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/swap/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsSwap{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationCellularGatewayEsimsSwap")
+	}
+
+	result := response.Result().(*ResponseCellularGatewayUpdateOrganizationCellularGatewayEsimsSwap)
+	return result, response, err
+
+}
+
+//DeleteOrganizationCellularGatewayEsimsServiceProvidersAccount Remove a service provider account's integration with the Dashboard.
+/* Remove a service provider account's integration with the Dashboard.
+
+@param organizationID organizationId path parameter. Organization ID
+@param accountID accountId path parameter. Account ID
+
+
+*/
+func (s *CellularGatewayService) DeleteOrganizationCellularGatewayEsimsServiceProvidersAccount(organizationID string, accountID string) (*resty.Response, error) {
+	//organizationID string,accountID string
+	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/{accountId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{accountId}", fmt.Sprintf("%v", accountID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteOrganizationCellularGatewayEsimsServiceProvidersAccount")
+	}
+
+	return response, err
 
 }

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -104,50 +104,110 @@ type GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams struct {
 }
 
 type ResponseDevicesGetDevice struct {
-	Address     string                             `json:"address,omitempty"`     // Physical address of the device
-	Details     *[]ResponseDevicesGetDeviceDetails `json:"details,omitempty"`     // Additional device information
-	Firmware    string                             `json:"firmware,omitempty"`    // Firmware version of the device
-	Imei        string                             `json:"imei,omitempty"`        // IMEI of the device, if applicable
-	LanIP       string                             `json:"lanIp,omitempty"`       // LAN IP address of the device
-	Lat         *float64                           `json:"lat,omitempty"`         // Latitude of the device
-	Lng         *float64                           `json:"lng,omitempty"`         // Longitude of the device
-	Mac         string                             `json:"mac,omitempty"`         // MAC address of the device
-	Model       string                             `json:"model,omitempty"`       // Model of the device
-	Name        string                             `json:"name,omitempty"`        // Name of the device
-	NetworkID   string                             `json:"networkId,omitempty"`   // ID of the network the device belongs to
-	Notes       string                             `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
-	ProductType string                             `json:"productType,omitempty"` // Product type of the device
-	Serial      string                             `json:"serial,omitempty"`      // Serial number of the device
-	Tags        []string                           `json:"tags,omitempty"`        // List of tags assigned to the device
+	Address        string                                  `json:"address,omitempty"`        // Physical address of the device
+	BeaconIDParams *ResponseDevicesGetDeviceBeaconIDParams `json:"beaconIdParams,omitempty"` // Beacon Id parameters with an identifier and major and minor versions
+	Details        *[]ResponseDevicesGetDeviceDetails      `json:"details,omitempty"`        // Additional device information
+	Firmware       string                                  `json:"firmware,omitempty"`       // Firmware version of the device
+	FloorPlanID    string                                  `json:"floorPlanId,omitempty"`    // The floor plan to associate to this device. null disassociates the device from the floorplan.
+	LanIP          string                                  `json:"lanIp,omitempty"`          // LAN IP address of the device
+	Lat            *float64                                `json:"lat,omitempty"`            // Latitude of the device
+	Lng            *float64                                `json:"lng,omitempty"`            // Longitude of the device
+	Mac            string                                  `json:"mac,omitempty"`            // MAC address of the device
+	Model          string                                  `json:"model,omitempty"`          // Model of the device
+	Name           string                                  `json:"name,omitempty"`           // Name of the device
+	NetworkID      string                                  `json:"networkId,omitempty"`      // ID of the network the device belongs to
+	Notes          string                                  `json:"notes,omitempty"`          // Notes for the device, limited to 255 characters
+	Serial         string                                  `json:"serial,omitempty"`         // Serial number of the device
+	Tags           []string                                `json:"tags,omitempty"`           // List of tags assigned to the device
+}
+type ResponseDevicesGetDeviceBeaconIDParams struct {
+	Major *int   `json:"major,omitempty"` // The major number to be used in the beacon identifier
+	Minor *int   `json:"minor,omitempty"` // The minor number to be used in the beacon identifier
+	UUID  string `json:"uuid,omitempty"`  // The UUID to be used in the beacon identifier
 }
 type ResponseDevicesGetDeviceDetails struct {
 	Name  string `json:"name,omitempty"`  // Additional property name
 	Value string `json:"value,omitempty"` // Additional property value
 }
-type ResponseDevicesUpdateDevice interface{}
+type ResponseDevicesUpdateDevice struct {
+	Address        string                                     `json:"address,omitempty"`        // Physical address of the device
+	BeaconIDParams *ResponseDevicesUpdateDeviceBeaconIDParams `json:"beaconIdParams,omitempty"` // Beacon Id parameters with an identifier and major and minor versions
+	Details        *[]ResponseDevicesUpdateDeviceDetails      `json:"details,omitempty"`        // Additional device information
+	Firmware       string                                     `json:"firmware,omitempty"`       // Firmware version of the device
+	FloorPlanID    string                                     `json:"floorPlanId,omitempty"`    // The floor plan to associate to this device. null disassociates the device from the floorplan.
+	LanIP          string                                     `json:"lanIp,omitempty"`          // LAN IP address of the device
+	Lat            *float64                                   `json:"lat,omitempty"`            // Latitude of the device
+	Lng            *float64                                   `json:"lng,omitempty"`            // Longitude of the device
+	Mac            string                                     `json:"mac,omitempty"`            // MAC address of the device
+	Model          string                                     `json:"model,omitempty"`          // Model of the device
+	Name           string                                     `json:"name,omitempty"`           // Name of the device
+	NetworkID      string                                     `json:"networkId,omitempty"`      // ID of the network the device belongs to
+	Notes          string                                     `json:"notes,omitempty"`          // Notes for the device, limited to 255 characters
+	Serial         string                                     `json:"serial,omitempty"`         // Serial number of the device
+	Tags           []string                                   `json:"tags,omitempty"`           // List of tags assigned to the device
+}
+type ResponseDevicesUpdateDeviceBeaconIDParams struct {
+	Major *int   `json:"major,omitempty"` // The major number to be used in the beacon identifier
+	Minor *int   `json:"minor,omitempty"` // The minor number to be used in the beacon identifier
+	UUID  string `json:"uuid,omitempty"`  // The UUID to be used in the beacon identifier
+}
+type ResponseDevicesUpdateDeviceDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
 type ResponseDevicesBlinkDeviceLeds struct {
 	Duration *int `json:"duration,omitempty"` // The duration in seconds. Will be between 5 and 120. Default is 20 seconds
 	Duty     *int `json:"duty,omitempty"`     // The duty cycle as the percent active. Will be between 10 and 90. Default is 50
 	Period   *int `json:"period,omitempty"`   // The period in milliseconds. Will be between 100 and 1000. Default is 160 milliseconds
 }
 type ResponseDevicesGetDeviceCellularSims struct {
-	Sims *[]ResponseDevicesGetDeviceCellularSimsSims `json:"sims,omitempty"` //
+	SimFailover *ResponseDevicesGetDeviceCellularSimsSimFailover `json:"simFailover,omitempty"` // SIM Failover settings.
+	SimOrdering []string                                         `json:"simOrdering,omitempty"` // Specifies the ordering of all SIMs for an MG: primary, secondary, and not-in-use (when applicable). It's required for devices with 3 or more SIMs and can be used in place of 'isPrimary' for dual-SIM devices. To indicate eSIM, use 'sim3'. Sim failover will occur only between primary and secondary sim slots.
+	Sims        *[]ResponseDevicesGetDeviceCellularSimsSims      `json:"sims,omitempty"`        // List of SIMs. If a SIM was previously configured and not specified in this request, it will remain unchanged.
+}
+type ResponseDevicesGetDeviceCellularSimsSimFailover struct {
+	Enabled *bool `json:"enabled,omitempty"` // Failover to secondary SIM
+	Timeout *int  `json:"timeout,omitempty"` // Failover timeout in seconds
 }
 type ResponseDevicesGetDeviceCellularSimsSims struct {
-	Apns      *[]ResponseDevicesGetDeviceCellularSimsSimsApns `json:"apns,omitempty"`      //
-	IsPrimary *bool                                           `json:"isPrimary,omitempty"` //
-	Slot      string                                          `json:"slot,omitempty"`      //
+	Apns      *[]ResponseDevicesGetDeviceCellularSimsSimsApns `json:"apns,omitempty"`      // APN configurations. If empty, the default APN will be used.
+	IsPrimary *bool                                           `json:"isPrimary,omitempty"` // If true, this SIM is activated on platform bootup. It must be true on single-SIM devices and is a required field for dual-SIM MGs unless it is being configured using 'simOrdering'.
+	Slot      string                                          `json:"slot,omitempty"`      // SIM slot being configured. Must be 'sim1' on single-sim devices. Use 'sim3' for eSIM.
 }
 type ResponseDevicesGetDeviceCellularSimsSimsApns struct {
-	AllowedIPTypes []string                                                    `json:"allowedIpTypes,omitempty"` //
-	Authentication *ResponseDevicesGetDeviceCellularSimsSimsApnsAuthentication `json:"authentication,omitempty"` //
-	Name           string                                                      `json:"name,omitempty"`           //
+	AllowedIPTypes []string                                                    `json:"allowedIpTypes,omitempty"` // IP versions to support (permitted values include 'ipv4', 'ipv6').
+	Authentication *ResponseDevicesGetDeviceCellularSimsSimsApnsAuthentication `json:"authentication,omitempty"` // APN authentication configurations.
+	Name           string                                                      `json:"name,omitempty"`           // APN name.
 }
 type ResponseDevicesGetDeviceCellularSimsSimsApnsAuthentication struct {
-	Type     string `json:"type,omitempty"`     //
-	Username string `json:"username,omitempty"` //
+	Password string `json:"password,omitempty"` // APN password, if type is set (if APN password is not supplied, the password is left unchanged).
+	Type     string `json:"type,omitempty"`     // APN auth type.
+	Username string `json:"username,omitempty"` // APN username, if type is set.
 }
-type ResponseDevicesUpdateDeviceCellularSims interface{}
+type ResponseDevicesUpdateDeviceCellularSims struct {
+	SimFailover *ResponseDevicesUpdateDeviceCellularSimsSimFailover `json:"simFailover,omitempty"` // SIM Failover settings.
+	SimOrdering []string                                            `json:"simOrdering,omitempty"` // Specifies the ordering of all SIMs for an MG: primary, secondary, and not-in-use (when applicable). It's required for devices with 3 or more SIMs and can be used in place of 'isPrimary' for dual-SIM devices. To indicate eSIM, use 'sim3'. Sim failover will occur only between primary and secondary sim slots.
+	Sims        *[]ResponseDevicesUpdateDeviceCellularSimsSims      `json:"sims,omitempty"`        // List of SIMs. If a SIM was previously configured and not specified in this request, it will remain unchanged.
+}
+type ResponseDevicesUpdateDeviceCellularSimsSimFailover struct {
+	Enabled *bool `json:"enabled,omitempty"` // Failover to secondary SIM
+	Timeout *int  `json:"timeout,omitempty"` // Failover timeout in seconds
+}
+type ResponseDevicesUpdateDeviceCellularSimsSims struct {
+	Apns      *[]ResponseDevicesUpdateDeviceCellularSimsSimsApns `json:"apns,omitempty"`      // APN configurations. If empty, the default APN will be used.
+	IsPrimary *bool                                              `json:"isPrimary,omitempty"` // If true, this SIM is activated on platform bootup. It must be true on single-SIM devices and is a required field for dual-SIM MGs unless it is being configured using 'simOrdering'.
+	Slot      string                                             `json:"slot,omitempty"`      // SIM slot being configured. Must be 'sim1' on single-sim devices. Use 'sim3' for eSIM.
+}
+type ResponseDevicesUpdateDeviceCellularSimsSimsApns struct {
+	AllowedIPTypes []string                                                       `json:"allowedIpTypes,omitempty"` // IP versions to support (permitted values include 'ipv4', 'ipv6').
+	Authentication *ResponseDevicesUpdateDeviceCellularSimsSimsApnsAuthentication `json:"authentication,omitempty"` // APN authentication configurations.
+	Name           string                                                         `json:"name,omitempty"`           // APN name.
+}
+type ResponseDevicesUpdateDeviceCellularSimsSimsApnsAuthentication struct {
+	Password string `json:"password,omitempty"` // APN password, if type is set (if APN password is not supplied, the password is left unchanged).
+	Type     string `json:"type,omitempty"`     // APN auth type.
+	Username string `json:"username,omitempty"` // APN username, if type is set.
+}
 type ResponseDevicesGetDeviceClients []ResponseItemDevicesGetDeviceClients // Array of ResponseDevicesGetDeviceClients
 type ResponseItemDevicesGetDeviceClients struct {
 	AdaptivePolicyGroup string                                    `json:"adaptivePolicyGroup,omitempty"` // A description of the adaptive policy group
@@ -239,6 +299,34 @@ type ResponseDevicesGetDeviceLiveToolsCableTestResultsPairs struct {
 	LengthMeters *int   `json:"lengthMeters,omitempty"` // The detected length of the twisted pair.
 	Status       string `json:"status,omitempty"`       // The test result of the twisted pair tested.
 }
+type ResponseDevicesCreateDeviceLiveToolsLedsBlink struct {
+	Callback    *ResponseDevicesCreateDeviceLiveToolsLedsBlinkCallback `json:"callback,omitempty"`    // Information for callback used to send back results
+	Error       string                                                 `json:"error,omitempty"`       // An error message for a failed Blink LEDs execution, if present
+	LedsBlinkID string                                                 `json:"ledsBlinkId,omitempty"` // ID of led blink job
+	Request     *ResponseDevicesCreateDeviceLiveToolsLedsBlinkRequest  `json:"request,omitempty"`     // The parameters of the leds blink request
+	Status      string                                                 `json:"status,omitempty"`      // Status of the leds blink request
+	URL         string                                                 `json:"url,omitempty"`         // GET this url to check the status of your leds blink request
+}
+type ResponseDevicesCreateDeviceLiveToolsLedsBlinkCallback struct {
+	ID     string `json:"id,omitempty"`     // The ID of the callback. To check the status of the callback, use this ID in a request to /webhooks/callbacks/statuses/{id}
+	Status string `json:"status,omitempty"` // The status of the callback
+	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
+}
+type ResponseDevicesCreateDeviceLiveToolsLedsBlinkRequest struct {
+	Duration *int   `json:"duration,omitempty"` // The duration to blink leds in seconds
+	Serial   string `json:"serial,omitempty"`   // Device serial number
+}
+type ResponseDevicesGetDeviceLiveToolsLedsBlink struct {
+	Error       string                                             `json:"error,omitempty"`       // An error message for a failed Blink LEDs execution, if present
+	LedsBlinkID string                                             `json:"ledsBlinkId,omitempty"` // ID of led blink job
+	Request     *ResponseDevicesGetDeviceLiveToolsLedsBlinkRequest `json:"request,omitempty"`     // The parameters of the leds blink request
+	Status      string                                             `json:"status,omitempty"`      // Status of the leds blink request
+	URL         string                                             `json:"url,omitempty"`         // GET this url to check the status of your leds blink request
+}
+type ResponseDevicesGetDeviceLiveToolsLedsBlinkRequest struct {
+	Duration *int   `json:"duration,omitempty"` // The duration to blink leds in seconds
+	Serial   string `json:"serial,omitempty"`   // Device serial number
+}
 type ResponseDevicesCreateDeviceLiveToolsPing struct {
 	Callback *ResponseDevicesCreateDeviceLiveToolsPingCallback `json:"callback,omitempty"` // Information for callback used to send back results
 	PingID   string                                            `json:"pingId,omitempty"`   // Id to check the status of your ping request.
@@ -252,7 +340,7 @@ type ResponseDevicesCreateDeviceLiveToolsPingCallback struct {
 	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesCreateDeviceLiveToolsPingRequest struct {
-	Count  *int   `json:"count,omitempty"`  // Number of pings to send
+	Count  *int   `json:"count,omitempty"`  // Number of pings to send. [1..5], default 5
 	Serial string `json:"serial,omitempty"` // Device serial number
 	Target string `json:"target,omitempty"` // IP address or FQDN to ping
 }
@@ -264,7 +352,7 @@ type ResponseDevicesGetDeviceLiveToolsPing struct {
 	URL     string                                        `json:"url,omitempty"`     // GET this url to check the status of your ping request.
 }
 type ResponseDevicesGetDeviceLiveToolsPingRequest struct {
-	Count  *int   `json:"count,omitempty"`  // Number of pings to send
+	Count  *int   `json:"count,omitempty"`  // Number of pings to send. [1..5], default 5
 	Serial string `json:"serial,omitempty"` // Device serial number
 	Target string `json:"target,omitempty"` // IP address or FQDN to ping
 }
@@ -301,9 +389,8 @@ type ResponseDevicesCreateDeviceLiveToolsPingDeviceCallback struct {
 	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesCreateDeviceLiveToolsPingDeviceRequest struct {
-	Count  *int   `json:"count,omitempty"`  // Number of pings to send
+	Count  *int   `json:"count,omitempty"`  // Number of pings to send. [1..5], default 5
 	Serial string `json:"serial,omitempty"` // Device serial number
-	Target string `json:"target,omitempty"` // IP address or FQDN to ping
 }
 type ResponseDevicesGetDeviceLiveToolsPingDevice struct {
 	Callback *ResponseDevicesGetDeviceLiveToolsPingDeviceCallback `json:"callback,omitempty"` // Information for callback used to send back results
@@ -319,9 +406,8 @@ type ResponseDevicesGetDeviceLiveToolsPingDeviceCallback struct {
 	URL    string `json:"url,omitempty"`    // The callback URL for the webhook target. This was either provided in the original request or comes from a configured webhook receiver
 }
 type ResponseDevicesGetDeviceLiveToolsPingDeviceRequest struct {
-	Count  *int   `json:"count,omitempty"`  // Number of pings to send
+	Count  *int   `json:"count,omitempty"`  // Number of pings to send. [1..5], default 5
 	Serial string `json:"serial,omitempty"` // Device serial number
-	Target string `json:"target,omitempty"` // IP address or FQDN to ping
 }
 type ResponseDevicesGetDeviceLiveToolsPingDeviceResults struct {
 	Latencies *ResponseDevicesGetDeviceLiveToolsPingDeviceResultsLatencies `json:"latencies,omitempty"` // Packet latency stats
@@ -364,7 +450,7 @@ type ResponseDevicesCreateDeviceLiveToolsThroughputTestResult struct {
 	Speeds *ResponseDevicesCreateDeviceLiveToolsThroughputTestResultSpeeds `json:"speeds,omitempty"` // Shows the speeds (Mbps)
 }
 type ResponseDevicesCreateDeviceLiveToolsThroughputTestResultSpeeds struct {
-	Downstream *int `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
+	Downstream *float64 `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
 }
 type ResponseDevicesGetDeviceLiveToolsThroughputTest struct {
 	Error            string                                                  `json:"error,omitempty"`            // Description of the error.
@@ -381,7 +467,7 @@ type ResponseDevicesGetDeviceLiveToolsThroughputTestResult struct {
 	Speeds *ResponseDevicesGetDeviceLiveToolsThroughputTestResultSpeeds `json:"speeds,omitempty"` // Shows the speeds (Mbps)
 }
 type ResponseDevicesGetDeviceLiveToolsThroughputTestResultSpeeds struct {
-	Downstream *int `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
+	Downstream *float64 `json:"downstream,omitempty"` // Shows the download speed from shard (Mbps)
 }
 type ResponseDevicesCreateDeviceLiveToolsWakeOnLan struct {
 	Callback    *ResponseDevicesCreateDeviceLiveToolsWakeOnLanCallback `json:"callback,omitempty"`    // Information for callback used to send back results
@@ -516,28 +602,38 @@ type ResponseDevicesRebootDevice struct {
 }
 type ResponseDevicesGetNetworkDevices []ResponseItemDevicesGetNetworkDevices // Array of ResponseDevicesGetNetworkDevices
 type ResponseItemDevicesGetNetworkDevices struct {
-	Address     string                                         `json:"address,omitempty"`     // Physical address of the device
-	Details     *[]ResponseItemDevicesGetNetworkDevicesDetails `json:"details,omitempty"`     // Additional device information
-	Firmware    string                                         `json:"firmware,omitempty"`    // Firmware version of the device
-	Imei        string                                         `json:"imei,omitempty"`        // IMEI of the device, if applicable
-	LanIP       string                                         `json:"lanIp,omitempty"`       // LAN IP address of the device
-	Lat         *float64                                       `json:"lat,omitempty"`         // Latitude of the device
-	Lng         *float64                                       `json:"lng,omitempty"`         // Longitude of the device
-	Mac         string                                         `json:"mac,omitempty"`         // MAC address of the device
-	Model       string                                         `json:"model,omitempty"`       // Model of the device
-	Name        string                                         `json:"name,omitempty"`        // Name of the device
-	NetworkID   string                                         `json:"networkId,omitempty"`   // ID of the network the device belongs to
-	Notes       string                                         `json:"notes,omitempty"`       // Notes for the device, limited to 255 characters
-	ProductType string                                         `json:"productType,omitempty"` // Product type of the device
-	Serial      string                                         `json:"serial,omitempty"`      // Serial number of the device
-	Tags        []string                                       `json:"tags,omitempty"`        // List of tags assigned to the device
+	Address        string                                              `json:"address,omitempty"`        // Physical address of the device
+	BeaconIDParams *ResponseItemDevicesGetNetworkDevicesBeaconIDParams `json:"beaconIdParams,omitempty"` // Beacon Id parameters with an identifier and major and minor versions
+	Details        *[]ResponseItemDevicesGetNetworkDevicesDetails      `json:"details,omitempty"`        // Additional device information
+	Firmware       string                                              `json:"firmware,omitempty"`       // Firmware version of the device
+	FloorPlanID    string                                              `json:"floorPlanId,omitempty"`    // The floor plan to associate to this device. null disassociates the device from the floorplan.
+	LanIP          string                                              `json:"lanIp,omitempty"`          // LAN IP address of the device
+	Lat            *float64                                            `json:"lat,omitempty"`            // Latitude of the device
+	Lng            *float64                                            `json:"lng,omitempty"`            // Longitude of the device
+	Mac            string                                              `json:"mac,omitempty"`            // MAC address of the device
+	Model          string                                              `json:"model,omitempty"`          // Model of the device
+	Name           string                                              `json:"name,omitempty"`           // Name of the device
+	NetworkID      string                                              `json:"networkId,omitempty"`      // ID of the network the device belongs to
+	Notes          string                                              `json:"notes,omitempty"`          // Notes for the device, limited to 255 characters
+	Serial         string                                              `json:"serial,omitempty"`         // Serial number of the device
+	Tags           []string                                            `json:"tags,omitempty"`           // List of tags assigned to the device
+}
+type ResponseItemDevicesGetNetworkDevicesBeaconIDParams struct {
+	Major *int   `json:"major,omitempty"` // The major number to be used in the beacon identifier
+	Minor *int   `json:"minor,omitempty"` // The minor number to be used in the beacon identifier
+	UUID  string `json:"uuid,omitempty"`  // The UUID to be used in the beacon identifier
 }
 type ResponseItemDevicesGetNetworkDevicesDetails struct {
 	Name  string `json:"name,omitempty"`  // Additional property name
 	Value string `json:"value,omitempty"` // Additional property value
 }
 type ResponseDevicesClaimNetworkDevices struct {
-	Serials []string `json:"serials,omitempty"` // The serials of the devices
+	Errors  *[]ResponseDevicesClaimNetworkDevicesErrors `json:"errors,omitempty"`  // Errors for devices that were not added
+	Serials []string                                    `json:"serials,omitempty"` // The serials of the devices
+}
+type ResponseDevicesClaimNetworkDevicesErrors struct {
+	Errors []string `json:"errors,omitempty"` // The errors for the device
+	Serial string   `json:"serial,omitempty"` // The serial of the device
 }
 type ResponseDevicesVmxNetworkDevicesClaim struct {
 	Address     string                                          `json:"address,omitempty"`     // Physical address of the device
@@ -559,6 +655,9 @@ type ResponseDevicesVmxNetworkDevicesClaim struct {
 type ResponseDevicesVmxNetworkDevicesClaimDetails struct {
 	Name  string `json:"name,omitempty"`  // Additional property name
 	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseDevicesBatchNetworkFloorPlansDevicesUpdate struct {
+	Success *bool `json:"success,omitempty"` // Status of attempt to update device floorplan assignments
 }
 type ResponseDevicesCheckinNetworkSmDevices struct {
 	IDs []string `json:"ids,omitempty"` // The Meraki Ids of the set of devices.
@@ -622,6 +721,7 @@ type ResponseItemDevicesGetNetworkSmDeviceDeviceProfiles struct {
 	ProfileIDentifier string `json:"profileIdentifier,omitempty"` // The identifier of the profile.
 	Version           string `json:"version,omitempty"`           // The verison of the profile.
 }
+type ResponseDevicesInstallNetworkSmDeviceApps interface{}
 type ResponseDevicesGetNetworkSmDeviceNetworkAdapters []ResponseItemDevicesGetNetworkSmDeviceNetworkAdapters // Array of ResponseDevicesGetNetworkSmDeviceNetworkAdapters
 type ResponseItemDevicesGetNetworkSmDeviceNetworkAdapters struct {
 	DhcpServer string `json:"dhcpServer,omitempty"` // The IP address of the DCHP Server.
@@ -633,17 +733,15 @@ type ResponseItemDevicesGetNetworkSmDeviceNetworkAdapters struct {
 	Name       string `json:"name,omitempty"`       // The name of the newtwork adapter.
 	Subnet     string `json:"subnet,omitempty"`     // The subnet for the network adapter.
 }
-type ResponseDevicesGetNetworkSmDeviceRestrictions []ResponseItemDevicesGetNetworkSmDeviceRestrictions // Array of ResponseDevicesGetNetworkSmDeviceRestrictions
-type ResponseItemDevicesGetNetworkSmDeviceRestrictions struct {
-	Profile      string                                                         `json:"profile,omitempty"`      //
-	Restrictions *ResponseItemDevicesGetNetworkSmDeviceRestrictionsRestrictions `json:"restrictions,omitempty"` //
+type ResponseDevicesRefreshNetworkSmDeviceDetails interface{}
+type ResponseDevicesGetNetworkSmDeviceRestrictions struct {
+	Restrictions *[]ResponseDevicesGetNetworkSmDeviceRestrictionsRestrictions `json:"restrictions,omitempty"` // The list of restrictions for the device
 }
-type ResponseItemDevicesGetNetworkSmDeviceRestrictionsRestrictions struct {
-	MyRestriction *ResponseItemDevicesGetNetworkSmDeviceRestrictionsRestrictionsMyRestriction `json:"myRestriction,omitempty"` //
+type ResponseDevicesGetNetworkSmDeviceRestrictionsRestrictions struct {
+	Profile      string                                                                 `json:"profile,omitempty"`      // The profile identifier.
+	Restrictions *ResponseDevicesGetNetworkSmDeviceRestrictionsRestrictionsRestrictions `json:"restrictions,omitempty"` // The restrictions for the profile.
 }
-type ResponseItemDevicesGetNetworkSmDeviceRestrictionsRestrictionsMyRestriction struct {
-	Value *bool `json:"value,omitempty"` //
-}
+type ResponseDevicesGetNetworkSmDeviceRestrictionsRestrictionsRestrictions interface{}
 type ResponseDevicesGetNetworkSmDeviceSecurityCenters []ResponseItemDevicesGetNetworkSmDeviceSecurityCenters // Array of ResponseDevicesGetNetworkSmDeviceSecurityCenters
 type ResponseItemDevicesGetNetworkSmDeviceSecurityCenters struct {
 	AntiVirusName        string `json:"antiVirusName,omitempty"`        // The name of the Antivirus.
@@ -686,14 +784,17 @@ type ResponseItemDevicesGetNetworkSmDeviceSoftwares struct {
 type ResponseDevicesUnenrollNetworkSmDevice struct {
 	Success *bool `json:"success,omitempty"` // Boolean indicating whether the operation was completed successfully.
 }
+type ResponseDevicesUninstallNetworkSmDeviceApps interface{}
 type ResponseDevicesGetNetworkSmDeviceWLANLists []ResponseItemDevicesGetNetworkSmDeviceWLANLists // Array of ResponseDevicesGetNetworkSmDeviceWlanLists
 type ResponseItemDevicesGetNetworkSmDeviceWLANLists struct {
 	CreatedAt string `json:"createdAt,omitempty"` // When the Meraki record for the wlanList was created.
 	ID        string `json:"id,omitempty"`        // The Meraki managed Id of the wlanList record.
 	Xml       string `json:"xml,omitempty"`       // An XML string containing the WLAN List for the device.
 }
-
-type ResponseOrganizationsCloneOrganizationSwitchDevices interface{}
+type ResponseOrganizationsCloneOrganizationSwitchDevices struct {
+	SourceSerial  string   `json:"sourceSerial,omitempty"`  // Serial number of the source switch (must be on a network not bound to a template)
+	TargetSerials []string `json:"targetSerials,omitempty"` // Array of serial numbers of one or more target switches (must be on a network not bound to a template)
+}
 type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice
 type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
 	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
@@ -865,6 +966,417 @@ type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkU
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
 	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
 }
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItems `json:"items,omitempty"` // List of Catalyst access points information
+	Meta  *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItems struct {
+	Controller  *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController `json:"controller,omitempty"`  // Associated wireless controller
+	CountryCode string                                                                                         `json:"countryCode,omitempty"` // Country code (2 characters)
+	Details     *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails  `json:"details,omitempty"`     // Catalyst access point details
+	JoinedAt    string                                                                                         `json:"joinedAt,omitempty"`    // The time when AP joins wireless controller
+	Mode        string                                                                                         `json:"mode,omitempty"`        // AP mode (local, flex, etc.)
+	Model       string                                                                                         `json:"model,omitempty"`       // AP model
+	Network     *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork    `json:"network,omitempty"`     // Catalyst access point network
+	Serial      string                                                                                         `json:"serial,omitempty"`      // AP cloud ID
+	Tags        *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags     `json:"tags,omitempty"`        // The tags of the catalyst access point
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController struct {
+	Serial string `json:"serial,omitempty"` // Associated wireless controller cloud ID
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails struct {
+	Name  string `json:"name,omitempty"`  // Item name
+	Value string `json:"value,omitempty"` // Item value
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Catalyst access point network ID
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags struct {
+	Policy string `json:"policy,omitempty"` // Policy tag
+	Rf     string `json:"rf,omitempty"`     // RF tag
+	Site   string `json:"site,omitempty"`   // Site tag
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L2 interfaces
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems struct {
+	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                              `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces struct {
+	ChannelGroup     *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`     // The channel group of this wireless LAN controller interface
+	Description      string                                                                                                        `json:"description,omitempty"`      // The description of the wireless LAN controller interface
+	Enabled          *bool                                                                                                         `json:"enabled,omitempty"`          // The status of the wireless LAN controller interface
+	IsRedundancyPort *bool                                                                                                         `json:"isRedundancyPort,omitempty"` // Indicate whether the interface is a redundancy port used to perform HA role negotiation
+	IsUplink         *bool                                                                                                         `json:"isUplink,omitempty"`         // Indicate whether the interface is uplink
+	LinkNegotiation  string                                                                                                        `json:"linkNegotiation,omitempty"`  // The interface negotiation mode
+	Mac              string                                                                                                        `json:"mac,omitempty"`              // The MAC address of the wireless LAN controller interface
+	Module           *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule       `json:"module,omitempty"`           // The module of this wireless LAN controller interface
+	Name             string                                                                                                        `json:"name,omitempty"`             // The name of the wireless LAN controller interface
+	Speed            string                                                                                                        `json:"speed,omitempty"`            // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status           string                                                                                                        `json:"status,omitempty"`           // The status of the wireless LAN controller interface
+	VLAN             *int                                                                                                          `json:"vlan,omitempty"`             // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup struct {
+	Number *int `json:"number,omitempty"` // The interface channel group number
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule struct {
+	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces historical status
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 2 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                          `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                          `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
+	Status   string   `json:"status,omitempty"`   // The status of the interface
+	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
+	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces usage
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 2 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                          `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings struct {
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
+	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
+	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
+	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L3 interfaces
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems struct {
+	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                              `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces struct {
+	Addresses       *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses  `json:"addresses,omitempty"`       // Available addresses for the interface.
+	ChannelGroup    *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`    // The channel group of this wireless LAN controller interface
+	Description     string                                                                                                        `json:"description,omitempty"`     // The description of the wireless LAN controller interface
+	IsUplink        *bool                                                                                                         `json:"isUplink,omitempty"`        // Indicate whether the interface is uplink
+	LinkNegotiation string                                                                                                        `json:"linkNegotiation,omitempty"` // The interface negotiation mode
+	Mac             string                                                                                                        `json:"mac,omitempty"`             // The MAC address of the wireless LAN controller interface
+	Module          *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule       `json:"module,omitempty"`          // The module of this wireless LAN controller interface
+	Name            string                                                                                                        `json:"name,omitempty"`            // The name of the wireless LAN controller interface
+	Speed           string                                                                                                        `json:"speed,omitempty"`           // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status          string                                                                                                        `json:"status,omitempty"`          // The status of the wireless LAN controller interface
+	VLAN            *int                                                                                                          `json:"vlan,omitempty"`            // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	Vrf             *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf          `json:"vrf,omitempty"`             // The virtual routing and forwarding (VRF) for the wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses struct {
+	Address  string `json:"address,omitempty"`  // The address of the wireless LAN controller interface
+	Protocol string `json:"protocol,omitempty"` // Type of address for the device uplink. Available options are: ipv4, ipv6. enum = [ipv4, ipv6]
+	Subnet   string `json:"subnet,omitempty"`   // The address of the wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup struct {
+	Number *int `json:"number,omitempty"` // The interface channel group number
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule struct {
+	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf struct {
+	Name string `json:"name,omitempty"` // The virtual routing and forwarding (VRF) name
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces historical status
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 3 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                          `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                          `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
+	Status   string   `json:"status,omitempty"`   // The status of the interface
+	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
+	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces usage
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 3 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                          `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings struct {
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
+	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
+	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
+	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems `json:"items,omitempty"` // Wireless LAN controller interfaces packets statuses
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems struct {
+	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                           `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces struct {
+	Name     string                                                                                                                   `json:"name,omitempty"`     // The name of the wireless LAN controller interface
+	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings `json:"readings,omitempty"` // The status of packets counter on the interfaces of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings struct {
+	Name  string                                                                                                                     `json:"name,omitempty"`  // The type of packets being counted
+	Rate  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate `json:"rate,omitempty"`  // The interface packet rates measured in packets per second
+	Recv  *int                                                                                                                       `json:"recv,omitempty"`  // The total count of packets received by the interface during the timespan
+	Send  *int                                                                                                                       `json:"send,omitempty"`  // The total count of packets sent by the interface during the timespan
+	Total *int                                                                                                                       `json:"total,omitempty"` // The total count of sent and received packets during the timespan
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate struct {
+	Recv  *int `json:"recv,omitempty"`  // The rate of packets received during the timespan
+	Send  *int `json:"send,omitempty"`  // The rate of packets sent during the timespan
+	Total *int `json:"total,omitempty"` // The rate of all packets sent and received during the timespan
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller interfaces usage data
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems struct {
+	Intervals *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of interfaces usage data of the wireless LAN controller
+	Serial    string                                                                                                         `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals struct {
+	ByInterface *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface `json:"byInterface,omitempty"` // The usage data on the interfaces of the wireless LAN controller
+	EndTs       string                                                                                                                    `json:"endTs,omitempty"`       // The end time interval snapshots of the query range with iso8601 format
+	Overall     *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall       `json:"overall,omitempty"`     // The overall usage of all queried interfaces of the wireless LAN controller
+	StartTs     string                                                                                                                    `json:"startTs,omitempty"`     // The start time interval snapshots of the query range with iso8601 format
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface struct {
+	Name  string                                                                                                                       `json:"name,omitempty"`  // The name of the wireless LAN controller interface
+	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage `json:"usage,omitempty"` // The usage on the interfaces of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage struct {
+	Recv  *int `json:"recv,omitempty"`  // The received usage on the interface during the interval, unit is bit/sec
+	Send  *int `json:"send,omitempty"`  // The sent usage on the interface during the interval, unit is bit/sec
+	Total *int `json:"total,omitempty"` // The total usage on the interface during the interval, unit is bit/sec
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall struct {
+	Recv  *int `json:"recv,omitempty"`  // The received usage of all queried interfaces during the interval, unit is bit/sec
+	Send  *int `json:"send,omitempty"`  // The sent usage of all queried interfaces during the interval, unit is bit/sec
+	Total *int `json:"total,omitempty"` // The total usage of all queried interfaces during the interval, unit is bit/sec
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory []ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory // Array of ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory struct {
+	Items *[]ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems `json:"items,omitempty"` // Wireless LAN controller HA failover events
+	Meta  *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems struct {
+	Active *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive `json:"active,omitempty"` // Details about the active unit
+	Failed *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed `json:"failed,omitempty"` // Details about the failed unit
+	Reason string                                                                                                 `json:"reason,omitempty"` // Failover reason
+	Serial string                                                                                                 `json:"serial,omitempty"` // Wireless LAN controller cloud ID
+	Ts     string                                                                                                 `json:"ts,omitempty"`     // Failover time
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive struct {
+	Chassis *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis `json:"chassis,omitempty"` // Details about the active unit chassis
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis struct {
+	Name string `json:"name,omitempty"` // The name of the active chassis unit
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed struct {
+	Chassis *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis `json:"chassis,omitempty"` // Details about the failed unit chassis
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis struct {
+	Name string `json:"name,omitempty"` // The name of the failed chassis unit
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta struct {
+	Counts *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts struct {
+	Items *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatuses struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItems `json:"items,omitempty"` // Wireless LAN controller redundancy statuses
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItems struct {
+	Enabled     *bool                                                                                         `json:"enabled,omitempty"`     // Wireless LAN controller redundancy enablement
+	Failover    *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover `json:"failover,omitempty"`    // Wireless LAN controller failover information
+	MobilityMac string                                                                                        `json:"mobilityMac,omitempty"` // Wireless LAN controller redundancy mobility mac
+	Mode        string                                                                                        `json:"mode,omitempty"`        // Wireless LAN controller redundancy SSO (stateful switchover)
+	Serial      string                                                                                        `json:"serial,omitempty"`      // Wireless LAN controller cloud ID
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts `json:"counts,omitempty"` // Wireless LAN controller switchover counts
+	Last   *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast   `json:"last,omitempty"`   // Wireless LAN controller last failover information
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts struct {
+	Total *int `json:"total,omitempty"` // Total number of failovers
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast struct {
+	Reason string `json:"reason,omitempty"` // Wireless LAN controller last redundancy switchover reason
+	Ts     string `json:"ts,omitempty"`     // Wireless LAN controller last redundancy switchover time
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval struct {
+	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller CPU usage data
+	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems struct {
+	Intervals *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of CPU usage data of the wireless LAN controller
+	Serial    string                                                                                                           `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals struct {
+	ByCore  *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore `json:"byCore,omitempty"`  // The CPU usage per core of the wireless LAN controller
+	EndTs   string                                                                                                                 `json:"endTs,omitempty"`   // The end time of the query range  with iso8601 format
+	Overall *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall  `json:"overall,omitempty"` // The overall CPU usage of the wireless LAN controller
+	StartTs string                                                                                                                 `json:"startTs,omitempty"` // The start time of the query range with iso8601 format
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore struct {
+	Name  string                                                                                                                    `json:"name,omitempty"`  // The CPU core name
+	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage `json:"usage,omitempty"` // The specific core CPU usage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage struct {
+	Average *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage `json:"average,omitempty"` // The specific core average CPU usage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage struct {
+	Percentage *float64 `json:"percentage,omitempty"` // The specific core CPU usage percentage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall struct {
+	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage `json:"usage,omitempty"` // The CPU usage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage struct {
+	Average *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage `json:"average,omitempty"` // The average CPU usage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage struct {
+	Percentage *float64 `json:"percentage,omitempty"` // The CPU usage percentage of the wireless LAN controller
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts struct {
+	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
 type RequestDevicesUpdateDevice struct {
 	Address         string   `json:"address,omitempty"`         // The address of a device
 	FloorPlanID     string   `json:"floorPlanId,omitempty"`     // The floor plan to associate to this device. null disassociates the device from the floorplan.
@@ -883,6 +1395,7 @@ type RequestDevicesBlinkDeviceLeds struct {
 }
 type RequestDevicesUpdateDeviceCellularSims struct {
 	SimFailover *RequestDevicesUpdateDeviceCellularSimsSimFailover `json:"simFailover,omitempty"` // SIM Failover settings.
+	SimOrdering []string                                           `json:"simOrdering,omitempty"` // Specifies the ordering of all SIMs for an MG: primary, secondary, and not-in-use (when applicable). It's required for devices with 3 or more SIMs and can be used in place of 'isPrimary' for dual-SIM devices. To indicate eSIM, use 'sim3'. Sim failover will occur only between primary and secondary sim slots.
 	Sims        *[]RequestDevicesUpdateDeviceCellularSimsSims      `json:"sims,omitempty"`        // List of SIMs. If a SIM was previously configured and not specified in this request, it will remain unchanged.
 }
 type RequestDevicesUpdateDeviceCellularSimsSimFailover struct {
@@ -891,8 +1404,9 @@ type RequestDevicesUpdateDeviceCellularSimsSimFailover struct {
 }
 type RequestDevicesUpdateDeviceCellularSimsSims struct {
 	Apns      *[]RequestDevicesUpdateDeviceCellularSimsSimsApns `json:"apns,omitempty"`      // APN configurations. If empty, the default APN will be used.
-	IsPrimary *bool                                             `json:"isPrimary,omitempty"` // If true, this SIM is used for boot. Must be true on single-sim devices.
-	Slot      string                                            `json:"slot,omitempty"`      // SIM slot being configured. Must be 'sim1' on single-sim devices.
+	IsPrimary *bool                                             `json:"isPrimary,omitempty"` // If true, this SIM is activated on platform bootup. It must be true on single-SIM devices and is a required field for dual-SIM MGs unless it is being configured using 'simOrdering'.
+	SimOrder  *int                                              `json:"simOrder,omitempty"`  // Priority of SIM slot being configured. Use a value between 1 and total number of SIMs available. The value must be unique for each SIM.
+	Slot      string                                            `json:"slot,omitempty"`      // SIM slot being configured. Must be 'sim1' on single-sim devices. Use 'sim3' for eSIM.
 }
 type RequestDevicesUpdateDeviceCellularSimsSimsApns struct {
 	AllowedIPTypes []string                                                      `json:"allowedIpTypes,omitempty"` // IP versions to support (permitted values include 'ipv4', 'ipv6').
@@ -921,7 +1435,7 @@ type RequestDevicesCreateDeviceLiveToolsArpTableCallbackPayloadTemplate struct {
 }
 type RequestDevicesCreateDeviceLiveToolsCableTest struct {
 	Callback *RequestDevicesCreateDeviceLiveToolsCableTestCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
-	Ports    []string                                              `json:"ports,omitempty"`    // A list of ports for which to perform the cable test.
+	Ports    []string                                              `json:"ports,omitempty"`    // A list of ports for which to perform the cable test.  For Catalyst switches, IOS interface names are also supported, such as "GigabitEthernet1/0/8", "Gi1/0/8", or even "1/0/8".
 }
 type RequestDevicesCreateDeviceLiveToolsCableTestCallback struct {
 	HTTPServer      *RequestDevicesCreateDeviceLiveToolsCableTestCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
@@ -933,6 +1447,22 @@ type RequestDevicesCreateDeviceLiveToolsCableTestCallbackHTTPServer struct {
 	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
 }
 type RequestDevicesCreateDeviceLiveToolsCableTestCallbackPayloadTemplate struct {
+	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
+}
+type RequestDevicesCreateDeviceLiveToolsLedsBlink struct {
+	Callback *RequestDevicesCreateDeviceLiveToolsLedsBlinkCallback `json:"callback,omitempty"` // Details for the callback. Please include either an httpServerId OR url and sharedSecret
+	Duration *int                                                  `json:"duration,omitempty"` // The duration in seconds to blink LEDs.
+}
+type RequestDevicesCreateDeviceLiveToolsLedsBlinkCallback struct {
+	HTTPServer      *RequestDevicesCreateDeviceLiveToolsLedsBlinkCallbackHTTPServer      `json:"httpServer,omitempty"`      // The webhook receiver used for the callback webhook.
+	PayloadTemplate *RequestDevicesCreateDeviceLiveToolsLedsBlinkCallbackPayloadTemplate `json:"payloadTemplate,omitempty"` // The payload template of the webhook used for the callback
+	SharedSecret    string                                                               `json:"sharedSecret,omitempty"`    // A shared secret that will be included in the requests sent to the callback URL. It can be used to verify that the request was sent by Meraki. If using this field, please also specify an url.
+	URL             string                                                               `json:"url,omitempty"`             // The callback URL for the webhook target. If using this field, please also specify a sharedSecret.
+}
+type RequestDevicesCreateDeviceLiveToolsLedsBlinkCallbackHTTPServer struct {
+	ID string `json:"id,omitempty"` // The webhook receiver ID that will receive information. If specifying this, please leave the url and sharedSecret fields blank.
+}
+type RequestDevicesCreateDeviceLiveToolsLedsBlinkCallbackPayloadTemplate struct {
 	ID string `json:"id,omitempty"` // The ID of the payload template. Defaults to 'wpt_00005' for the Callback (included) template.
 }
 type RequestDevicesCreateDeviceLiveToolsPing struct {
@@ -1031,6 +1561,16 @@ type RequestDevicesVmxNetworkDevicesClaim struct {
 type RequestDevicesRemoveNetworkDevices struct {
 	Serial string `json:"serial,omitempty"` // The serial of a device
 }
+type RequestDevicesBatchNetworkFloorPlansDevicesUpdate struct {
+	Assignments *[]RequestDevicesBatchNetworkFloorPlansDevicesUpdateAssignments `json:"assignments,omitempty"` // List of floorplan assignments to update. Up to 100 floor plan assignments can be provided in a request.
+}
+type RequestDevicesBatchNetworkFloorPlansDevicesUpdateAssignments struct {
+	FloorPlan *RequestDevicesBatchNetworkFloorPlansDevicesUpdateAssignmentsFloorPlan `json:"floorPlan,omitempty"` // Floorplan to be assigned or unassigned
+	Serial    string                                                                 `json:"serial,omitempty"`    // Serial of the device to change the floor plan assignment for
+}
+type RequestDevicesBatchNetworkFloorPlansDevicesUpdateAssignmentsFloorPlan struct {
+	ID string `json:"id,omitempty"` // The ID of the floor plan to assign the device to, or null to unassign the device from its floor plan
+}
 type RequestDevicesCheckinNetworkSmDevices struct {
 	IDs      []string `json:"ids,omitempty"`      // The ids of the devices to be checked-in.
 	Scope    []string `json:"scope,omitempty"`    // The scope (one of all, none, withAny, withAll, withoutAny, or withoutAll) and a set of tags of the devices to be checked-in.
@@ -1108,7 +1648,7 @@ type RequestOrganizationsCloneOrganizationSwitchDevices struct {
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device
+
 */
 func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}"
@@ -1141,7 +1681,7 @@ func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *r
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-cellular-sims
+
 */
 func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesGetDeviceCellularSims, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellular/sims"
@@ -1175,7 +1715,7 @@ func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesG
 @param serial serial path parameter.
 @param getDeviceClientsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-clients
+
 */
 func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryParams *GetDeviceClientsQueryParams) (*ResponseDevicesGetDeviceClients, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/clients"
@@ -1211,7 +1751,7 @@ func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryPa
 @param serial serial path parameter.
 @param arpTableID arpTableId path parameter. Arp table ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-arp-table
+
 */
 func (s *DevicesService) GetDeviceLiveToolsArpTable(serial string, arpTableID string) (*ResponseDevicesGetDeviceLiveToolsArpTable, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/arpTable/{arpTableId}"
@@ -1246,7 +1786,7 @@ func (s *DevicesService) GetDeviceLiveToolsArpTable(serial string, arpTableID st
 @param serial serial path parameter.
 @param id id path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-cable-test
+
 */
 func (s *DevicesService) GetDeviceLiveToolsCableTest(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsCableTest, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/cableTest/{id}"
@@ -1275,13 +1815,48 @@ func (s *DevicesService) GetDeviceLiveToolsCableTest(serial string, id string) (
 
 }
 
+//GetDeviceLiveToolsLedsBlink Return a blink LEDs job
+/* Return a blink LEDs job
+
+@param serial serial path parameter.
+@param ledsBlinkID ledsBlinkId path parameter. Leds blink ID
+
+
+*/
+func (s *DevicesService) GetDeviceLiveToolsLedsBlink(serial string, ledsBlinkID string) (*ResponseDevicesGetDeviceLiveToolsLedsBlink, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/leds/blink/{ledsBlinkId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{ledsBlinkId}", fmt.Sprintf("%v", ledsBlinkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetDeviceLiveToolsLedsBlink{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceLiveToolsLedsBlink")
+	}
+
+	result := response.Result().(*ResponseDevicesGetDeviceLiveToolsLedsBlink)
+	return result, response, err
+
+}
+
 //GetDeviceLiveToolsPing Return a ping job
 /* Return a ping job. Latency unit in response is in milliseconds. Size is in bytes.
 
 @param serial serial path parameter.
 @param id id path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-ping
+
 */
 func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPing, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/ping/{id}"
@@ -1316,7 +1891,7 @@ func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*Resp
 @param serial serial path parameter.
 @param id id path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-ping-device
+
 */
 func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPingDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/pingDevice/{id}"
@@ -1351,7 +1926,7 @@ func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) 
 @param serial serial path parameter.
 @param throughputTestID throughputTestId path parameter. Throughput test ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-throughput-test
+
 */
 func (s *DevicesService) GetDeviceLiveToolsThroughputTest(serial string, throughputTestID string) (*ResponseDevicesGetDeviceLiveToolsThroughputTest, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/throughputTest/{throughputTestId}"
@@ -1386,7 +1961,7 @@ func (s *DevicesService) GetDeviceLiveToolsThroughputTest(serial string, through
 @param serial serial path parameter.
 @param wakeOnLanID wakeOnLanId path parameter. Wake on lan ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-live-tools-wake-on-lan
+
 */
 func (s *DevicesService) GetDeviceLiveToolsWakeOnLan(serial string, wakeOnLanID string) (*ResponseDevicesGetDeviceLiveToolsWakeOnLan, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/wakeOnLan/{wakeOnLanId}"
@@ -1420,7 +1995,7 @@ func (s *DevicesService) GetDeviceLiveToolsWakeOnLan(serial string, wakeOnLanID 
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-lldp-cdp
+
 */
 func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDeviceLldpCdp, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lldpCdp"
@@ -1454,7 +2029,7 @@ func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDev
 @param serial serial path parameter.
 @param getDeviceLossAndLatencyHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-loss-and-latency-history
+
 */
 func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDeviceLossAndLatencyHistoryQueryParams *GetDeviceLossAndLatencyHistoryQueryParams) (*ResponseDevicesGetDeviceLossAndLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lossAndLatencyHistory"
@@ -1489,7 +2064,7 @@ func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDevice
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-management-interface
+
 */
 func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseDevicesGetDeviceManagementInterface, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/managementInterface"
@@ -1522,7 +2097,7 @@ func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseD
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-devices
+
 */
 func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGetNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices"
@@ -1556,7 +2131,7 @@ func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGe
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-cellular-usage-history
+
 */
 func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCellularUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/cellularUsageHistory"
@@ -1591,7 +2166,7 @@ func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-certs
+
 */
 func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCerts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/certs"
@@ -1626,7 +2201,7 @@ func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID stri
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-device-profiles
+
 */
 func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceDeviceProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/deviceProfiles"
@@ -1661,7 +2236,7 @@ func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, devi
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-network-adapters
+
 */
 func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceNetworkAdapters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/networkAdapters"
@@ -1696,7 +2271,7 @@ func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, dev
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-restrictions
+
 */
 func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceRestrictions, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/restrictions"
@@ -1731,7 +2306,7 @@ func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, device
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-security-centers
+
 */
 func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSecurityCenters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/securityCenters"
@@ -1766,7 +2341,7 @@ func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, dev
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-softwares
+
 */
 func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSoftwares, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/softwares"
@@ -1801,7 +2376,7 @@ func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID 
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-sm-device-wlan-lists
+
 */
 func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceWLANLists, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/wlanLists"
@@ -1836,7 +2411,7 @@ func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-devices-availabilities-change-history
+
 */
 func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/availabilities/changeHistory"
@@ -1865,20 +2440,20 @@ func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organ
 
 }
 
-//GetOrganizationDevicesBootsHistory Returns the history of device boots in reverse chronological order (most recent first)
-/* Returns the history of device boots in reverse chronological order (most recent first). Currently supported for MS devices only.
+//GetOrganizationDevicesOverviewByModel Lists the count for each device model
+/* Lists the count for each device model
 
 @param organizationID organizationId path parameter. Organization ID
-@param getOrganizationDevicesBootsHistoryQueryParams Filtering parameter
+@param getOrganizationDevicesOverviewByModelQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-devices-boots-history
+
 */
-func (s *DevicesService) GetOrganizationDevicesBootsHistory(organizationID string, getOrganizationDevicesBootsHistoryQueryParams *GetOrganizationDevicesBootsHistoryQueryParams) (*resty.Response, error) {
-	path := "/api/v1/organizations/{organizationId}/devices/boots/history"
+func (s *DevicesService) GetOrganizationDevicesOverviewByModel(organizationID string, getOrganizationDevicesOverviewByModelQueryParams *GetOrganizationDevicesOverviewByModelQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/overview/byModel"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
-	queryString, _ := query.Values(getOrganizationDevicesBootsHistoryQueryParams)
+	queryString, _ := query.Values(getOrganizationDevicesOverviewByModelQueryParams)
 
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
@@ -1893,7 +2468,42 @@ func (s *DevicesService) GetOrganizationDevicesBootsHistory(organizationID strin
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationDevicesBootsHistory")
+		return response, fmt.Errorf("error with operation GetOrganizationDevicesOverviewByModel")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationFloorPlansAutoLocateDevices List auto locate details for each device in your organization
+/* List auto locate details for each device in your organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationFloorPlansAutoLocateDevicesQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevices(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams *GetOrganizationFloorPlansAutoLocateDevicesQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/devices"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateDevicesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationFloorPlansAutoLocateDevices")
 	}
 
 	return response, err
@@ -1906,7 +2516,7 @@ func (s *DevicesService) GetOrganizationDevicesBootsHistory(organizationID strin
 @param organizationID organizationId path parameter. Organization ID
 @param id id path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-inventory-devices-swaps-bulk
+
 */
 func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk/{id}"
@@ -1939,7 +2549,7 @@ func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID
 @param organizationID organizationId path parameter. Organization ID
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-inventory-device
+
 */
 func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, serial string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/{serial}"
@@ -1972,7 +2582,7 @@ func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, s
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-device
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
@@ -2007,7 +2617,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevic
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-network
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
@@ -2042,7 +2652,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwo
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-device-by-interval
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
@@ -2077,7 +2687,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-network-by-interval
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
@@ -2112,7 +2722,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByClientQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-client
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
@@ -2147,7 +2757,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organi
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByDeviceQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-device
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
@@ -2182,7 +2792,7 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organi
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByNetworkQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-network
+
 */
 func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
@@ -2211,12 +2821,432 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organ
 
 }
 
+//GetOrganizationWirelessDevicesWirelessControllersByDevice List of Catalyst access points information
+/* List of Catalyst access points information
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams *GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/wirelessControllers/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesWirelessControllersByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice List wireless LAN controller layer 2 interfaces in an organization
+/* List wireless LAN controller layer 2 interfaces in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice List wireless LAN controller layer 2 interfaces history status in an organization
+/* List wireless LAN controller layer 2 interfaces history status in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/statuses/changeHistory/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval List wireless LAN controller layer 2 interfaces history usage in an organization
+/* List wireless LAN controller layer 2 interfaces history usage in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice List wireless LAN controller layer 3 interfaces in an organization
+/* List wireless LAN controller layer 3 interfaces in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice List wireless LAN controller layer 3 interfaces history status in an organization
+/* List wireless LAN controller layer 3 interfaces history status in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/statuses/changeHistory/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval List wireless LAN controller layer 3 interfaces history usage in an organization
+/* List wireless LAN controller layer 3 interfaces history usage in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice Retrieve the packet counters for the interfaces of a Wireless LAN controller
+/* Retrieve the packet counters for the interfaces of a Wireless LAN controller
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/packets/overview/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval Retrieve the traffic for the interfaces of a Wireless LAN controller
+/* Retrieve the traffic for the interfaces of a Wireless LAN controller
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory List the failover events of wireless LAN controllers in an organization
+/* List the failover events of wireless LAN controllers in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams *GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/failover/history"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesRedundancyStatuses List redundancy details of wireless LAN controllers in an organization
+/* List redundancy details of wireless LAN controllers in an organization. The failover count refers to the total failovers system happens from the moment of this device onboarding to Dashboard
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams *GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/statuses"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyStatuses")
+	}
+
+	return response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval List cpu utilization data of wireless LAN controllers in an organization
+/* List cpu utilization data of wireless LAN controllers in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/system/utilization/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval")
+	}
+
+	return response, err
+
+}
+
 //BlinkDeviceLeds Blink the LEDs on a device
-/* Blink the LEDs on a device
+/* Blink the LEDs on a device.  This endpoint is deprecrated in favor of "/devices/{serial}/liveTools/leds/blink".
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!blink-device-leds
+
 */
 
 func (s *DevicesService) BlinkDeviceLeds(serial string, requestDevicesBlinkDeviceLeds *RequestDevicesBlinkDeviceLeds) (*ResponseDevicesBlinkDeviceLeds, *resty.Response, error) {
@@ -2247,11 +3277,11 @@ func (s *DevicesService) BlinkDeviceLeds(serial string, requestDevicesBlinkDevic
 }
 
 //CreateDeviceLiveToolsArpTable Enqueue a job to perform a ARP table request for the device
-/* Enqueue a job to perform a ARP table request for the device. This endpoint currently supports switches.
+/* Enqueue a job to perform a ARP table request for the device. This endpoint currently supports switches. This endpoint has a sustained rate limit of one request every five seconds per device, with an allowed burst of five requests.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-arp-table
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsArpTable(serial string, requestDevicesCreateDeviceLiveToolsArpTable *RequestDevicesCreateDeviceLiveToolsArpTable) (*ResponseDevicesCreateDeviceLiveToolsArpTable, *resty.Response, error) {
@@ -2281,12 +3311,12 @@ func (s *DevicesService) CreateDeviceLiveToolsArpTable(serial string, requestDev
 
 }
 
-//CreateDeviceLiveToolsCableTest Enqueue a job to perform a cable test for the device on the specified ports.
-/* Enqueue a job to perform a cable test for the device on the specified ports.
+//CreateDeviceLiveToolsCableTest Enqueue a job to perform a cable test for the device on the specified ports
+/* Enqueue a job to perform a cable test for the device on the specified ports. This endpoint has a sustained rate limit of one request every five seconds per device, with an allowed burst of five requests.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-cable-test
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsCableTest(serial string, requestDevicesCreateDeviceLiveToolsCableTest *RequestDevicesCreateDeviceLiveToolsCableTest) (*ResponseDevicesCreateDeviceLiveToolsCableTest, *resty.Response, error) {
@@ -2316,12 +3346,47 @@ func (s *DevicesService) CreateDeviceLiveToolsCableTest(serial string, requestDe
 
 }
 
-//CreateDeviceLiveToolsPing Enqueue a job to ping a target host from the device
-/* Enqueue a job to ping a target host from the device
+//CreateDeviceLiveToolsLedsBlink Enqueue a job to blink LEDs on a device
+/* Enqueue a job to blink LEDs on a device. This endpoint has a rate limit of one request every 10 seconds.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-ping
+
+*/
+
+func (s *DevicesService) CreateDeviceLiveToolsLedsBlink(serial string, requestDevicesCreateDeviceLiveToolsLedsBlink *RequestDevicesCreateDeviceLiveToolsLedsBlink) (*ResponseDevicesCreateDeviceLiveToolsLedsBlink, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/liveTools/leds/blink"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesCreateDeviceLiveToolsLedsBlink).
+		SetResult(&ResponseDevicesCreateDeviceLiveToolsLedsBlink{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceLiveToolsLedsBlink")
+	}
+
+	result := response.Result().(*ResponseDevicesCreateDeviceLiveToolsLedsBlink)
+	return result, response, err
+
+}
+
+//CreateDeviceLiveToolsPing Enqueue a job to ping a target host from the device
+/* Enqueue a job to ping a target host from the device. This endpoint has a sustained rate limit of one request every five seconds per device, with an allowed burst of five requests.
+
+@param serial serial path parameter.
+
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsPing(serial string, requestDevicesCreateDeviceLiveToolsPing *RequestDevicesCreateDeviceLiveToolsPing) (*ResponseDevicesCreateDeviceLiveToolsPing, *resty.Response, error) {
@@ -2352,11 +3417,11 @@ func (s *DevicesService) CreateDeviceLiveToolsPing(serial string, requestDevices
 }
 
 //CreateDeviceLiveToolsPingDevice Enqueue a job to check connectivity status to the device
-/* Enqueue a job to check connectivity status to the device
+/* Enqueue a job to check connectivity status to the device. This endpoint has a sustained rate limit of one request every five seconds per device, with an allowed burst of five requests.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-ping-device
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsPingDevice(serial string, requestDevicesCreateDeviceLiveToolsPingDevice *RequestDevicesCreateDeviceLiveToolsPingDevice) (*ResponseDevicesCreateDeviceLiveToolsPingDevice, *resty.Response, error) {
@@ -2387,11 +3452,11 @@ func (s *DevicesService) CreateDeviceLiveToolsPingDevice(serial string, requestD
 }
 
 //CreateDeviceLiveToolsThroughputTest Enqueue a job to test a device throughput, the test will run for 10 secs to test throughput
-/* Enqueue a job to test a device throughput, the test will run for 10 secs to test throughput
+/* Enqueue a job to test a device throughput, the test will run for 10 secs to test throughput. This endpoint has a rate limit of one request every five seconds per device.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-throughput-test
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsThroughputTest(serial string, requestDevicesCreateDeviceLiveToolsThroughputTest *RequestDevicesCreateDeviceLiveToolsThroughputTest) (*ResponseDevicesCreateDeviceLiveToolsThroughputTest, *resty.Response, error) {
@@ -2422,11 +3487,11 @@ func (s *DevicesService) CreateDeviceLiveToolsThroughputTest(serial string, requ
 }
 
 //CreateDeviceLiveToolsWakeOnLan Enqueue a job to send a Wake-on-LAN packet from the device
-/* Enqueue a job to send a Wake-on-LAN packet from the device
+/* Enqueue a job to send a Wake-on-LAN packet from the device. This endpoint has a sustained rate limit of one request every five seconds per device, with an allowed burst of five requests.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-device-live-tools-wake-on-lan
+
 */
 
 func (s *DevicesService) CreateDeviceLiveToolsWakeOnLan(serial string, requestDevicesCreateDeviceLiveToolsWakeOnLan *RequestDevicesCreateDeviceLiveToolsWakeOnLan) (*ResponseDevicesCreateDeviceLiveToolsWakeOnLan, *resty.Response, error) {
@@ -2457,11 +3522,11 @@ func (s *DevicesService) CreateDeviceLiveToolsWakeOnLan(serial string, requestDe
 }
 
 //RebootDevice Reboot a device
-/* Reboot a device
+/* Reboot a device. This endpoint has a sustained rate limit of one request every 60 seconds.
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!reboot-device
+
 */
 
 func (s *DevicesService) RebootDevice(serial string) (*ResponseDevicesRebootDevice, *resty.Response, error) {
@@ -2494,19 +3559,22 @@ func (s *DevicesService) RebootDevice(serial string) (*ResponseDevicesRebootDevi
 /* Claim devices into a network. (Note: for recently claimed devices, it may take a few minutes for API requests against that device to succeed). This operation can be used up to ten times within a single five minute window.
 
 @param networkID networkId path parameter. Network ID
+@param claimNetworkDevicesQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!claim-network-devices
+
 */
 
-func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesClaimNetworkDevices *RequestDevicesClaimNetworkDevices) (*ResponseDevicesClaimNetworkDevices, *resty.Response, error) {
+func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesClaimNetworkDevices *RequestDevicesClaimNetworkDevices, claimNetworkDevicesQueryParams *ClaimNetworkDevicesQueryParams) (*ResponseDevicesClaimNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices/claim"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
+	queryString, _ := query.Values(claimNetworkDevicesQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBody(requestDevicesClaimNetworkDevices).
+		SetQueryString(queryString.Encode()).SetBody(requestDevicesClaimNetworkDevices).
 		SetResult(&ResponseDevicesClaimNetworkDevices{}).
 		SetError(&Error).
 		Post(path)
@@ -2530,7 +3598,7 @@ func (s *DevicesService) ClaimNetworkDevices(networkID string, requestDevicesCla
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!vmx-network-devices-claim
+
 */
 
 func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevicesVmxNetworkDevicesClaim *RequestDevicesVmxNetworkDevicesClaim) (*ResponseDevicesVmxNetworkDevicesClaim, *resty.Response, error) {
@@ -2565,7 +3633,7 @@ func (s *DevicesService) VmxNetworkDevicesClaim(networkID string, requestDevices
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!remove-network-devices
+
 */
 
 func (s *DevicesService) RemoveNetworkDevices(networkID string, requestDevicesRemoveNetworkDevices *RequestDevicesRemoveNetworkDevices) (*resty.Response, error) {
@@ -2593,12 +3661,47 @@ func (s *DevicesService) RemoveNetworkDevices(networkID string, requestDevicesRe
 
 }
 
+//BatchNetworkFloorPlansDevicesUpdate Update floorplan assignments for a batch of devices
+/* Update floorplan assignments for a batch of devices
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *DevicesService) BatchNetworkFloorPlansDevicesUpdate(networkID string, requestDevicesBatchNetworkFloorPlansDevicesUpdate *RequestDevicesBatchNetworkFloorPlansDevicesUpdate) (*ResponseDevicesBatchNetworkFloorPlansDevicesUpdate, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/floorPlans/devices/batchUpdate"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestDevicesBatchNetworkFloorPlansDevicesUpdate).
+		SetResult(&ResponseDevicesBatchNetworkFloorPlansDevicesUpdate{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation BatchNetworkFloorPlansDevicesUpdate")
+	}
+
+	result := response.Result().(*ResponseDevicesBatchNetworkFloorPlansDevicesUpdate)
+	return result, response, err
+
+}
+
 //CheckinNetworkSmDevices Force check-in a set of devices
 /* Force check-in a set of devices
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!checkin-network-sm-devices
+
 */
 
 func (s *DevicesService) CheckinNetworkSmDevices(networkID string, requestDevicesCheckinNetworkSmDevices *RequestDevicesCheckinNetworkSmDevices) (*ResponseDevicesCheckinNetworkSmDevices, *resty.Response, error) {
@@ -2633,7 +3736,7 @@ func (s *DevicesService) CheckinNetworkSmDevices(networkID string, requestDevice
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!lock-network-sm-devices
+
 */
 
 func (s *DevicesService) LockNetworkSmDevices(networkID string, requestDevicesLockNetworkSmDevices *RequestDevicesLockNetworkSmDevices) (*ResponseDevicesLockNetworkSmDevices, *resty.Response, error) {
@@ -2668,7 +3771,7 @@ func (s *DevicesService) LockNetworkSmDevices(networkID string, requestDevicesLo
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!modify-network-sm-devices-tags
+
 */
 
 func (s *DevicesService) ModifyNetworkSmDevicesTags(networkID string, requestDevicesModifyNetworkSmDevicesTags *RequestDevicesModifyNetworkSmDevicesTags) (*ResponseDevicesModifyNetworkSmDevicesTags, *resty.Response, error) {
@@ -2703,7 +3806,7 @@ func (s *DevicesService) ModifyNetworkSmDevicesTags(networkID string, requestDev
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!move-network-sm-devices
+
 */
 
 func (s *DevicesService) MoveNetworkSmDevices(networkID string, requestDevicesMoveNetworkSmDevices *RequestDevicesMoveNetworkSmDevices) (*ResponseDevicesMoveNetworkSmDevices, *resty.Response, error) {
@@ -2738,7 +3841,7 @@ func (s *DevicesService) MoveNetworkSmDevices(networkID string, requestDevicesMo
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!reboot-network-sm-devices
+
 */
 
 func (s *DevicesService) RebootNetworkSmDevices(networkID string, requestDevicesRebootNetworkSmDevices *RequestDevicesRebootNetworkSmDevices) (*ResponseDevicesRebootNetworkSmDevices, *resty.Response, error) {
@@ -2773,7 +3876,7 @@ func (s *DevicesService) RebootNetworkSmDevices(networkID string, requestDevices
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!shutdown-network-sm-devices
+
 */
 
 func (s *DevicesService) ShutdownNetworkSmDevices(networkID string, requestDevicesShutdownNetworkSmDevices *RequestDevicesShutdownNetworkSmDevices) (*ResponseDevicesShutdownNetworkSmDevices, *resty.Response, error) {
@@ -2808,7 +3911,7 @@ func (s *DevicesService) ShutdownNetworkSmDevices(networkID string, requestDevic
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!wipe-network-sm-devices
+
 */
 
 func (s *DevicesService) WipeNetworkSmDevices(networkID string, requestDevicesWipeNetworkSmDevices *RequestDevicesWipeNetworkSmDevices) (*ResponseDevicesWipeNetworkSmDevices, *resty.Response, error) {
@@ -2844,7 +3947,7 @@ func (s *DevicesService) WipeNetworkSmDevices(networkID string, requestDevicesWi
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!install-network-sm-device-apps
+
 */
 
 func (s *DevicesService) InstallNetworkSmDeviceApps(networkID string, deviceID string, requestDevicesInstallNetworkSmDeviceApps *RequestDevicesInstallNetworkSmDeviceApps) (*resty.Response, error) {
@@ -2857,6 +3960,7 @@ func (s *DevicesService) InstallNetworkSmDeviceApps(networkID string, deviceID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesInstallNetworkSmDeviceApps).
+		// SetResult(&ResponseDevicesInstallNetworkSmDeviceApps{}).
 		SetError(&Error).
 		Post(path)
 
@@ -2879,7 +3983,7 @@ func (s *DevicesService) InstallNetworkSmDeviceApps(networkID string, deviceID s
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!refresh-network-sm-device-details
+
 */
 
 func (s *DevicesService) RefreshNetworkSmDeviceDetails(networkID string, deviceID string) (*resty.Response, error) {
@@ -2891,6 +3995,8 @@ func (s *DevicesService) RefreshNetworkSmDeviceDetails(networkID string, deviceI
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+
+		// SetResult(&ResponseDevicesRefreshNetworkSmDeviceDetails{}).
 		SetError(&Error).
 		Post(path)
 
@@ -2913,7 +4019,7 @@ func (s *DevicesService) RefreshNetworkSmDeviceDetails(networkID string, deviceI
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!unenroll-network-sm-device
+
 */
 
 func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID string) (*ResponseDevicesUnenrollNetworkSmDevice, *resty.Response, error) {
@@ -2949,7 +4055,7 @@ func (s *DevicesService) UnenrollNetworkSmDevice(networkID string, deviceID stri
 @param networkID networkId path parameter. Network ID
 @param deviceID deviceId path parameter. Device ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!uninstall-network-sm-device-apps
+
 */
 
 func (s *DevicesService) UninstallNetworkSmDeviceApps(networkID string, deviceID string, requestDevicesUninstallNetworkSmDeviceApps *RequestDevicesUninstallNetworkSmDeviceApps) (*resty.Response, error) {
@@ -2962,6 +4068,7 @@ func (s *DevicesService) UninstallNetworkSmDeviceApps(networkID string, deviceID
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesUninstallNetworkSmDeviceApps).
+		// SetResult(&ResponseDevicesUninstallNetworkSmDeviceApps{}).
 		SetError(&Error).
 		Post(path)
 
@@ -2978,12 +4085,44 @@ func (s *DevicesService) UninstallNetworkSmDeviceApps(networkID string, deviceID
 
 }
 
+//BulkUpdateOrganizationDevicesDetails Updating device details (currently only used for Catalyst devices)
+/* Updating device details (currently only used for Catalyst devices)
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *DevicesService) BulkUpdateOrganizationDevicesDetails(organizationID string) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/details/bulkUpdate"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation BulkUpdateOrganizationDevicesDetails")
+	}
+
+	return response, err
+
+}
+
 //CreateOrganizationInventoryDevicesSwapsBulk Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
 /* Swap the devices identified by devices.old with a devices.new, then perform the :afterAction on the devices.old.
 
 @param organizationID organizationId path parameter. Organization ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-organization-inventory-devices-swaps-bulk
+
 */
 
 func (s *DevicesService) CreateOrganizationInventoryDevicesSwapsBulk(organizationID string) (*resty.Response, error) {
@@ -3015,7 +4154,7 @@ func (s *DevicesService) CreateOrganizationInventoryDevicesSwapsBulk(organizatio
 
 @param organizationID organizationId path parameter. Organization ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!clone-organization-switch-devices
+
 */
 
 func (s *DevicesService) CloneOrganizationSwitchDevices(organizationID string) (*resty.Response, error) {
@@ -3047,7 +4186,7 @@ func (s *DevicesService) CloneOrganizationSwitchDevices(organizationID string) (
 
 @param serial serial path parameter.
 */
-func (s *DevicesService) UpdateDevice(serial string, requestDevicesUpdateDevice *RequestDevicesUpdateDevice) (*resty.Response, error) {
+func (s *DevicesService) UpdateDevice(serial string, requestDevicesUpdateDevice *RequestDevicesUpdateDevice) (*ResponseDevicesUpdateDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -3056,19 +4195,21 @@ func (s *DevicesService) UpdateDevice(serial string, requestDevicesUpdateDevice 
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesUpdateDevice).
+		SetResult(&ResponseDevicesUpdateDevice{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDevice")
+		return nil, response, fmt.Errorf("error with operation UpdateDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesUpdateDevice)
+	return result, response, err
 
 }
 
@@ -3077,7 +4218,7 @@ func (s *DevicesService) UpdateDevice(serial string, requestDevicesUpdateDevice 
 
 @param serial serial path parameter.
 */
-func (s *DevicesService) UpdateDeviceCellularSims(serial string, requestDevicesUpdateDeviceCellularSims *RequestDevicesUpdateDeviceCellularSims) (*resty.Response, error) {
+func (s *DevicesService) UpdateDeviceCellularSims(serial string, requestDevicesUpdateDeviceCellularSims *RequestDevicesUpdateDeviceCellularSims) (*ResponseDevicesUpdateDeviceCellularSims, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellular/sims"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
@@ -3086,19 +4227,21 @@ func (s *DevicesService) UpdateDeviceCellularSims(serial string, requestDevicesU
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestDevicesUpdateDeviceCellularSims).
+		SetResult(&ResponseDevicesUpdateDeviceCellularSims{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateDeviceCellularSims")
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceCellularSims")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesUpdateDeviceCellularSims)
+	return result, response, err
 
 }
 

--- a/sdk/licensing.go
+++ b/sdk/licensing.go
@@ -21,6 +21,7 @@ type GetAdministeredLicensingSubscriptionSubscriptionsQueryParams struct {
 	OrganizationIDs []string `url:"organizationIds[],omitempty"` //Organizations to get associated subscriptions for
 	Statuses        []string `url:"statuses[],omitempty"`        //List of statuses that returned subscriptions can have
 	ProductTypes    []string `url:"productTypes[],omitempty"`    //List of product types that returned subscriptions need to have entitlements for.
+	Name            string   `url:"name,omitempty"`              //Search for subscription name
 	StartDate       string   `url:"startDate,omitempty"`         //Filter subscriptions by start date, ISO 8601 format. To filter with a range of dates, use 'startDate[<option>]=?' in the request. Accepted options include lt, gt, lte, gte.
 	EndDate         string   `url:"endDate,omitempty"`           //Filter subscriptions by end date, ISO 8601 format. To filter with a range of dates, use 'endDate[<option>]=?' in the request. Accepted options include lt, gt, lte, gte.
 }
@@ -52,94 +53,151 @@ type ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements struct {
 }
 type ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions []ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptions // Array of ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptions struct {
-	Counts         *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
-	Description    string                                                                                `json:"description,omitempty"`    // Subscription description
-	EndDate        string                                                                                `json:"endDate,omitempty"`        // Subscription expiration date
-	Entitlements   *[]ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlements `json:"entitlements,omitempty"`   // Entitlement info
-	Name           string                                                                                `json:"name,omitempty"`           // Subscription name
-	ProductTypes   []string                                                                              `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
-	StartDate      string                                                                                `json:"startDate,omitempty"`      // Subscription start date
-	Status         string                                                                                `json:"status,omitempty"`         // Subscription status
-	SubscriptionID string                                                                                `json:"subscriptionId,omitempty"` // Subscription's ID
-	WebOrderID     string                                                                                `json:"webOrderId,omitempty"`     // Web order id
+	Counts              *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCounts              `json:"counts,omitempty"`              // Numeric breakdown of network, organizations, entitlement counts
+	Description         string                                                                                     `json:"description,omitempty"`         // Subscription description
+	EndDate             string                                                                                     `json:"endDate,omitempty"`             // Subscription expiration date
+	EnterpriseAgreement *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEnterpriseAgreement `json:"enterpriseAgreement,omitempty"` // enterprise agreement details
+	Entitlements        *[]ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlements      `json:"entitlements,omitempty"`        // Entitlement info
+	LastUpdatedAt       string                                                                                     `json:"lastUpdatedAt,omitempty"`       // When the subscription was last changed
+	Name                string                                                                                     `json:"name,omitempty"`                // Subscription name
+	ProductTypes        []string                                                                                   `json:"productTypes,omitempty"`        // Products the subscription has entitlements for
+	RenewalRequested    *bool                                                                                      `json:"renewalRequested,omitempty"`    // Whether a renewal has been requested for the subscription
+	SmartAccount        *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsSmartAccount        `json:"smartAccount,omitempty"`        // Smart Account linkage information
+	StartDate           string                                                                                     `json:"startDate,omitempty"`           // Subscription start date
+	Status              string                                                                                     `json:"status,omitempty"`              // Subscription status
+	SubscriptionID      string                                                                                     `json:"subscriptionId,omitempty"`      // Subscription's ID
+	Type                string                                                                                     `json:"type,omitempty"`                // Subscription type
+	WebOrderID          string                                                                                     `json:"webOrderId,omitempty"`          // Web order id
 }
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCounts struct {
-	Networks *int                                                                               `json:"networks,omitempty"` // Number of networks bound to this subscription
-	Seats    *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`    // Seat distribution
+	Networks      *int                                                                               `json:"networks,omitempty"`      // Number of networks bound to this subscription
+	Organizations *int                                                                               `json:"organizations,omitempty"` // Number of organizations bound to this subscription
+	Seats         *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`         // Seat distribution
 }
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsCountsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
 }
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEnterpriseAgreement struct {
+	Suites []string `json:"suites,omitempty"` // List of suites included. Empty for non-EA subscriptions.
+}
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlements struct {
-	Seats *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
-	Sku   string                                                                                   `json:"sku,omitempty"`   // SKU of the required product
+	Seats          *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"`          // Seat distribution
+	Sku            string                                                                                   `json:"sku,omitempty"`            // SKU of the required product
+	WebOrderLineID string                                                                                   `json:"webOrderLineId,omitempty"` // Web order line ID
 }
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
 }
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsSmartAccount struct {
+	Account *ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsSmartAccountAccount `json:"account,omitempty"` // Smart Account data
+	Status  string                                                                                     `json:"status,omitempty"`  // Subscription Smart Account status
+}
+type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsSmartAccountAccount struct {
+	Domain string `json:"domain,omitempty"` // The domain of the Smart Account
+	ID     string `json:"id,omitempty"`     // Smart Account ID
+	Name   string `json:"name,omitempty"`   // The name of the smart account
+}
 type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptions struct {
-	Counts         *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
-	Description    string                                                                              `json:"description,omitempty"`    // Subscription description
-	EndDate        string                                                                              `json:"endDate,omitempty"`        // Subscription expiration date
-	Entitlements   *[]ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlements `json:"entitlements,omitempty"`   // Entitlement info
-	Name           string                                                                              `json:"name,omitempty"`           // Subscription name
-	ProductTypes   []string                                                                            `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
-	StartDate      string                                                                              `json:"startDate,omitempty"`      // Subscription start date
-	Status         string                                                                              `json:"status,omitempty"`         // Subscription status
-	SubscriptionID string                                                                              `json:"subscriptionId,omitempty"` // Subscription's ID
-	WebOrderID     string                                                                              `json:"webOrderId,omitempty"`     // Web order id
+	Counts              *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCounts              `json:"counts,omitempty"`              // Numeric breakdown of network, organizations, entitlement counts
+	Description         string                                                                                   `json:"description,omitempty"`         // Subscription description
+	EndDate             string                                                                                   `json:"endDate,omitempty"`             // Subscription expiration date
+	EnterpriseAgreement *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEnterpriseAgreement `json:"enterpriseAgreement,omitempty"` // enterprise agreement details
+	Entitlements        *[]ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlements      `json:"entitlements,omitempty"`        // Entitlement info
+	LastUpdatedAt       string                                                                                   `json:"lastUpdatedAt,omitempty"`       // When the subscription was last changed
+	Name                string                                                                                   `json:"name,omitempty"`                // Subscription name
+	ProductTypes        []string                                                                                 `json:"productTypes,omitempty"`        // Products the subscription has entitlements for
+	RenewalRequested    *bool                                                                                    `json:"renewalRequested,omitempty"`    // Whether a renewal has been requested for the subscription
+	SmartAccount        *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsSmartAccount        `json:"smartAccount,omitempty"`        // Smart Account linkage information
+	StartDate           string                                                                                   `json:"startDate,omitempty"`           // Subscription start date
+	Status              string                                                                                   `json:"status,omitempty"`              // Subscription status
+	SubscriptionID      string                                                                                   `json:"subscriptionId,omitempty"`      // Subscription's ID
+	Type                string                                                                                   `json:"type,omitempty"`                // Subscription type
+	WebOrderID          string                                                                                   `json:"webOrderId,omitempty"`          // Web order id
 }
 type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCounts struct {
-	Networks *int                                                                             `json:"networks,omitempty"` // Number of networks bound to this subscription
-	Seats    *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`    // Seat distribution
+	Networks      *int                                                                             `json:"networks,omitempty"`      // Number of networks bound to this subscription
+	Organizations *int                                                                             `json:"organizations,omitempty"` // Number of organizations bound to this subscription
+	Seats         *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCountsSeats `json:"seats,omitempty"`         // Seat distribution
 }
 type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsCountsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
 }
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEnterpriseAgreement struct {
+	Suites []string `json:"suites,omitempty"` // List of suites included. Empty for non-EA subscriptions.
+}
 type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlements struct {
-	Seats *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
-	Sku   string                                                                                 `json:"sku,omitempty"`   // SKU of the required product
+	Seats          *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats `json:"seats,omitempty"`          // Seat distribution
+	Sku            string                                                                                 `json:"sku,omitempty"`            // SKU of the required product
+	WebOrderLineID string                                                                                 `json:"webOrderLineId,omitempty"` // Web order line ID
 }
 type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsEntitlementsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
 }
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsSmartAccount struct {
+	Account *ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsSmartAccountAccount `json:"account,omitempty"` // Smart Account data
+	Status  string                                                                                   `json:"status,omitempty"`  // Subscription Smart Account status
+}
+type ResponseLicensingClaimAdministeredLicensingSubscriptionSubscriptionsSmartAccountAccount struct {
+	Domain string `json:"domain,omitempty"` // The domain of the Smart Account
+	ID     string `json:"id,omitempty"`     // Smart Account ID
+	Name   string `json:"name,omitempty"`   // The name of the smart account
+}
 type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKey struct {
-	Counts         *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCounts         `json:"counts,omitempty"`         // Numeric breakdown of network and entitlement counts
-	Description    string                                                                                         `json:"description,omitempty"`    // Subscription description
-	EndDate        string                                                                                         `json:"endDate,omitempty"`        // Subscription expiration date
-	Entitlements   *[]ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlements `json:"entitlements,omitempty"`   // Entitlement info
-	Name           string                                                                                         `json:"name,omitempty"`           // Subscription name
-	ProductTypes   []string                                                                                       `json:"productTypes,omitempty"`   // Products the subscription has entitlements for
-	StartDate      string                                                                                         `json:"startDate,omitempty"`      // Subscription start date
-	Status         string                                                                                         `json:"status,omitempty"`         // Subscription status
-	SubscriptionID string                                                                                         `json:"subscriptionId,omitempty"` // Subscription's ID
-	WebOrderID     string                                                                                         `json:"webOrderId,omitempty"`     // Web order id
+	Counts              *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCounts              `json:"counts,omitempty"`              // Numeric breakdown of network, organizations, entitlement counts
+	Description         string                                                                                              `json:"description,omitempty"`         // Subscription description
+	EndDate             string                                                                                              `json:"endDate,omitempty"`             // Subscription expiration date
+	EnterpriseAgreement *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEnterpriseAgreement `json:"enterpriseAgreement,omitempty"` // enterprise agreement details
+	Entitlements        *[]ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlements      `json:"entitlements,omitempty"`        // Entitlement info
+	LastUpdatedAt       string                                                                                              `json:"lastUpdatedAt,omitempty"`       // When the subscription was last changed
+	Name                string                                                                                              `json:"name,omitempty"`                // Subscription name
+	ProductTypes        []string                                                                                            `json:"productTypes,omitempty"`        // Products the subscription has entitlements for
+	RenewalRequested    *bool                                                                                               `json:"renewalRequested,omitempty"`    // Whether a renewal has been requested for the subscription
+	SmartAccount        *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeySmartAccount        `json:"smartAccount,omitempty"`        // Smart Account linkage information
+	StartDate           string                                                                                              `json:"startDate,omitempty"`           // Subscription start date
+	Status              string                                                                                              `json:"status,omitempty"`              // Subscription status
+	SubscriptionID      string                                                                                              `json:"subscriptionId,omitempty"`      // Subscription's ID
+	Type                string                                                                                              `json:"type,omitempty"`                // Subscription type
+	WebOrderID          string                                                                                              `json:"webOrderId,omitempty"`          // Web order id
 }
 type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCounts struct {
-	Networks *int                                                                                        `json:"networks,omitempty"` // Number of networks bound to this subscription
-	Seats    *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCountsSeats `json:"seats,omitempty"`    // Seat distribution
+	Networks      *int                                                                                        `json:"networks,omitempty"`      // Number of networks bound to this subscription
+	Organizations *int                                                                                        `json:"organizations,omitempty"` // Number of organizations bound to this subscription
+	Seats         *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCountsSeats `json:"seats,omitempty"`         // Seat distribution
 }
 type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyCountsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription
 }
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEnterpriseAgreement struct {
+	Suites []string `json:"suites,omitempty"` // List of suites included. Empty for non-EA subscriptions.
+}
 type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlements struct {
-	Seats *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlementsSeats `json:"seats,omitempty"` // Seat distribution
-	Sku   string                                                                                            `json:"sku,omitempty"`   // SKU of the required product
+	Seats          *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlementsSeats `json:"seats,omitempty"`          // Seat distribution
+	Sku            string                                                                                            `json:"sku,omitempty"`            // SKU of the required product
+	WebOrderLineID string                                                                                            `json:"webOrderLineId,omitempty"` // Web order line ID
 }
 type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeyEntitlementsSeats struct {
 	Assigned  *int `json:"assigned,omitempty"`  // Number of seats in use
 	Available *int `json:"available,omitempty"` // Number of seats available for use
 	Limit     *int `json:"limit,omitempty"`     // Total number of seats provided by this subscription for this sku
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeySmartAccount struct {
+	Account *ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeySmartAccountAccount `json:"account,omitempty"` // Smart Account data
+	Status  string                                                                                              `json:"status,omitempty"`  // Subscription Smart Account status
+}
+type ResponseLicensingValidateAdministeredLicensingSubscriptionSubscriptionsClaimKeySmartAccountAccount struct {
+	Domain string `json:"domain,omitempty"` // The domain of the Smart Account
+	ID     string `json:"id,omitempty"`     // Smart Account ID
+	Name   string `json:"name,omitempty"`   // The name of the smart account
 }
 type ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses []ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses // Array of ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses
 type ResponseItemLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses struct {

--- a/sdk/organizations.go
+++ b/sdk/organizations.go
@@ -18,6 +18,9 @@ type GetOrganizationsQueryParams struct {
 type GetOrganizationActionBatchesQueryParams struct {
 	Status string `url:"status,omitempty"` //Filter batches by status. Valid types are pending, completed, and failed.
 }
+type GetOrganizationAdminsQueryParams struct {
+	NetworkIDs []string `url:"networkIds[],omitempty"` //Optional parameter to filter the result set by the included set of network IDs
+}
 type GetOrganizationAPIRequestsQueryParams struct {
 	T0            string   `url:"t0,omitempty"`             //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
 	T1            string   `url:"t1,omitempty"`             //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
@@ -50,10 +53,99 @@ type GetOrganizationAPIRequestsOverviewResponseCodesByIntervalQueryParams struct
 	AdminIDs     []string `url:"adminIds[],omitempty"`     //Filter by admin ID of user that made the API request
 	UserAgent    string   `url:"userAgent,omitempty"`      //Filter by user agent string for API request. This will filter by a complete or partial match.
 }
+type GetOrganizationAssuranceAlertsQueryParams struct {
+	PerPage                       int      `url:"perPage,omitempty"`                       //The number of entries per page returned. Acceptable range is 4 - 300. Default is 30.
+	StartingAfter                 string   `url:"startingAfter,omitempty"`                 //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore                  string   `url:"endingBefore,omitempty"`                  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder                     string   `url:"sortOrder,omitempty"`                     //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'ascending'.
+	NetworkID                     string   `url:"networkId,omitempty"`                     //Optional parameter to filter alerts by network ids.
+	Severity                      string   `url:"severity,omitempty"`                      //Optional parameter to filter by severity type.
+	Types                         []string `url:"types[],omitempty"`                       //Optional parameter to filter by alert type.
+	TsStart                       string   `url:"tsStart,omitempty"`                       //Optional parameter to filter by starting timestamp
+	TsEnd                         string   `url:"tsEnd,omitempty"`                         //Optional parameter to filter by end timestamp
+	Category                      string   `url:"category,omitempty"`                      //Optional parameter to filter by category.
+	SortBy                        string   `url:"sortBy,omitempty"`                        //Optional parameter to set column to sort by.
+	Serials                       []string `url:"serials[],omitempty"`                     //Optional parameter to filter by primary device serial
+	DeviceTypes                   []string `url:"deviceTypes[],omitempty"`                 //Optional parameter to filter by device types
+	DeviceTags                    []string `url:"deviceTags[],omitempty"`                  //Optional parameter to filter by device tags
+	Active                        bool     `url:"active,omitempty"`                        //Optional parameter to filter by active alerts defaults to true
+	Dismissed                     bool     `url:"dismissed,omitempty"`                     //Optional parameter to filter by dismissed alerts defaults to false
+	Resolved                      bool     `url:"resolved,omitempty"`                      //Optional parameter to filter by resolved alerts defaults to false
+	SuppressAlertsForOfflineNodes bool     `url:"suppressAlertsForOfflineNodes,omitempty"` //When set to true the api will only return connectivity alerts for a given device if that device is in an offline state. This only applies to devices. This is ignored when resolved is true. Example:  If a Switch has a VLan Mismatch and is Unreachable. only the Unreachable alert will be returned. Defaults to false.
+}
+type GetOrganizationAssuranceAlertsOverviewQueryParams struct {
+	NetworkID                     string   `url:"networkId,omitempty"`                     //Optional parameter to filter alerts overview by network ids.
+	Severity                      string   `url:"severity,omitempty"`                      //Optional parameter to filter alerts overview by severity type.
+	Types                         []string `url:"types[],omitempty"`                       //Optional parameter to filter by alert type.
+	TsStart                       string   `url:"tsStart,omitempty"`                       //Optional parameter to filter by starting timestamp
+	TsEnd                         string   `url:"tsEnd,omitempty"`                         //Optional parameter to filter by end timestamp
+	Category                      string   `url:"category,omitempty"`                      //Optional parameter to filter by category.
+	Serials                       []string `url:"serials[],omitempty"`                     //Optional parameter to filter by primary device serial
+	DeviceTypes                   []string `url:"deviceTypes[],omitempty"`                 //Optional parameter to filter by device types
+	DeviceTags                    []string `url:"deviceTags[],omitempty"`                  //Optional parameter to filter by device tags
+	Active                        bool     `url:"active,omitempty"`                        //Optional parameter to filter by active alerts defaults to true
+	Dismissed                     bool     `url:"dismissed,omitempty"`                     //Optional parameter to filter by dismissed alerts defaults to false
+	Resolved                      bool     `url:"resolved,omitempty"`                      //Optional parameter to filter by resolved alerts defaults to false
+	SuppressAlertsForOfflineNodes bool     `url:"suppressAlertsForOfflineNodes,omitempty"` //When set to true the api will only return connectivity alerts for a given device if that device is in an offline state. This only applies to devices. This is ignored when resolved is true. Example:  If a Switch has a VLan Mismatch and is Unreachable. only the Unreachable alert will be returned. Defaults to false.
+}
+type GetOrganizationAssuranceAlertsOverviewByNetworkQueryParams struct {
+	PerPage                       int      `url:"perPage,omitempty"`                       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter                 string   `url:"startingAfter,omitempty"`                 //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore                  string   `url:"endingBefore,omitempty"`                  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder                     string   `url:"sortOrder,omitempty"`                     //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'ascending'.
+	NetworkID                     string   `url:"networkId,omitempty"`                     //Optional parameter to filter alerts overview by network id.
+	Severity                      string   `url:"severity,omitempty"`                      //Optional parameter to filter alerts overview by severity type.
+	Types                         []string `url:"types[],omitempty"`                       //Optional parameter to filter by alert type.
+	TsStart                       string   `url:"tsStart,omitempty"`                       //Optional parameter to filter by starting timestamp
+	TsEnd                         string   `url:"tsEnd,omitempty"`                         //Optional parameter to filter by end timestamp
+	Category                      string   `url:"category,omitempty"`                      //Optional parameter to filter by category.
+	Serials                       []string `url:"serials[],omitempty"`                     //Optional parameter to filter by primary device serial
+	DeviceTypes                   []string `url:"deviceTypes[],omitempty"`                 //Optional parameter to filter by device types
+	DeviceTags                    []string `url:"deviceTags[],omitempty"`                  //Optional parameter to filter by device tags
+	Active                        bool     `url:"active,omitempty"`                        //Optional parameter to filter by active alerts defaults to true
+	Dismissed                     bool     `url:"dismissed,omitempty"`                     //Optional parameter to filter by dismissed alerts defaults to false
+	Resolved                      bool     `url:"resolved,omitempty"`                      //Optional parameter to filter by resolved alerts defaults to false
+	SuppressAlertsForOfflineNodes bool     `url:"suppressAlertsForOfflineNodes,omitempty"` //When set to true the api will only return connectivity alerts for a given device if that device is in an offline state. This only applies to devices. This is ignored when resolved is true. Example:  If a Switch has a VLan Mismatch and is Unreachable. only the Unreachable alert will be returned. Defaults to false.
+}
+type GetOrganizationAssuranceAlertsOverviewByTypeQueryParams struct {
+	PerPage                       int      `url:"perPage,omitempty"`                       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter                 string   `url:"startingAfter,omitempty"`                 //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore                  string   `url:"endingBefore,omitempty"`                  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder                     string   `url:"sortOrder,omitempty"`                     //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'ascending'.
+	NetworkID                     string   `url:"networkId,omitempty"`                     //Optional parameter to filter alerts overview by network ids.
+	Severity                      string   `url:"severity,omitempty"`                      //Optional parameter to filter alerts overview by severity type.
+	Types                         []string `url:"types[],omitempty"`                       //Optional parameter to filter by alert type.
+	TsStart                       string   `url:"tsStart,omitempty"`                       //Optional parameter to filter by starting timestamp
+	TsEnd                         string   `url:"tsEnd,omitempty"`                         //Optional parameter to filter by end timestamp
+	Category                      string   `url:"category,omitempty"`                      //Optional parameter to filter by category.
+	SortBy                        string   `url:"sortBy,omitempty"`                        //Optional parameter to set column to sort by.
+	Serials                       []string `url:"serials[],omitempty"`                     //Optional parameter to filter by primary device serial
+	DeviceTypes                   []string `url:"deviceTypes[],omitempty"`                 //Optional parameter to filter by device types
+	DeviceTags                    []string `url:"deviceTags[],omitempty"`                  //Optional parameter to filter by device tags
+	Active                        bool     `url:"active,omitempty"`                        //Optional parameter to filter by active alerts defaults to true
+	Dismissed                     bool     `url:"dismissed,omitempty"`                     //Optional parameter to filter by dismissed alerts defaults to false
+	Resolved                      bool     `url:"resolved,omitempty"`                      //Optional parameter to filter by resolved alerts defaults to false
+	SuppressAlertsForOfflineNodes bool     `url:"suppressAlertsForOfflineNodes,omitempty"` //When set to true the api will only return connectivity alerts for a given device if that device is in an offline state. This only applies to devices. This is ignored when resolved is true. Example:  If a Switch has a VLan Mismatch and is Unreachable. only the Unreachable alert will be returned. Defaults to false.
+}
+type GetOrganizationAssuranceAlertsOverviewHistoricalQueryParams struct {
+	SegmentDuration int      `url:"segmentDuration,omitempty"` //Amount of time in seconds for each segment in the returned dataset
+	NetworkID       string   `url:"networkId,omitempty"`       //Optional parameter to filter alerts overview by network ids.
+	Severity        string   `url:"severity,omitempty"`        //Optional parameter to filter alerts overview by severity type.
+	Types           []string `url:"types[],omitempty"`         //Optional parameter to filter by alert type.
+	TsStart         string   `url:"tsStart,omitempty"`         //Parameter to define starting timestamp of historical totals
+	TsEnd           string   `url:"tsEnd,omitempty"`           //Optional parameter to filter by end timestamp defaults to the current time
+	Category        string   `url:"category,omitempty"`        //Optional parameter to filter by category.
+	Serials         []string `url:"serials[],omitempty"`       //Optional parameter to filter by primary device serial
+	DeviceTypes     []string `url:"deviceTypes[],omitempty"`   //Optional parameter to filter by device types
+}
 type GetOrganizationClientsBandwidthUsageHistoryQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationClientsOverviewQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
@@ -61,10 +153,10 @@ type GetOrganizationClientsOverviewQueryParams struct {
 	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
 }
 type GetOrganizationClientsSearchQueryParams struct {
-	Mac           string `url:"mac,omitempty"`           //The MAC address of the client. Required.
 	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 5. Default is 5.
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	Mac           string `url:"mac,omitempty"`           //The MAC address of the client. Required.
 }
 type GetOrganizationConfigurationChangesQueryParams struct {
 	T0            string  `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 365 days from today.
@@ -82,7 +174,7 @@ type GetOrganizationDevicesQueryParams struct {
 	EndingBefore              string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Filter results by whether or not the device's configuration has been updated after the given timestamp
 	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter devices by network.
-	ProductTypes              []string `url:"productTypes[],omitempty"`            //Optional parameter to filter devices by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, and sensor.
+	ProductTypes              []string `url:"productTypes[],omitempty"`            //Optional parameter to filter devices by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor, wirelessController, and secureConnect.
 	Tags                      []string `url:"tags[],omitempty"`                    //Optional parameter to filter devices by tags.
 	TagsFilterType            string   `url:"tagsFilterType,omitempty"`            //Optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return networks which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.
 	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter devices by name. All returned devices will have a name that contains the search term or is an exact match.
@@ -100,10 +192,11 @@ type GetOrganizationDevicesAvailabilitiesQueryParams struct {
 	StartingAfter  string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore   string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	NetworkIDs     []string `url:"networkIds[],omitempty"`   //Optional parameter to filter device availabilities by network ID. This filter uses multiple exact matches.
-	ProductTypes   []string `url:"productTypes[],omitempty"` //Optional parameter to filter device availabilities by device product types. This filter uses multiple exact matches.
+	ProductTypes   []string `url:"productTypes[],omitempty"` //Optional parameter to filter device availabilities by device product types. This filter uses multiple exact matches. Valid types are wireless, appliance, switch, camera, cellularGateway, sensor, wirelessController, and campusGateway
 	Serials        []string `url:"serials[],omitempty"`      //Optional parameter to filter device availabilities by device serial numbers. This filter uses multiple exact matches.
 	Tags           []string `url:"tags[],omitempty"`         //An optional parameter to filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below). This filter uses multiple exact matches.
 	TagsFilterType string   `url:"tagsFilterType,omitempty"` //An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return devices which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.
+	Statuses       []string `url:"statuses[],omitempty"`     //Optional parameter to filter device availabilities by device status. This filter uses multiple exact matches.
 }
 type GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -117,16 +210,10 @@ type GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams struct {
 	NetworkIDs    []string `url:"networkIds[],omitempty"`   //Optional parameter to filter device availabilities history by network IDs
 	Statuses      []string `url:"statuses[],omitempty"`     //Optional parameter to filter device availabilities history by device statuses
 }
-type GetOrganizationDevicesBootsHistoryQueryParams struct {
-	T0                  string   `url:"t0,omitempty"`                  //The beginning of the timespan for the data.
-	T1                  string   `url:"t1,omitempty"`                  //The end of the timespan for the data. t1 can be a maximum of 730 days after t0.
-	Timespan            float64  `url:"timespan,omitempty"`            //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 730 days.
-	Serials             []string `url:"serials[],omitempty"`           //Optional parameter to filter device by device serial numbers. This filter uses multiple exact matches.
-	MostRecentPerDevice bool     `url:"mostRecentPerDevice,omitempty"` //If true, only the most recent boot for each device is returned.
-	PerPage             int      `url:"perPage,omitempty"`             //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter       string   `url:"startingAfter,omitempty"`       //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore        string   `url:"endingBefore,omitempty"`        //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	SortOrder           string   `url:"sortOrder,omitempty"`           //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'descending'.
+type GetOrganizationDevicesOverviewByModelQueryParams struct {
+	Models       []string `url:"models[],omitempty"`       //Optional parameter to filter devices by one or more models. All returned devices will have a model that is an exact match.
+	NetworkIDs   []string `url:"networkIds[],omitempty"`   //Optional parameter to filter devices by networkId.
+	ProductTypes []string `url:"productTypes[],omitempty"` //Optional parameter to filter device by device product types. This filter uses multiple exact matches.
 }
 type GetOrganizationDevicesPowerModulesStatusesByDeviceQueryParams struct {
 	PerPage        int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -156,13 +243,13 @@ type GetOrganizationDevicesStatusesQueryParams struct {
 	NetworkIDs     []string `url:"networkIds[],omitempty"`   //Optional parameter to filter devices by network ids.
 	Serials        []string `url:"serials[],omitempty"`      //Optional parameter to filter devices by serials.
 	Statuses       []string `url:"statuses[],omitempty"`     //Optional parameter to filter devices by statuses. Valid statuses are ["online", "alerting", "offline", "dormant"].
-	ProductTypes   []string `url:"productTypes[],omitempty"` //An optional parameter to filter device statuses by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, and sensor.
+	ProductTypes   []string `url:"productTypes[],omitempty"` //An optional parameter to filter device statuses by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor, wirelessController, and secureConnect.
 	Models         []string `url:"models[],omitempty"`       //Optional parameter to filter devices by models.
 	Tags           []string `url:"tags[],omitempty"`         //An optional parameter to filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below).
 	TagsFilterType string   `url:"tagsFilterType,omitempty"` //An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return devices which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.
 }
 type GetOrganizationDevicesStatusesOverviewQueryParams struct {
-	ProductTypes []string `url:"productTypes[],omitempty"` //An optional parameter to filter device statuses by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, and sensor.
+	ProductTypes []string `url:"productTypes[],omitempty"` //An optional parameter to filter device statuses by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor, wirelessController, and secureConnect.
 	NetworkIDs   []string `url:"networkIds[],omitempty"`   //An optional parameter to filter device statuses by network.
 }
 type GetOrganizationDevicesUplinksAddressesByDeviceQueryParams struct {
@@ -198,6 +285,21 @@ type GetOrganizationFirmwareUpgradesByDeviceQueryParams struct {
 	Macs                    []string `url:"macs[],omitempty"`                    //Optional parameter to filter by one or more MAC addresses belonging to devices. All devices returned belong to MAC addresses that are an exact match.
 	FirmwareUpgradeBatchIDs []string `url:"firmwareUpgradeBatchIds[],omitempty"` //Optional parameter to filter by firmware upgrade batch ids.
 	Upgradestatuses         []string `url:"upgradeStatuses[],omitempty"`         //Optional parameter to filter by firmware upgrade statuses.
+	CurrentUpgradesOnly     bool     `url:"currentUpgradesOnly,omitempty"`       //Optional parameter to filter to only current or pending upgrade statuses
+}
+type GetOrganizationFloorPlansAutoLocateDevicesQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 10000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	NetworkIDs    []string `url:"networkIds[],omitempty"`   //Optional parameter to filter devices by one or more network IDs
+	FloorPlanIDs  []string `url:"floorPlanIds[],omitempty"` //Optional parameter to filter devices by one or more floorplan IDs
+}
+type GetOrganizationFloorPlansAutoLocateStatusesQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 10000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	NetworkIDs    []string `url:"networkIds[],omitempty"`   //Optional parameter to filter floorplans by one or more network IDs
+	FloorPlanIDs  []string `url:"floorPlanIds[],omitempty"` //Optional parameter to filter floorplans by one or more floorplan IDs
 }
 type GetOrganizationInventoryDevicesQueryParams struct {
 	PerPage        int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -212,7 +314,7 @@ type GetOrganizationInventoryDevicesQueryParams struct {
 	OrderNumbers   []string `url:"orderNumbers[],omitempty"` //Search for devices in inventory based on order numbers.
 	Tags           []string `url:"tags[],omitempty"`         //Filter devices by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below).
 	TagsFilterType string   `url:"tagsFilterType,omitempty"` //To use with 'tags' parameter, to filter devices which contain ANY or ALL given tags. Accepted values are 'withAnyTags' or 'withAllTags', default is 'withAnyTags'.
-	ProductTypes   []string `url:"productTypes[],omitempty"` //Filter devices by product type. Accepted values are appliance, camera, cellularGateway, sensor, switch, systemsManager, and wireless.
+	ProductTypes   []string `url:"productTypes[],omitempty"` //Filter devices by product type. Accepted values are appliance, camera, cellularGateway, secureConnect, sensor, switch, systemsManager, wireless, and wirelessController.
 }
 type GetOrganizationInventoryOnboardingCloudMonitoringImportsQueryParams struct {
 	ImportIDs []string `url:"importIds[],omitempty"` //import ids from an imports
@@ -237,6 +339,7 @@ type GetOrganizationNetworksQueryParams struct {
 	IsBoundToConfigTemplate bool     `url:"isBoundToConfigTemplate,omitempty"` //An optional parameter to filter config template bound networks. If configTemplateId is set, this cannot be false.
 	Tags                    []string `url:"tags[],omitempty"`                  //An optional parameter to filter networks by tags. The filtering is case-sensitive. If tags are included, 'tagsFilterType' should also be included (see below).
 	TagsFilterType          string   `url:"tagsFilterType,omitempty"`          //An optional parameter of value 'withAnyTags' or 'withAllTags' to indicate whether to return networks which contain ANY or ALL of the included tags. If no type is included, 'withAnyTags' will be selected.
+	ProductTypes            []string `url:"productTypes[],omitempty"`          //An optional parameter to filter networks by product type. Results will have at least one of the included product types.
 	PerPage                 int      `url:"perPage,omitempty"`                 //The number of entries per page returned. Acceptable range is 3 - 100000. Default is 1000.
 	StartingAfter           string   `url:"startingAfter,omitempty"`           //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore            string   `url:"endingBefore,omitempty"`            //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
@@ -255,44 +358,106 @@ type GetOrganizationPolicyObjectsGroupsQueryParams struct {
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
 type GetOrganizationSummaryTopAppliancesByUtilizationQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 186 days. The default is 1 day.
+}
+type GetOrganizationSummaryTopApplicationsByUsageQueryParams struct {
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	Device      string  `url:"device,omitempty"`      //Match result to an exact device tag
+	NetworkID   string  `url:"networkId,omitempty"`   //Match result to an exact network id
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 186 days. The default is 1 day.
+}
+type GetOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams struct {
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	NetworkID   string  `url:"networkId,omitempty"`   //Match result to an exact network id
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopClientsByUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopClientsManufacturersByUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopDevicesByUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopDevicesModelsByUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopNetworksByStatusQueryParams struct {
+	NetworkTag    string `url:"networkTag,omitempty"`    //Match result to an exact network tag
+	DeviceTag     string `url:"deviceTag,omitempty"`     //Match result to an exact device tag
+	Quantity      int    `url:"quantity,omitempty"`      //Set number of desired results to return. Default is 10.
+	SSIDName      string `url:"ssidName,omitempty"`      //Filter results by ssid name
+	UsageUplink   string `url:"usageUplink,omitempty"`   //Filter results by usage uplink
 	PerPage       int    `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 5000.
 	StartingAfter string `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
 type GetOrganizationSummaryTopSSIDsByUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 8 hours and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSummaryTopSwitchesByEnergyUsageQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 31 days. The default is 1 day.
+	NetworkTag  string  `url:"networkTag,omitempty"`  //Match result to an exact network tag
+	DeviceTag   string  `url:"deviceTag,omitempty"`   //Match result to an exact device tag
+	Quantity    int     `url:"quantity,omitempty"`    //Set number of desired results to return. Default is 10.
+	SSIDName    string  `url:"ssidName,omitempty"`    //Filter results by ssid name
+	UsageUplink string  `url:"usageUplink,omitempty"` //Filter results by usage uplink
+	T0          string  `url:"t0,omitempty"`          //The beginning of the timespan for the data.
+	T1          string  `url:"t1,omitempty"`          //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan    float64 `url:"timespan,omitempty"`    //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 25 minutes and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationUplinksStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -332,13 +497,17 @@ type ResponseItemOrganizationsGetOrganizationsCloud struct {
 	Region *ResponseItemOrganizationsGetOrganizationsCloudRegion `json:"region,omitempty"` // Region info
 }
 type ResponseItemOrganizationsGetOrganizationsCloudRegion struct {
-	Name string `json:"name,omitempty"` // Name of region
+	Host *ResponseItemOrganizationsGetOrganizationsCloudRegionHost `json:"host,omitempty"` // Where organization data is hosted
+	Name string                                                    `json:"name,omitempty"` // Name of region
+}
+type ResponseItemOrganizationsGetOrganizationsCloudRegionHost struct {
+	Name string `json:"name,omitempty"` // Name of location
 }
 type ResponseItemOrganizationsGetOrganizationsLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseItemOrganizationsGetOrganizationsManagement struct {
-	Details *[]ResponseItemOrganizationsGetOrganizationsManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
+	Details *[]ResponseItemOrganizationsGetOrganizationsManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'customer number', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseItemOrganizationsGetOrganizationsManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -360,13 +529,17 @@ type ResponseOrganizationsCreateOrganizationCloud struct {
 	Region *ResponseOrganizationsCreateOrganizationCloudRegion `json:"region,omitempty"` // Region info
 }
 type ResponseOrganizationsCreateOrganizationCloudRegion struct {
-	Name string `json:"name,omitempty"` // Name of region
+	Host *ResponseOrganizationsCreateOrganizationCloudRegionHost `json:"host,omitempty"` // Where organization data is hosted
+	Name string                                                  `json:"name,omitempty"` // Name of region
+}
+type ResponseOrganizationsCreateOrganizationCloudRegionHost struct {
+	Name string `json:"name,omitempty"` // Name of location
 }
 type ResponseOrganizationsCreateOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsCreateOrganizationManagement struct {
-	Details *[]ResponseOrganizationsCreateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
+	Details *[]ResponseOrganizationsCreateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'customer number', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsCreateOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -388,13 +561,17 @@ type ResponseOrganizationsGetOrganizationCloud struct {
 	Region *ResponseOrganizationsGetOrganizationCloudRegion `json:"region,omitempty"` // Region info
 }
 type ResponseOrganizationsGetOrganizationCloudRegion struct {
-	Name string `json:"name,omitempty"` // Name of region
+	Host *ResponseOrganizationsGetOrganizationCloudRegionHost `json:"host,omitempty"` // Where organization data is hosted
+	Name string                                               `json:"name,omitempty"` // Name of region
+}
+type ResponseOrganizationsGetOrganizationCloudRegionHost struct {
+	Name string `json:"name,omitempty"` // Name of location
 }
 type ResponseOrganizationsGetOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsGetOrganizationManagement struct {
-	Details *[]ResponseOrganizationsGetOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
+	Details *[]ResponseOrganizationsGetOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'customer number', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsGetOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -416,13 +593,17 @@ type ResponseOrganizationsUpdateOrganizationCloud struct {
 	Region *ResponseOrganizationsUpdateOrganizationCloudRegion `json:"region,omitempty"` // Region info
 }
 type ResponseOrganizationsUpdateOrganizationCloudRegion struct {
-	Name string `json:"name,omitempty"` // Name of region
+	Host *ResponseOrganizationsUpdateOrganizationCloudRegionHost `json:"host,omitempty"` // Where organization data is hosted
+	Name string                                                  `json:"name,omitempty"` // Name of region
+}
+type ResponseOrganizationsUpdateOrganizationCloudRegionHost struct {
+	Name string `json:"name,omitempty"` // Name of location
 }
 type ResponseOrganizationsUpdateOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsUpdateOrganizationManagement struct {
-	Details *[]ResponseOrganizationsUpdateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
+	Details *[]ResponseOrganizationsUpdateOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'customer number', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsUpdateOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -600,37 +781,65 @@ type ResponseOrganizationsUpdateOrganizationAdaptivePolicyACLRules struct {
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyGroups []ResponseItemOrganizationsGetOrganizationAdaptivePolicyGroups // Array of ResponseOrganizationsGetOrganizationAdaptivePolicyGroups
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyGroups struct {
-	CreatedAt          string                                                                       `json:"createdAt,omitempty"`          //
-	Description        string                                                                       `json:"description,omitempty"`        //
-	GroupID            string                                                                       `json:"groupId,omitempty"`            //
-	IsDefaultGroup     *bool                                                                        `json:"isDefaultGroup,omitempty"`     //
-	Name               string                                                                       `json:"name,omitempty"`               //
-	PolicyObjects      *[]ResponseItemOrganizationsGetOrganizationAdaptivePolicyGroupsPolicyObjects `json:"policyObjects,omitempty"`      //
-	RequiredIPMappings []string                                                                     `json:"requiredIpMappings,omitempty"` //
-	Sgt                *int                                                                         `json:"sgt,omitempty"`                //
-	UpdatedAt          string                                                                       `json:"updatedAt,omitempty"`          //
+	CreatedAt          string                                                                       `json:"createdAt,omitempty"`          // Created at timestamp for the adaptive policy group
+	Description        string                                                                       `json:"description,omitempty"`        // The description for the adaptive policy group
+	GroupID            string                                                                       `json:"groupId,omitempty"`            // The ID of the adaptive policy group
+	IsDefaultGroup     *bool                                                                        `json:"isDefaultGroup,omitempty"`     // Whether the adaptive policy group is the default group
+	Name               string                                                                       `json:"name,omitempty"`               // The name of the adaptive policy group
+	PolicyObjects      *[]ResponseItemOrganizationsGetOrganizationAdaptivePolicyGroupsPolicyObjects `json:"policyObjects,omitempty"`      // The policy objects for the adaptive policy group
+	RequiredIPMappings []string                                                                     `json:"requiredIpMappings,omitempty"` // List of required IP mappings for the adaptive policy group
+	Sgt                *int                                                                         `json:"sgt,omitempty"`                // The security group tag for the adaptive policy group
+	UpdatedAt          string                                                                       `json:"updatedAt,omitempty"`          // Updated at timestamp for the adaptive policy group
 }
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyGroupsPolicyObjects struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The ID of the policy object
+	Name string `json:"name,omitempty"` // The name of the policy object
 }
-type ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup interface{}
+type ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup struct {
+	CreatedAt          string                                                                     `json:"createdAt,omitempty"`          // Created at timestamp for the adaptive policy group
+	Description        string                                                                     `json:"description,omitempty"`        // The description for the adaptive policy group
+	GroupID            string                                                                     `json:"groupId,omitempty"`            // The ID of the adaptive policy group
+	IsDefaultGroup     *bool                                                                      `json:"isDefaultGroup,omitempty"`     // Whether the adaptive policy group is the default group
+	Name               string                                                                     `json:"name,omitempty"`               // The name of the adaptive policy group
+	PolicyObjects      *[]ResponseOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"`      // The policy objects for the adaptive policy group
+	RequiredIPMappings []string                                                                   `json:"requiredIpMappings,omitempty"` // List of required IP mappings for the adaptive policy group
+	Sgt                *int                                                                       `json:"sgt,omitempty"`                // The security group tag for the adaptive policy group
+	UpdatedAt          string                                                                     `json:"updatedAt,omitempty"`          // Updated at timestamp for the adaptive policy group
+}
+type ResponseOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects struct {
+	ID   string `json:"id,omitempty"`   // The ID of the policy object
+	Name string `json:"name,omitempty"` // The name of the policy object
+}
 type ResponseOrganizationsGetOrganizationAdaptivePolicyGroup struct {
-	CreatedAt          string                                                                  `json:"createdAt,omitempty"`          //
-	Description        string                                                                  `json:"description,omitempty"`        //
-	GroupID            string                                                                  `json:"groupId,omitempty"`            //
-	IsDefaultGroup     *bool                                                                   `json:"isDefaultGroup,omitempty"`     //
-	Name               string                                                                  `json:"name,omitempty"`               //
-	PolicyObjects      *[]ResponseOrganizationsGetOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"`      //
-	RequiredIPMappings []string                                                                `json:"requiredIpMappings,omitempty"` //
-	Sgt                *int                                                                    `json:"sgt,omitempty"`                //
-	UpdatedAt          string                                                                  `json:"updatedAt,omitempty"`          //
+	CreatedAt          string                                                                  `json:"createdAt,omitempty"`          // Created at timestamp for the adaptive policy group
+	Description        string                                                                  `json:"description,omitempty"`        // The description for the adaptive policy group
+	GroupID            string                                                                  `json:"groupId,omitempty"`            // The ID of the adaptive policy group
+	IsDefaultGroup     *bool                                                                   `json:"isDefaultGroup,omitempty"`     // Whether the adaptive policy group is the default group
+	Name               string                                                                  `json:"name,omitempty"`               // The name of the adaptive policy group
+	PolicyObjects      *[]ResponseOrganizationsGetOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"`      // The policy objects for the adaptive policy group
+	RequiredIPMappings []string                                                                `json:"requiredIpMappings,omitempty"` // List of required IP mappings for the adaptive policy group
+	Sgt                *int                                                                    `json:"sgt,omitempty"`                // The security group tag for the adaptive policy group
+	UpdatedAt          string                                                                  `json:"updatedAt,omitempty"`          // Updated at timestamp for the adaptive policy group
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyGroupPolicyObjects struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The ID of the policy object
+	Name string `json:"name,omitempty"` // The name of the policy object
 }
-type ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroup interface{}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroup struct {
+	CreatedAt          string                                                                     `json:"createdAt,omitempty"`          // Created at timestamp for the adaptive policy group
+	Description        string                                                                     `json:"description,omitempty"`        // The description for the adaptive policy group
+	GroupID            string                                                                     `json:"groupId,omitempty"`            // The ID of the adaptive policy group
+	IsDefaultGroup     *bool                                                                      `json:"isDefaultGroup,omitempty"`     // Whether the adaptive policy group is the default group
+	Name               string                                                                     `json:"name,omitempty"`               // The name of the adaptive policy group
+	PolicyObjects      *[]ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"`      // The policy objects for the adaptive policy group
+	RequiredIPMappings []string                                                                   `json:"requiredIpMappings,omitempty"` // List of required IP mappings for the adaptive policy group
+	Sgt                *int                                                                       `json:"sgt,omitempty"`                // The security group tag for the adaptive policy group
+	UpdatedAt          string                                                                     `json:"updatedAt,omitempty"`          // Updated at timestamp for the adaptive policy group
+}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroupPolicyObjects struct {
+	ID   string `json:"id,omitempty"`   // The ID of the policy object
+	Name string `json:"name,omitempty"` // The name of the policy object
+}
 type ResponseOrganizationsGetOrganizationAdaptivePolicyOverview struct {
 	Counts *ResponseOrganizationsGetOrganizationAdaptivePolicyOverviewCounts `json:"counts,omitempty"` // The current amount of various adaptive policy objects.
 	Limits *ResponseOrganizationsGetOrganizationAdaptivePolicyOverviewLimits `json:"limits,omitempty"` // The current limits of various adaptive policy objects.
@@ -652,79 +861,103 @@ type ResponseOrganizationsGetOrganizationAdaptivePolicyOverviewLimits struct {
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyPolicies []ResponseItemOrganizationsGetOrganizationAdaptivePolicyPolicies // Array of ResponseOrganizationsGetOrganizationAdaptivePolicyPolicies
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyPolicies struct {
-	ACLs             *[]ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesACLs           `json:"acls,omitempty"`             //
-	AdaptivePolicyID string                                                                          `json:"adaptivePolicyId,omitempty"` //
-	CreatedAt        string                                                                          `json:"createdAt,omitempty"`        //
-	DestinationGroup *ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesDestinationGroup `json:"destinationGroup,omitempty"` //
-	LastEntryRule    string                                                                          `json:"lastEntryRule,omitempty"`    //
-	SourceGroup      *ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesSourceGroup      `json:"sourceGroup,omitempty"`      //
-	UpdatedAt        string                                                                          `json:"updatedAt,omitempty"`        //
+	ACLs             *[]ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesACLs           `json:"acls,omitempty"`             // The access control lists for the adaptive policy
+	AdaptivePolicyID string                                                                          `json:"adaptivePolicyId,omitempty"` // The ID for the adaptive policy
+	CreatedAt        string                                                                          `json:"createdAt,omitempty"`        // The created at timestamp for the adaptive policy
+	DestinationGroup *ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesDestinationGroup `json:"destinationGroup,omitempty"` // The destination group for the given adaptive policy
+	LastEntryRule    string                                                                          `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL
+	SourceGroup      *ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesSourceGroup      `json:"sourceGroup,omitempty"`      // The source group for the given adaptive policy
+	UpdatedAt        string                                                                          `json:"updatedAt,omitempty"`        // The updated at timestamp for the adaptive policy
 }
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesACLs struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The ID for the access control list
+	Name string `json:"name,omitempty"` // The name for the access control list
 }
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesDestinationGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the destination group
+	Name string `json:"name,omitempty"` // The name for the destination group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the destination group
 }
 type ResponseItemOrganizationsGetOrganizationAdaptivePolicyPoliciesSourceGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the source group
+	Name string `json:"name,omitempty"` // The name for the source group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the source group
 }
 type ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicy struct {
-	ACLs             *[]ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             //
-	AdaptivePolicyID string                                                                       `json:"adaptivePolicyId,omitempty"` //
-	CreatedAt        string                                                                       `json:"createdAt,omitempty"`        //
-	DestinationGroup *ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` //
-	LastEntryRule    string                                                                       `json:"lastEntryRule,omitempty"`    //
-	SourceGroup      *ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      //
-	UpdatedAt        string                                                                       `json:"updatedAt,omitempty"`        //
+	ACLs             *[]ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // The access control lists for the adaptive policy
+	AdaptivePolicyID string                                                                       `json:"adaptivePolicyId,omitempty"` // The ID for the adaptive policy
+	CreatedAt        string                                                                       `json:"createdAt,omitempty"`        // The created at timestamp for the adaptive policy
+	DestinationGroup *ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` // The destination group for the given adaptive policy
+	LastEntryRule    string                                                                       `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL
+	SourceGroup      *ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      // The source group for the given adaptive policy
+	UpdatedAt        string                                                                       `json:"updatedAt,omitempty"`        // The updated at timestamp for the adaptive policy
 }
 type ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The ID for the access control list
+	Name string `json:"name,omitempty"` // The name for the access control list
 }
 type ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicyDestinationGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the destination group
+	Name string `json:"name,omitempty"` // The name for the destination group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the destination group
 }
 type ResponseOrganizationsCreateOrganizationAdaptivePolicyPolicySourceGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the source group
+	Name string `json:"name,omitempty"` // The name for the source group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the source group
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyPolicy struct {
-	ACLs             *[]ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             //
-	AdaptivePolicyID string                                                                    `json:"adaptivePolicyId,omitempty"` //
-	CreatedAt        string                                                                    `json:"createdAt,omitempty"`        //
-	DestinationGroup *ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` //
-	LastEntryRule    string                                                                    `json:"lastEntryRule,omitempty"`    //
-	SourceGroup      *ResponseOrganizationsGetOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      //
-	UpdatedAt        string                                                                    `json:"updatedAt,omitempty"`        //
+	ACLs             *[]ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // The access control lists for the adaptive policy
+	AdaptivePolicyID string                                                                    `json:"adaptivePolicyId,omitempty"` // The ID for the adaptive policy
+	CreatedAt        string                                                                    `json:"createdAt,omitempty"`        // The created at timestamp for the adaptive policy
+	DestinationGroup *ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` // The destination group for the given adaptive policy
+	LastEntryRule    string                                                                    `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL
+	SourceGroup      *ResponseOrganizationsGetOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      // The source group for the given adaptive policy
+	UpdatedAt        string                                                                    `json:"updatedAt,omitempty"`        // The updated at timestamp for the adaptive policy
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyACLs struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
+	ID   string `json:"id,omitempty"`   // The ID for the access control list
+	Name string `json:"name,omitempty"` // The name for the access control list
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyPolicyDestinationGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the destination group
+	Name string `json:"name,omitempty"` // The name for the destination group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the destination group
 }
 type ResponseOrganizationsGetOrganizationAdaptivePolicyPolicySourceGroup struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-	Sgt  *int   `json:"sgt,omitempty"`  //
+	ID   string `json:"id,omitempty"`   // The ID for the source group
+	Name string `json:"name,omitempty"` // The name for the source group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the source group
 }
-type ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicy interface{}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicy struct {
+	ACLs             *[]ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // The access control lists for the adaptive policy
+	AdaptivePolicyID string                                                                       `json:"adaptivePolicyId,omitempty"` // The ID for the adaptive policy
+	CreatedAt        string                                                                       `json:"createdAt,omitempty"`        // The created at timestamp for the adaptive policy
+	DestinationGroup *ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` // The destination group for the given adaptive policy
+	LastEntryRule    string                                                                       `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL
+	SourceGroup      *ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      // The source group for the given adaptive policy
+	UpdatedAt        string                                                                       `json:"updatedAt,omitempty"`        // The updated at timestamp for the adaptive policy
+}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicyACLs struct {
+	ID   string `json:"id,omitempty"`   // The ID for the access control list
+	Name string `json:"name,omitempty"` // The name for the access control list
+}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicyDestinationGroup struct {
+	ID   string `json:"id,omitempty"`   // The ID for the destination group
+	Name string `json:"name,omitempty"` // The name for the destination group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the destination group
+}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicySourceGroup struct {
+	ID   string `json:"id,omitempty"`   // The ID for the source group
+	Name string `json:"name,omitempty"` // The name for the source group
+	Sgt  *int   `json:"sgt,omitempty"`  // The security group tag for the source group
+}
 type ResponseOrganizationsGetOrganizationAdaptivePolicySettings struct {
-	EnabledNetworks []string `json:"enabledNetworks,omitempty"` //
+	EnabledNetworks []string `json:"enabledNetworks,omitempty"` // List of network IDs with adaptive policy enabled
 }
-type ResponseOrganizationsUpdateOrganizationAdaptivePolicySettings interface{}
+type ResponseOrganizationsUpdateOrganizationAdaptivePolicySettings struct {
+	EnabledNetworks []string `json:"enabledNetworks,omitempty"` // List of network IDs with adaptive policy enabled
+}
 type ResponseOrganizationsGetOrganizationAdmins []ResponseItemOrganizationsGetOrganizationAdmins // Array of ResponseOrganizationsGetOrganizationAdmins
 type ResponseItemOrganizationsGetOrganizationAdmins struct {
 	AccountStatus        string                                                    `json:"accountStatus,omitempty"`        // Status of the admin's account
@@ -913,17 +1146,6 @@ type ResponseOrganizationsGetOrganizationAPIRequestsOverviewResponseCodeCounts s
 	Status431 *int `json:"431,omitempty"` // HTTP 431 response code count.
 	Status451 *int `json:"451,omitempty"` // HTTP 451 response code count.
 	Status500 *int `json:"500,omitempty"` // HTTP 500 response code count.
-	Status501 *int `json:"501,omitempty"` // HTTP 501 response code count.
-	Status502 *int `json:"502,omitempty"` // HTTP 502 response code count.
-	Status503 *int `json:"503,omitempty"` // HTTP 503 response code count.
-	Status504 *int `json:"504,omitempty"` // HTTP 504 response code count.
-	Status505 *int `json:"505,omitempty"` // HTTP 505 response code count.
-	Status506 *int `json:"506,omitempty"` // HTTP 506 response code count.
-	Status507 *int `json:"507,omitempty"` // HTTP 507 response code count.
-	Status508 *int `json:"508,omitempty"` // HTTP 508 response code count.
-	Status509 *int `json:"509,omitempty"` // HTTP 509 response code count.
-	Status510 *int `json:"510,omitempty"` // HTTP 510 response code count.
-	Status511 *int `json:"511,omitempty"` // HTTP 511 response code count.
 }
 type ResponseOrganizationsGetOrganizationAPIRequestsOverviewResponseCodesByInterval []ResponseItemOrganizationsGetOrganizationAPIRequestsOverviewResponseCodesByInterval // Array of ResponseOrganizationsGetOrganizationApiRequestsOverviewResponseCodesByInterval
 type ResponseItemOrganizationsGetOrganizationAPIRequestsOverviewResponseCodesByInterval struct {
@@ -935,6 +1157,161 @@ type ResponseItemOrganizationsGetOrganizationAPIRequestsOverviewResponseCodesByI
 	Code  *int `json:"code,omitempty"`  // Response status code of the API response
 	Count *int `json:"count,omitempty"` // Number of records that match the status code
 }
+type ResponseOrganizationsGetOrganizationAssuranceAlerts []ResponseItemOrganizationsGetOrganizationAssuranceAlerts // Array of ResponseOrganizationsGetOrganizationAssuranceAlerts
+type ResponseItemOrganizationsGetOrganizationAssuranceAlerts struct {
+	CategoryType string                                                          `json:"categoryType,omitempty"` // Category type that the health alert belongs to
+	Description  string                                                          `json:"description,omitempty"`  // Description of the alert
+	DeviceType   string                                                          `json:"deviceType,omitempty"`   // Device Type that the alert occurred on
+	DismissedAt  string                                                          `json:"dismissedAt,omitempty"`  // Time when the alert was dismissed
+	ID           string                                                          `json:"id,omitempty"`           // ID of the health alert
+	Network      *ResponseItemOrganizationsGetOrganizationAssuranceAlertsNetwork `json:"network,omitempty"`      // Network details
+	ResolvedAt   string                                                          `json:"resolvedAt,omitempty"`   // Time when the alert was resolved
+	Scope        *ResponseItemOrganizationsGetOrganizationAssuranceAlertsScope   `json:"scope,omitempty"`        // Scope of the alert (which devices and networks are affected)
+	Severity     string                                                          `json:"severity,omitempty"`     // Alert severity
+	StartedAt    string                                                          `json:"startedAt,omitempty"`    // Time when the alert started
+	Title        string                                                          `json:"title,omitempty"`        // Human Readable Title for Alert type
+	Type         string                                                          `json:"type,omitempty"`         // Alert Type
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsNetwork struct {
+	ID   string `json:"id,omitempty"`   // ID of the network where alert appears
+	Name string `json:"name,omitempty"` // Name of the network where alert appears
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScope struct {
+	Applications *[]ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeApplications `json:"applications,omitempty"` // Applications affected by the alert
+	Devices      *[]ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeDevices      `json:"devices,omitempty"`      // Description of affected devices
+	Peers        *[]ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopePeers        `json:"peers,omitempty"`        // Peers affected by the alert
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeApplications interface{}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeDevices struct {
+	Imei        string                                                                   `json:"imei,omitempty"`        // IMEI of affected device
+	Lldp        *ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeDevicesLldp `json:"lldp,omitempty"`        // Port of affected device
+	Mac         string                                                                   `json:"mac,omitempty"`         // MAC address of affected device
+	Name        string                                                                   `json:"name,omitempty"`        // Name of affected device
+	Order       *int                                                                     `json:"order,omitempty"`       // Order of affected device in array
+	ProductType string                                                                   `json:"productType,omitempty"` // Type of affected device
+	Serial      string                                                                   `json:"serial,omitempty"`      // Serial of affected device
+	URL         string                                                                   `json:"url,omitempty"`         // URL of affected device
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopeDevicesLldp struct {
+	Port string `json:"port,omitempty"` // Port of affect device
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopePeers struct {
+	Network *ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopePeersNetwork `json:"network,omitempty"` // Network of the peer
+	URL     string                                                                    `json:"url,omitempty"`     // URL to the peer
+}
+type ResponseItemOrganizationsGetOrganizationAssuranceAlertsScopePeersNetwork struct {
+	ID   string `json:"id,omitempty"`   // Id of the network
+	Name string `json:"name,omitempty"` // Name of the network
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverview struct {
+	Counts *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewCounts `json:"counts,omitempty"` // Counts of alerts on the organization
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewCounts struct {
+	BySeverity *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewCountsBySeverity `json:"bySeverity,omitempty"` // Counts of alerts on organization by severity
+	Total      *int                                                                           `json:"total,omitempty"`      // Total number of alerts on the organization
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewCountsBySeverity struct {
+	Count *int   `json:"count,omitempty"` // Total count of the given severity type
+	Type  string `json:"type,omitempty"`  // Severity Type
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork struct {
+	Items *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkItems `json:"items,omitempty"` // Alert Counts by Network
+	Meta  *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkMeta    `json:"meta,omitempty"`  // Metadata about the response
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkItems struct {
+	AlertCount     *int                                                                                       `json:"alertCount,omitempty"`     // Total Alerts
+	NetworkID      string                                                                                     `json:"networkId,omitempty"`      // id
+	NetworkName    string                                                                                     `json:"networkName,omitempty"`    // Name
+	SeverityCounts *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkItemsSeverityCounts `json:"severityCounts,omitempty"` // Alerts By Severity
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkItemsSeverityCounts struct {
+	Count *int   `json:"count,omitempty"` // Count
+	Type  string `json:"type,omitempty"`  // Type
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkMetaCounts `json:"counts,omitempty"` // Counts
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetworkMetaCounts struct {
+	Items *int `json:"items,omitempty"` // Total Alerts
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType struct {
+	Items *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeItems `json:"items,omitempty"` // Organization Alert counts by type
+	Meta  *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeMeta    `json:"meta,omitempty"`  // Metadata about the response
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeItems struct {
+	Count *int   `json:"count,omitempty"` // Total count of the given alert type
+	Type  string `json:"type,omitempty"`  // Alert Type
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeMetaCounts `json:"counts,omitempty"` // Counts
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByTypeMetaCounts struct {
+	Items *int `json:"items,omitempty"` // Total Alerts
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistorical struct {
+	Items *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItems `json:"items,omitempty"` // Historical Severity Counts
+	Meta  *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalMeta    `json:"meta,omitempty"`  // Metadata about the response
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItems struct {
+	ByAlertType  *[]ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItemsByAlertType `json:"byAlertType,omitempty"`  // Totals by Type
+	SegmentStart string                                                                                   `json:"segmentStart,omitempty"` // Starting datetime of the segment in iso8601 format
+	Totals       *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItemsTotals        `json:"totals,omitempty"`       // Totals by Severity
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItemsByAlertType struct {
+	Critical      *int   `json:"critical,omitempty"`      // Critical Severity Count
+	Informational *int   `json:"informational,omitempty"` // Informational Severity Count
+	Type          string `json:"type,omitempty"`          // Alert Type
+	Warning       *int   `json:"warning,omitempty"`       // Warning Severity Count
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalItemsTotals struct {
+	Critical      *int `json:"critical,omitempty"`      // Critical Severity Count
+	Informational *int `json:"informational,omitempty"` // Informational Severity Count
+	Warning       *int `json:"warning,omitempty"`       // Warning Severity Count
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalMeta struct {
+	Counts *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalMetaCounts `json:"counts,omitempty"` // Counts
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistoricalMetaCounts struct {
+	Items *int `json:"items,omitempty"` // Total Segments
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlert struct {
+	CategoryType string                                                     `json:"categoryType,omitempty"` // Category type that the health alert belongs to
+	Description  string                                                     `json:"description,omitempty"`  // Description of the alert
+	DeviceType   string                                                     `json:"deviceType,omitempty"`   // Device Type that the alert occurred on
+	DismissedAt  string                                                     `json:"dismissedAt,omitempty"`  // Time when the alert was dismissed
+	ID           string                                                     `json:"id,omitempty"`           // ID of the health alert
+	Network      *ResponseOrganizationsGetOrganizationAssuranceAlertNetwork `json:"network,omitempty"`      // Network details
+	ResolvedAt   string                                                     `json:"resolvedAt,omitempty"`   // Time when the alert was resolved
+	Scope        *ResponseOrganizationsGetOrganizationAssuranceAlertScope   `json:"scope,omitempty"`        // Scope of the alert (which devices and networks are affected)
+	Severity     string                                                     `json:"severity,omitempty"`     // Alert severity
+	StartedAt    string                                                     `json:"startedAt,omitempty"`    // Time when the alert started
+	Title        string                                                     `json:"title,omitempty"`        // Human Readable Title for Alert type
+	Type         string                                                     `json:"type,omitempty"`         // Alert Type
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertNetwork struct {
+	ID   string `json:"id,omitempty"`   // ID of the network where alert appears
+	Name string `json:"name,omitempty"` // Name of the network where alert appears
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertScope struct {
+	Applications *[]ResponseOrganizationsGetOrganizationAssuranceAlertScopeApplications `json:"applications,omitempty"` // Applications affected by the alert
+	Devices      *[]ResponseOrganizationsGetOrganizationAssuranceAlertScopeDevices      `json:"devices,omitempty"`      // Description of affected devices
+	Peers        *[]ResponseOrganizationsGetOrganizationAssuranceAlertScopePeers        `json:"peers,omitempty"`        // Peers affected by the alert
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertScopeApplications interface{}
+type ResponseOrganizationsGetOrganizationAssuranceAlertScopeDevices struct {
+	Imei        string                                                              `json:"imei,omitempty"`        // IMEI of affected device
+	Lldp        *ResponseOrganizationsGetOrganizationAssuranceAlertScopeDevicesLldp `json:"lldp,omitempty"`        // Port of affected device
+	Mac         string                                                              `json:"mac,omitempty"`         // MAC address of affected device
+	Name        string                                                              `json:"name,omitempty"`        // Name of affected device
+	Order       *int                                                                `json:"order,omitempty"`       // Order of affected device in array
+	ProductType string                                                              `json:"productType,omitempty"` // Type of affected device
+	Serial      string                                                              `json:"serial,omitempty"`      // Serial of affected device
+	URL         string                                                              `json:"url,omitempty"`         // URL of affected device
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertScopeDevicesLldp struct {
+	Port string `json:"port,omitempty"` // Port of affect device
+}
+type ResponseOrganizationsGetOrganizationAssuranceAlertScopePeers interface{}
 type ResponseOrganizationsGetOrganizationBrandingPolicies []ResponseItemOrganizationsGetOrganizationBrandingPolicies // Array of ResponseOrganizationsGetOrganizationBrandingPolicies
 type ResponseItemOrganizationsGetOrganizationBrandingPolicies struct {
 	AdminSettings *ResponseItemOrganizationsGetOrganizationBrandingPoliciesAdminSettings `json:"adminSettings,omitempty"` // Settings for describing which kinds of admins this policy applies to.
@@ -1131,45 +1508,47 @@ type ResponseOrganizationsGetOrganizationClientsOverviewUsageOverall struct {
 	Upstream   *float64 `json:"upstream,omitempty"`   // Upstream data usage (in kb) of all clients across organization
 }
 type ResponseOrganizationsGetOrganizationClientsSearch struct {
-	ClientID     string                                                      `json:"clientId,omitempty"`     //
-	Mac          string                                                      `json:"mac,omitempty"`          //
-	Manufacturer string                                                      `json:"manufacturer,omitempty"` //
-	Records      *[]ResponseOrganizationsGetOrganizationClientsSearchRecords `json:"records,omitempty"`      //
+	ClientID     string                                                      `json:"clientId,omitempty"`     // The ID of the client
+	Mac          string                                                      `json:"mac,omitempty"`          // The MAC address of the client
+	Manufacturer string                                                      `json:"manufacturer,omitempty"` // Manufacturer of the client
+	Records      *[]ResponseOrganizationsGetOrganizationClientsSearchRecords `json:"records,omitempty"`      // The clients that appear on any networks within an organization
 }
 type ResponseOrganizationsGetOrganizationClientsSearchRecords struct {
-	Cdp                  string                                                                          `json:"cdp,omitempty"`                  //
-	ClientVpnConnections *[]ResponseOrganizationsGetOrganizationClientsSearchRecordsClientVpnConnections `json:"clientVpnConnections,omitempty"` //
-	Description          string                                                                          `json:"description,omitempty"`          //
-	FirstSeen            *int                                                                            `json:"firstSeen,omitempty"`            //
-	IP                   string                                                                          `json:"ip,omitempty"`                   //
-	IP6                  string                                                                          `json:"ip6,omitempty"`                  //
-	LastSeen             *int                                                                            `json:"lastSeen,omitempty"`             //
-	Lldp                 []string                                                                        `json:"lldp,omitempty"`                 //
-	Network              *ResponseOrganizationsGetOrganizationClientsSearchRecordsNetwork                `json:"network,omitempty"`              //
-	Os                   string                                                                          `json:"os,omitempty"`                   //
-	SmInstalled          *bool                                                                           `json:"smInstalled,omitempty"`          //
-	SSID                 string                                                                          `json:"ssid,omitempty"`                 //
-	Status               string                                                                          `json:"status,omitempty"`               //
-	Switchport           string                                                                          `json:"switchport,omitempty"`           //
-	User                 string                                                                          `json:"user,omitempty"`                 //
-	VLAN                 string                                                                          `json:"vlan,omitempty"`                 //
-	WirelessCapabilities string                                                                          `json:"wirelessCapabilities,omitempty"` //
+	Cdp                  *[][]string                                                                     `json:"cdp,omitempty"`                  // The Cisco discover protocol settings for the client
+	ClientVpnConnections *[]ResponseOrganizationsGetOrganizationClientsSearchRecordsClientVpnConnections `json:"clientVpnConnections,omitempty"` // VPN connections associated with the client
+	Description          string                                                                          `json:"description,omitempty"`          // Short description of the client
+	FirstSeen            *int                                                                            `json:"firstSeen,omitempty"`            // Timestamp client was first seen in the network
+	IP                   string                                                                          `json:"ip,omitempty"`                   // The IP address of the client
+	IP6                  string                                                                          `json:"ip6,omitempty"`                  // The IPv6 address of the client
+	LastSeen             *int                                                                            `json:"lastSeen,omitempty"`             // Timestamp client was last seen in the network
+	Lldp                 *[][]string                                                                     `json:"lldp,omitempty"`                 // The link layer discover protocol settings for the client
+	Network              *ResponseOrganizationsGetOrganizationClientsSearchRecordsNetwork                `json:"network,omitempty"`              // The network upon which a client with the given MAC address was found
+	Os                   string                                                                          `json:"os,omitempty"`                   // The operating system of the client
+	RecentDeviceMac      string                                                                          `json:"recentDeviceMac,omitempty"`      // The MAC address of the node that the device was last connected to
+	SmInstalled          *bool                                                                           `json:"smInstalled,omitempty"`          // Status of SM for the client
+	SSID                 string                                                                          `json:"ssid,omitempty"`                 // The name of the SSID that the client is connected to
+	Status               string                                                                          `json:"status,omitempty"`               // The connection status of the client
+	Switchport           string                                                                          `json:"switchport,omitempty"`           // The switch port the client is connected to
+	User                 string                                                                          `json:"user,omitempty"`                 // The username of the user of the client
+	VLAN                 string                                                                          `json:"vlan,omitempty"`                 // The name of the VLAN that the client is connected to
+	WirelessCapabilities string                                                                          `json:"wirelessCapabilities,omitempty"` // Wireless capabilities of the client
 }
 type ResponseOrganizationsGetOrganizationClientsSearchRecordsClientVpnConnections struct {
-	ConnectedAt    *int   `json:"connectedAt,omitempty"`    //
-	DisconnectedAt *int   `json:"disconnectedAt,omitempty"` //
-	RemoteIP       string `json:"remoteIp,omitempty"`       //
+	ConnectedAt    *int   `json:"connectedAt,omitempty"`    // The time the client last connected to the VPN
+	DisconnectedAt *int   `json:"disconnectedAt,omitempty"` // The time the client last disconnected from the VPN
+	RemoteIP       string `json:"remoteIp,omitempty"`       // The IP address of the VPN the client last connected to
 }
 type ResponseOrganizationsGetOrganizationClientsSearchRecordsNetwork struct {
-	EnrollmentString        string   `json:"enrollmentString,omitempty"`        //
-	ID                      string   `json:"id,omitempty"`                      //
-	IsBoundToConfigTemplate *bool    `json:"isBoundToConfigTemplate,omitempty"` //
-	Name                    string   `json:"name,omitempty"`                    //
-	Notes                   string   `json:"notes,omitempty"`                   //
-	OrganizationID          string   `json:"organizationId,omitempty"`          //
+	EnrollmentString        string   `json:"enrollmentString,omitempty"`        // The network enrollment string
+	ID                      string   `json:"id,omitempty"`                      // The network identifier
+	IsBoundToConfigTemplate *bool    `json:"isBoundToConfigTemplate,omitempty"` // If the network is bound to a config template
+	Name                    string   `json:"name,omitempty"`                    // The network name
+	Notes                   string   `json:"notes,omitempty"`                   // The notes for the network
+	OrganizationID          string   `json:"organizationId,omitempty"`          // The organization identifier
 	ProductTypes            []string `json:"productTypes,omitempty"`            //
-	Tags                    []string `json:"tags,omitempty"`                    //
-	TimeZone                string   `json:"timeZone,omitempty"`                //
+	Tags                    []string `json:"tags,omitempty"`                    // The network tags
+	TimeZone                string   `json:"timeZone,omitempty"`                // The network's timezone
+	URL                     string   `json:"url,omitempty"`                     // The network URL
 }
 type ResponseOrganizationsCloneOrganization struct {
 	API        *ResponseOrganizationsCloneOrganizationAPI        `json:"api,omitempty"`        // API related settings
@@ -1187,13 +1566,17 @@ type ResponseOrganizationsCloneOrganizationCloud struct {
 	Region *ResponseOrganizationsCloneOrganizationCloudRegion `json:"region,omitempty"` // Region info
 }
 type ResponseOrganizationsCloneOrganizationCloudRegion struct {
-	Name string `json:"name,omitempty"` // Name of region
+	Host *ResponseOrganizationsCloneOrganizationCloudRegionHost `json:"host,omitempty"` // Where organization data is hosted
+	Name string                                                 `json:"name,omitempty"` // Name of region
+}
+type ResponseOrganizationsCloneOrganizationCloudRegionHost struct {
+	Name string `json:"name,omitempty"` // Name of location
 }
 type ResponseOrganizationsCloneOrganizationLicensing struct {
 	Model string `json:"model,omitempty"` // Organization licensing model. Can be 'co-term', 'per-device', or 'subscription'.
 }
 type ResponseOrganizationsCloneOrganizationManagement struct {
-	Details *[]ResponseOrganizationsCloneOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
+	Details *[]ResponseOrganizationsCloneOrganizationManagementDetails `json:"details,omitempty"` // Details related to organization management, possibly empty. Details may be named 'MSP ID', 'customer number', 'IP restriction mode for API', or 'IP restriction mode for dashboard', if the organization admin has configured any.
 }
 type ResponseOrganizationsCloneOrganizationManagementDetails struct {
 	Name  string `json:"name,omitempty"`  // Name of management data
@@ -1306,17 +1689,15 @@ type ResponseItemOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistoryN
 	Tags []string `json:"tags,omitempty"` // Network tags
 	URL  string   `json:"url,omitempty"`  // Network dashboard url
 }
-type ResponseOrganizationsGetOrganizationDevicesBootsHistory []ResponseItemOrganizationsGetOrganizationDevicesBootsHistory // Array of ResponseOrganizationsGetOrganizationDevicesBootsHistory
-type ResponseItemOrganizationsGetOrganizationDevicesBootsHistory struct {
-	Network *ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryNetwork `json:"network,omitempty"` // Device network
-	Serial  string                                                              `json:"serial,omitempty"`  // Device serial number
-	Start   *ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryStart   `json:"start,omitempty"`   // Device power up
+type ResponseOrganizationsBulkUpdateOrganizationDevicesDetails struct {
+	Serials []string `json:"serials,omitempty"` // A list of serials of devices updated
 }
-type ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryNetwork struct {
-	ID string `json:"id,omitempty"` // API-formatted network ID
+type ResponseOrganizationsGetOrganizationDevicesOverviewByModel struct {
+	Counts *[]ResponseOrganizationsGetOrganizationDevicesOverviewByModelCounts `json:"counts,omitempty"` // Counts of devices per model
 }
-type ResponseItemOrganizationsGetOrganizationDevicesBootsHistoryStart struct {
-	BootedAt string `json:"bootedAt,omitempty"` // Indicates when the device booted
+type ResponseOrganizationsGetOrganizationDevicesOverviewByModelCounts struct {
+	Model string `json:"model,omitempty"` // Device model
+	Total *int   `json:"total,omitempty"` // Total number of devices for the model
 }
 type ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice []ResponseItemOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice // Array of ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice
 type ResponseItemOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice struct {
@@ -1413,14 +1794,22 @@ type ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUpli
 	Interface string                                                                                     `json:"interface,omitempty"` // Interface for the device uplink. Available options are: cellular, man1, man2, wan1, wan2
 }
 type ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddresses struct {
-	Address        string                                                                                         `json:"address,omitempty"`        // Device uplink address.
-	AssignmentMode string                                                                                         `json:"assignmentMode,omitempty"` // Indicates how the device uplink address is assigned. Available options are: static, dynamic.
-	Gateway        string                                                                                         `json:"gateway,omitempty"`        // Device uplink gateway address.
-	Protocol       string                                                                                         `json:"protocol,omitempty"`       // Type of address for the device uplink. Available options are: ipv4, ipv6.
-	Public         *ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesPublic `json:"public,omitempty"`         // Public interface information.
+	Address        string                                                                                              `json:"address,omitempty"`        // Device uplink address.
+	AssignmentMode string                                                                                              `json:"assignmentMode,omitempty"` // Indicates how the device uplink address is assigned. Available options are: static, dynamic.
+	Gateway        string                                                                                              `json:"gateway,omitempty"`        // Device uplink gateway address.
+	Nameservers    *ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesNameservers `json:"nameservers,omitempty"`    // Device DNS nameserver information.
+	Protocol       string                                                                                              `json:"protocol,omitempty"`       // Type of address for the device uplink. Available options are: ipv4, ipv6.
+	Public         *ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesPublic      `json:"public,omitempty"`         // Public interface information.
+	VLAN           *ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesVLAN        `json:"vlan,omitempty"`           // VLAN information of the uplink interface
+}
+type ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesNameservers struct {
+	Addresses []string `json:"addresses,omitempty"` // Device DNS nameserver address.
 }
 type ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesPublic struct {
 	Address string `json:"address,omitempty"` // The device uplink public IP address.
+}
+type ResponseItemOrganizationsGetOrganizationDevicesUplinksAddressesByDeviceUplinksAddressesVLAN struct {
+	ID string `json:"id,omitempty"` // VLAN ID of the uplink interface
 }
 type ResponseOrganizationsGetOrganizationDevicesUplinksLossAndLatency []ResponseItemOrganizationsGetOrganizationDevicesUplinksLossAndLatency // Array of ResponseOrganizationsGetOrganizationDevicesUplinksLossAndLatency
 type ResponseItemOrganizationsGetOrganizationDevicesUplinksLossAndLatency struct {
@@ -1453,41 +1842,81 @@ type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIns struct {
 	CreatedAt            string                                                                               `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
 	ID                   string                                                                               `json:"id,omitempty"`                   // ID of Early Access Feature
 	LimitScopeToNetworks *[]ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	OptOutEligibility    *ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsOptOutEligibility      `json:"optOutEligibility,omitempty"`    // Descriptions of the early access feature
 	ShortName            string                                                                               `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsLimitScopeToNetworks struct {
 	ID   string `json:"id,omitempty"`   // ID of Network
 	Name string `json:"name,omitempty"` // Name of Network
 }
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsOptOutEligibility struct {
+	Eligible *bool                                                                               `json:"eligible,omitempty"` // Condition flag to opt out from the feature
+	Help     *ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsOptOutEligibilityHelp `json:"help,omitempty"`     // Additional help information
+	Reason   string                                                                              `json:"reason,omitempty"`   // User friendly message regarding opt-out eligibility
+}
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInsOptOutEligibilityHelp struct {
+	Label string `json:"label,omitempty"` // Help link label
+	URL   string `json:"url,omitempty"`   // Help link url
+}
 type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptIn struct {
 	CreatedAt            string                                                                                 `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
 	ID                   string                                                                                 `json:"id,omitempty"`                   // ID of Early Access Feature
 	LimitScopeToNetworks *[]ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	OptOutEligibility    *ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInOptOutEligibility      `json:"optOutEligibility,omitempty"`    // Descriptions of the early access feature
 	ShortName            string                                                                                 `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
 	ID   string `json:"id,omitempty"`   // ID of Network
 	Name string `json:"name,omitempty"` // Name of Network
 }
+type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInOptOutEligibility struct {
+	Eligible *bool                                                                                 `json:"eligible,omitempty"` // Condition flag to opt out from the feature
+	Help     *ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp `json:"help,omitempty"`     // Additional help information
+	Reason   string                                                                                `json:"reason,omitempty"`   // User friendly message regarding opt-out eligibility
+}
+type ResponseOrganizationsCreateOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp struct {
+	Label string `json:"label,omitempty"` // Help link label
+	URL   string `json:"url,omitempty"`   // Help link url
+}
 type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIn struct {
 	CreatedAt            string                                                                              `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
 	ID                   string                                                                              `json:"id,omitempty"`                   // ID of Early Access Feature
 	LimitScopeToNetworks *[]ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	OptOutEligibility    *ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInOptOutEligibility      `json:"optOutEligibility,omitempty"`    // Descriptions of the early access feature
 	ShortName            string                                                                              `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
 	ID   string `json:"id,omitempty"`   // ID of Network
 	Name string `json:"name,omitempty"` // Name of Network
 }
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInOptOutEligibility struct {
+	Eligible *bool                                                                              `json:"eligible,omitempty"` // Condition flag to opt out from the feature
+	Help     *ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp `json:"help,omitempty"`     // Additional help information
+	Reason   string                                                                             `json:"reason,omitempty"`   // User friendly message regarding opt-out eligibility
+}
+type ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp struct {
+	Label string `json:"label,omitempty"` // Help link label
+	URL   string `json:"url,omitempty"`   // Help link url
+}
 type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptIn struct {
 	CreatedAt            string                                                                                 `json:"createdAt,omitempty"`            // Time when Early Access Feature was created
 	ID                   string                                                                                 `json:"id,omitempty"`                   // ID of Early Access Feature
 	LimitScopeToNetworks *[]ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks `json:"limitScopeToNetworks,omitempty"` // Networks assigned to the Early Access Feature
+	OptOutEligibility    *ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInOptOutEligibility      `json:"optOutEligibility,omitempty"`    // Descriptions of the early access feature
 	ShortName            string                                                                                 `json:"shortName,omitempty"`            // Name of Early Access Feature
 }
 type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInLimitScopeToNetworks struct {
 	ID   string `json:"id,omitempty"`   // ID of Network
 	Name string `json:"name,omitempty"` // Name of Network
+}
+type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInOptOutEligibility struct {
+	Eligible *bool                                                                                 `json:"eligible,omitempty"` // Condition flag to opt out from the feature
+	Help     *ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp `json:"help,omitempty"`     // Additional help information
+	Reason   string                                                                                `json:"reason,omitempty"`   // User friendly message regarding opt-out eligibility
+}
+type ResponseOrganizationsUpdateOrganizationEarlyAccessFeaturesOptInOptOutEligibilityHelp struct {
+	Label string `json:"label,omitempty"` // Help link label
+	URL   string `json:"url,omitempty"`   // Help link url
 }
 type ResponseOrganizationsGetOrganizationFirmwareUpgrades []ResponseItemOrganizationsGetOrganizationFirmwareUpgrades // Array of ResponseOrganizationsGetOrganizationFirmwareUpgrades
 type ResponseItemOrganizationsGetOrganizationFirmwareUpgrades struct {
@@ -1552,6 +1981,108 @@ type ResponseItemOrganizationsGetOrganizationFirmwareUpgradesByDeviceUpgradeToVe
 	ReleaseDate string `json:"releaseDate,omitempty"` // Release date of the firmware version
 	ReleaseType string `json:"releaseType,omitempty"` // Release type of the firmware version
 	ShortName   string `json:"shortName,omitempty"`   // Firmware version short name
+}
+type ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices []ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevices // Array of ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevices struct {
+	Items *[]ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItems `json:"items,omitempty"` // Items in the paginated dataset
+	Meta  *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItems struct {
+	AutoLocate *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsAutoLocate `json:"autoLocate,omitempty"` // The auto locate position for this device
+	FloorPlan  *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsFloorPlan  `json:"floorPlan,omitempty"`  // The assigned floor plan for this device
+	IsAnchor   *bool                                                                               `json:"isAnchor,omitempty"`   // Whether or not this auto locate position is an anchor
+	Lat        *float64                                                                            `json:"lat,omitempty"`        // Latitude
+	Lng        *float64                                                                            `json:"lng,omitempty"`        // Longitude
+	Mac        string                                                                              `json:"mac,omitempty"`        // MAC Address
+	Model      string                                                                              `json:"model,omitempty"`      // Model
+	Name       string                                                                              `json:"name,omitempty"`       // Device Name
+	Network    *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsNetwork    `json:"network,omitempty"`    // Network info
+	Serial     string                                                                              `json:"serial,omitempty"`     // Device Serial Number
+	Status     string                                                                              `json:"status,omitempty"`     // Device Status
+	Tags       []string                                                                            `json:"tags,omitempty"`       // Tags
+	Type       string                                                                              `json:"type,omitempty"`       // The type of auto locate position. Possible values: 'user', 'gnss', and 'calculated'
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsAutoLocate struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsFloorPlan struct {
+	ID     string `json:"id,omitempty"`     // Floor plan ID
+	Status string `json:"status,omitempty"` // Floor plan name
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesItemsNetwork struct {
+	ID string `json:"id,omitempty"` // ID for the network containing this device
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMeta struct {
+	Counts *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMetaCounts struct {
+	Items *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateDevicesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses []ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatuses // Array of ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatuses struct {
+	Items *[]ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItems `json:"items,omitempty"` // Items in the paginated dataset
+	Meta  *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItems struct {
+	Counts      *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsCounts  `json:"counts,omitempty"`      // Counts for this floor plan
+	FloorPlanID string                                                                            `json:"floorPlanId,omitempty"` // Floor plan ID
+	Jobs        *[]ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobs  `json:"jobs,omitempty"`        // The most recent job for this floor plan
+	Name        string                                                                            `json:"name,omitempty"`        // Floor plan name
+	Network     *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsNetwork `json:"network,omitempty"`     // Network info
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsCounts struct {
+	Devices *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsCountsDevices `json:"devices,omitempty"` // Device counts for this floor plan
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsCountsDevices struct {
+	Total *int `json:"total,omitempty"` // The total number of devices that will participate if an auto locate job is started
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobs struct {
+	Completed   *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsCompleted `json:"completed,omitempty"`   // Auto locate job progress information
+	Errors      *[]ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsErrors  `json:"errors,omitempty"`      // List of errors that occurred during a failed run of auto locate
+	Gnss        *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsGnss      `json:"gnss,omitempty"`        // GNSS (e.g. GPS) status and progress information
+	ID          string                                                                                  `json:"id,omitempty"`          // Auto locate job ID
+	Ranging     *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsRanging   `json:"ranging,omitempty"`     // Ranging status and progress information
+	ScheduledAt string                                                                                  `json:"scheduledAt,omitempty"` // Scheduled start time for auto locate job
+	Status      string                                                                                  `json:"status,omitempty"`      // Auto locate job status. Possible values: 'scheduled', 'in progress', 'canceling', 'error', 'finished', 'published', 'canceled'
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsCompleted struct {
+	Percentage *int `json:"percentage,omitempty"` // Approximate auto locate job completion percentage
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsErrors struct {
+	Source string `json:"source,omitempty"` // The step of the auto locate process when the error occurred. Possible values: 'gnss', 'ranging', 'positioning'
+	Type   string `json:"type,omitempty"`   // The type of error that occurred. Possible values: 'failure', 'no neighbors', 'missing anchors', 'wrong anchors', 'calculation failure', 'scheduling failure'
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsGnss struct {
+	Completed *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsGnssCompleted `json:"completed,omitempty"` // Progress information for the GNSS acquisition process
+	Status    string                                                                                      `json:"status,omitempty"`    // GNSS status. Possible values: 'scheduled', 'in progress', 'error', 'finished', 'not applicable', 'canceled'
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsGnssCompleted struct {
+	Percentage *int `json:"percentage,omitempty"` // Completion percentage of the GNSS acquisition process
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsRanging struct {
+	Completed *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsRangingCompleted `json:"completed,omitempty"` // Progress information for the ranging process
+	Status    string                                                                                         `json:"status,omitempty"`    // Ranging status. Possible values: 'scheduled', 'in progress', 'error', 'finished', 'no neighbors'
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsJobsRangingCompleted struct {
+	Percentage *int `json:"percentage,omitempty"` // Completion percentage of the ranging process
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesItemsNetwork struct {
+	ID string `json:"id,omitempty"` // ID for the network containing the floorplan
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMeta struct {
+	Counts *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMetaCounts struct {
+	Items *ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemOrganizationsGetOrganizationFloorPlansAutoLocateStatusesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
 type ResponseOrganizationsClaimIntoOrganizationInventory struct {
 	Licenses *[]ResponseOrganizationsClaimIntoOrganizationInventoryLicenses `json:"licenses,omitempty"` // The licenses claimed
@@ -2094,13 +2625,13 @@ type ResponseOrganizationsCreateOrganizationPolicyObjectsGroup struct {
 	UpdatedAt  string    `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
 type ResponseOrganizationsGetOrganizationPolicyObjectsGroup struct {
-	Category   string    `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
-	CreatedAt  string    `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
-	ID         string    `json:"id,omitempty"`         // Policy object ID
-	Name       string    `json:"name,omitempty"`       // Name of the Policy object group.
-	NetworkIDs []string  `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
-	ObjectIDs  *[]string `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
-	UpdatedAt  string    `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
+	Category   string   `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
+	CreatedAt  string   `json:"createdAt,omitempty"`  // Time Stamp of policy object creation.
+	ID         string   `json:"id,omitempty"`         // Policy object ID
+	Name       string   `json:"name,omitempty"`       // Name of the Policy object group.
+	NetworkIDs []string `json:"networkIds,omitempty"` // Network ID's associated with the policy objects.
+	ObjectIDs  *[]int   `json:"objectIds,omitempty"`  // Policy objects associated with Network Object Group or Port Object Group
+	UpdatedAt  string   `json:"updatedAt,omitempty"`  // Time Stamp of policy object updation.
 }
 type ResponseOrganizationsUpdateOrganizationPolicyObjectsGroup struct {
 	Category   string    `json:"category,omitempty"`   // Type of object groups. (NetworkObjectGroup, GeoLocationGroup, PortObjectGroup, ApplicationGroup)
@@ -2269,6 +2800,35 @@ type ResponseOrganizationsUpdateOrganizationSNMP struct {
 	V3PrivMode        string   `json:"v3PrivMode,omitempty"`        // The SNMP version 3 privacy mode. Can be either 'DES' or 'AES128'.
 	V3User            string   `json:"v3User,omitempty"`            // The user for SNMP version 3, if enabled.
 }
+type ResponseOrganizationsGetOrganizationSplashAsset struct {
+	FileData string `json:"fileData,omitempty"` // Splash theme asset file date base64 encoded
+	ID       string `json:"id,omitempty"`       // Splash theme asset id
+	Name     string `json:"name,omitempty"`     // Splash theme asset name
+}
+type ResponseOrganizationsGetOrganizationSplashThemes []ResponseItemOrganizationsGetOrganizationSplashThemes // Array of ResponseOrganizationsGetOrganizationSplashThemes
+type ResponseItemOrganizationsGetOrganizationSplashThemes struct {
+	ID          string                                                             `json:"id,omitempty"`          // theme id
+	Name        string                                                             `json:"name,omitempty"`        // theme name
+	ThemeAssets *[]ResponseItemOrganizationsGetOrganizationSplashThemesThemeAssets `json:"themeAssets,omitempty"` // list of theme assets
+}
+type ResponseItemOrganizationsGetOrganizationSplashThemesThemeAssets struct {
+	ID   string `json:"id,omitempty"`   // asset id
+	Name string `json:"name,omitempty"` // asset name
+}
+type ResponseOrganizationsCreateOrganizationSplashTheme struct {
+	ID          string                                                           `json:"id,omitempty"`          // theme id
+	Name        string                                                           `json:"name,omitempty"`        // theme name
+	ThemeAssets *[]ResponseOrganizationsCreateOrganizationSplashThemeThemeAssets `json:"themeAssets,omitempty"` // list of theme assets
+}
+type ResponseOrganizationsCreateOrganizationSplashThemeThemeAssets struct {
+	ID   string `json:"id,omitempty"`   // asset id
+	Name string `json:"name,omitempty"` // asset name
+}
+type ResponseOrganizationsCreateOrganizationSplashThemeAsset struct {
+	FileData string `json:"fileData,omitempty"` // Splash theme asset file date base64 encoded
+	ID       string `json:"id,omitempty"`       // Splash theme asset id
+	Name     string `json:"name,omitempty"`     // Splash theme asset name
+}
 type ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization []ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilization // Array of ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization
 type ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilization struct {
 	Mac         string                                                                                `json:"mac,omitempty"`         // Mac address of the appliance
@@ -2287,6 +2847,22 @@ type ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilizationUt
 }
 type ResponseItemOrganizationsGetOrganizationSummaryTopAppliancesByUtilizationUtilizationAverage struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Average percentage utilization of the appliance
+}
+type ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage []ResponseItemOrganizationsGetOrganizationSummaryTopApplicationsByUsage // Array of ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage
+type ResponseItemOrganizationsGetOrganizationSummaryTopApplicationsByUsage struct {
+	Application string   `json:"application,omitempty"` // Name of the Application
+	Downstream  *float64 `json:"downstream,omitempty"`  // Downstream usage of the Application, in megabytes
+	Percentage  *float64 `json:"percentage,omitempty"`  // Percent usage of the Application
+	Total       *float64 `json:"total,omitempty"`       // Total usage of the Application, in megabytes
+	Upstream    *float64 `json:"upstream,omitempty"`    // Upstream usage of the Application, in megabytes
+}
+type ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage []ResponseItemOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage // Array of ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage
+type ResponseItemOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage struct {
+	Category   string   `json:"category,omitempty"`   // Name of the Application Category
+	Downstream *float64 `json:"downstream,omitempty"` // Downstream usage of the Application Category, in megabytes
+	Percentage *float64 `json:"percentage,omitempty"` // Percent usage of the Application Category
+	Total      *float64 `json:"total,omitempty"`      // Total usage of the Application Category, in megabytes
+	Upstream   *float64 `json:"upstream,omitempty"`   // Upstream usage of the Application Category, in megabytes
 }
 type ResponseOrganizationsGetOrganizationSummaryTopClientsByUsage []ResponseItemOrganizationsGetOrganizationSummaryTopClientsByUsage // Array of ResponseOrganizationsGetOrganizationSummaryTopClientsByUsage
 type ResponseItemOrganizationsGetOrganizationSummaryTopClientsByUsage struct {
@@ -2614,7 +3190,7 @@ type RequestOrganizationsUpdateOrganizationAdaptivePolicyACLRules struct {
 type RequestOrganizationsCreateOrganizationAdaptivePolicyGroup struct {
 	Description   string                                                                    `json:"description,omitempty"`   // Description of the group (default: "")
 	Name          string                                                                    `json:"name,omitempty"`          // Name of the group
-	PolicyObjects *[]RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"` // The policy objects that belong to this group; traffic from addresses specified by these policy objects will be tagged with this group's SGT value if no other tagging scheme is being used (each requires one unique attribute) ()
+	PolicyObjects *[]RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects `json:"policyObjects,omitempty"` // The policy objects that belong to this group; traffic from addresses specified by these policy objects will be tagged with this group's SGT value if no other tagging scheme is being used (each requires one unique attribute) (default: [])
 	Sgt           *int                                                                      `json:"sgt,omitempty"`           // SGT value of the group
 }
 type RequestOrganizationsCreateOrganizationAdaptivePolicyGroupPolicyObjects struct {
@@ -2632,7 +3208,7 @@ type RequestOrganizationsUpdateOrganizationAdaptivePolicyGroupPolicyObjects stru
 	Name string `json:"name,omitempty"` // The name of the policy object
 }
 type RequestOrganizationsCreateOrganizationAdaptivePolicyPolicy struct {
-	ACLs             *[]RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // An ordered array of adaptive policy ACLs (each requires one unique attribute) that apply to this policy ()
+	ACLs             *[]RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyACLs           `json:"acls,omitempty"`             // An ordered array of adaptive policy ACLs (each requires one unique attribute) that apply to this policy (default: [])
 	DestinationGroup *RequestOrganizationsCreateOrganizationAdaptivePolicyPolicyDestinationGroup `json:"destinationGroup,omitempty"` // The destination adaptive policy group (requires one unique attribute)
 	LastEntryRule    string                                                                      `json:"lastEntryRule,omitempty"`    // The rule to apply if there is no matching ACL (default: "default")
 	SourceGroup      *RequestOrganizationsCreateOrganizationAdaptivePolicyPolicySourceGroup      `json:"sourceGroup,omitempty"`      // The source adaptive policy group (requires one unique attribute)
@@ -2675,7 +3251,7 @@ type RequestOrganizationsUpdateOrganizationAdaptivePolicySettings struct {
 	EnabledNetworks []string `json:"enabledNetworks,omitempty"` // List of network IDs with adaptive policy enabled
 }
 type RequestOrganizationsCreateOrganizationAdmin struct {
-	AuthenticationMethod string                                                 `json:"authenticationMethod,omitempty"` // The method of authentication the user will use to sign in to the Meraki dashboard. Can be one of 'Email' or 'Cisco SecureX Sign-On'. The default is Email authentication
+	AuthenticationMethod string                                                 `json:"authenticationMethod,omitempty"` // No longer used as of Cisco SecureX end-of-life. Can be one of 'Email'. The default is Email authentication.
 	Email                string                                                 `json:"email,omitempty"`                // The email of the dashboard administrator. This attribute can not be updated.
 	Name                 string                                                 `json:"name,omitempty"`                 // The name of the dashboard administrator
 	Networks             *[]RequestOrganizationsCreateOrganizationAdminNetworks `json:"networks,omitempty"`             // The list of networks that the dashboard administrator has privileges on
@@ -2746,6 +3322,12 @@ type RequestOrganizationsUpdateOrganizationAlertsProfileAlertCondition struct {
 type RequestOrganizationsUpdateOrganizationAlertsProfileRecipients struct {
 	Emails        []string `json:"emails,omitempty"`        // A list of emails that will receive information about the alert
 	HTTPServerIDs []string `json:"httpServerIds,omitempty"` // A list base64 encoded urls of webhook endpoints that will receive information about the alert
+}
+type RequestOrganizationsDismissOrganizationAssuranceAlerts struct {
+	AlertIDs []string `json:"alertIds,omitempty"` // Array of alert IDs to dismiss
+}
+type RequestOrganizationsRestoreOrganizationAssuranceAlerts struct {
+	AlertIDs []string `json:"alertIds,omitempty"` // Array of alert IDs to restore
 }
 type RequestOrganizationsCreateOrganizationBrandingPolicy struct {
 	AdminSettings *RequestOrganizationsCreateOrganizationBrandingPolicyAdminSettings `json:"adminSettings,omitempty"` // Settings for describing which kinds of admins this policy applies to.
@@ -2843,6 +3425,14 @@ type RequestOrganizationsUpdateOrganizationConfigTemplate struct {
 	Name     string `json:"name,omitempty"`     // The name of the configuration template
 	TimeZone string `json:"timeZone,omitempty"` // The timezone of the configuration template. For a list of allowed timezones, please see the 'TZ' column in the table in <a target='_blank' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>this article.</a>
 }
+type RequestOrganizationsBulkUpdateOrganizationDevicesDetails struct {
+	Details *[]RequestOrganizationsBulkUpdateOrganizationDevicesDetailsDetails `json:"details,omitempty"` // An array of details
+	Serials []string                                                           `json:"serials,omitempty"` // A list of serials of devices to update
+}
+type RequestOrganizationsBulkUpdateOrganizationDevicesDetailsDetails struct {
+	Name  string `json:"name,omitempty"`  // Name of device detail
+	Value string `json:"value,omitempty"` // Value of device detail
+}
 type RequestOrganizationsCreateOrganizationEarlyAccessFeaturesOptIn struct {
 	LimitScopeToNetworks []string `json:"limitScopeToNetworks,omitempty"` // A list of network IDs to apply the opt-in to
 	ShortName            string   `json:"shortName,omitempty"`            // Short name of the early access feature
@@ -2886,6 +3476,7 @@ type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringImp
 }
 type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepare struct {
 	Devices *[]RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareDevices `json:"devices,omitempty"` // A set of devices to import (or update)
+	Options *RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareOptions   `json:"options,omitempty"` // Additional options for the import
 }
 type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareDevices struct {
 	Sudi   string                                                                                        `json:"sudi,omitempty"`   // Device SUDI certificate
@@ -2931,6 +3522,9 @@ type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPre
 }
 type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareDevicesVtyAuthorizationGroup struct {
 	Name string `json:"name,omitempty"` // Group Name
+}
+type RequestOrganizationsCreateOrganizationInventoryOnboardingCloudMonitoringPrepareOptions struct {
+	SkipCommit *bool `json:"skipCommit,omitempty"` // Flag to skip adding the device to RDM
 }
 type RequestOrganizationsReleaseFromOrganizationInventory struct {
 	Serials []string `json:"serials,omitempty"` // Serials of the devices that should be released
@@ -3036,7 +3630,7 @@ type RequestOrganizationsCreateOrganizationSamlRole struct {
 	Tags      *[]RequestOrganizationsCreateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privileges on
 }
 type RequestOrganizationsCreateOrganizationSamlRoleNetworks struct {
-	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only' or 'ssid-admin'
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only', 'ssid-admin' or 'port-tags'
 	ID     string `json:"id,omitempty"`     // The network ID
 }
 type RequestOrganizationsCreateOrganizationSamlRoleTags struct {
@@ -3050,7 +3644,7 @@ type RequestOrganizationsUpdateOrganizationSamlRole struct {
 	Tags      *[]RequestOrganizationsUpdateOrganizationSamlRoleTags     `json:"tags,omitempty"`      // The list of tags that the SAML administrator has privileges on
 }
 type RequestOrganizationsUpdateOrganizationSamlRoleNetworks struct {
-	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only' or 'ssid-admin'
+	Access string `json:"access,omitempty"` // The privilege of the SAML administrator on the network. Can be one of 'full', 'read-only', 'guest-ambassador', 'monitor-only', 'ssid-admin' or 'port-tags'
 	ID     string `json:"id,omitempty"`     // The network ID
 }
 type RequestOrganizationsUpdateOrganizationSamlRoleTags struct {
@@ -3065,6 +3659,14 @@ type RequestOrganizationsUpdateOrganizationSNMP struct {
 	V3Enabled  *bool    `json:"v3Enabled,omitempty"`  // Boolean indicating whether SNMP version 3 is enabled for the organization.
 	V3PrivMode string   `json:"v3PrivMode,omitempty"` // The SNMP version 3 privacy mode. Can be either 'DES' or 'AES128'.
 	V3PrivPass string   `json:"v3PrivPass,omitempty"` // The SNMP version 3 privacy password. Must be at least 8 characters if specified.
+}
+type RequestOrganizationsCreateOrganizationSplashTheme struct {
+	BaseTheme string `json:"baseTheme,omitempty"` // base theme id
+	Name      string `json:"name,omitempty"`      // theme name
+}
+type RequestOrganizationsCreateOrganizationSplashThemeAsset struct {
+	Content string `json:"content,omitempty"` // a file containing the asset content
+	Name    string `json:"name,omitempty"`    // File name. Will overwrite files with same name.
 }
 
 //GetOrganizations List the organizations that the user has privileges on
@@ -3479,18 +4081,21 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicySettings(organizatio
 /* List the dashboard administrators in this organization
 
 @param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAdminsQueryParams Filtering parameter
 
 
 */
-func (s *OrganizationsService) GetOrganizationAdmins(organizationID string) (*ResponseOrganizationsGetOrganizationAdmins, *resty.Response, error) {
+func (s *OrganizationsService) GetOrganizationAdmins(organizationID string, getOrganizationAdminsQueryParams *GetOrganizationAdminsQueryParams) (*ResponseOrganizationsGetOrganizationAdmins, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/admins"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
+	queryString, _ := query.Values(getOrganizationAdminsQueryParams)
+
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseOrganizationsGetOrganizationAdmins{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAdmins{}).
 		SetError(&Error).
 		Get(path)
 
@@ -3649,6 +4254,221 @@ func (s *OrganizationsService) GetOrganizationAPIRequestsOverviewResponseCodesBy
 
 }
 
+//GetOrganizationAssuranceAlerts Return all health alerts for an organization
+/* Return all health alerts for an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAssuranceAlertsQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlerts(organizationID string, getOrganizationAssuranceAlertsQueryParams *GetOrganizationAssuranceAlertsQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlerts, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationAssuranceAlertsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlerts{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlerts")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlerts)
+	return result, response, err
+
+}
+
+//GetOrganizationAssuranceAlertsOverview Return overview of active health alerts for an organization
+/* Return overview of active health alerts for an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAssuranceAlertsOverviewQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverview(organizationID string, getOrganizationAssuranceAlertsOverviewQueryParams *GetOrganizationAssuranceAlertsOverviewQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverview, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlertsOverview{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlertsOverview")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlertsOverview)
+	return result, response, err
+
+}
+
+//GetOrganizationAssuranceAlertsOverviewByNetwork Return a Summary of Alerts grouped by network and severity
+/* Return a Summary of Alerts grouped by network and severity
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAssuranceAlertsOverviewByNetworkQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByNetwork(organizationID string, getOrganizationAssuranceAlertsOverviewByNetworkQueryParams *GetOrganizationAssuranceAlertsOverviewByNetworkQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlertsOverviewByNetwork")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork)
+	return result, response, err
+
+}
+
+//GetOrganizationAssuranceAlertsOverviewByType Return a Summary of Alerts grouped by type and severity
+/* Return a Summary of Alerts grouped by type and severity
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAssuranceAlertsOverviewByTypeQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByType(organizationID string, getOrganizationAssuranceAlertsOverviewByTypeQueryParams *GetOrganizationAssuranceAlertsOverviewByTypeQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/byType"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewByTypeQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlertsOverviewByType")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType)
+	return result, response, err
+
+}
+
+//GetOrganizationAssuranceAlertsOverviewHistorical Returns historical health alert overviews
+/* Returns historical health alert overviews
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationAssuranceAlertsOverviewHistoricalQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewHistorical(organizationID string, getOrganizationAssuranceAlertsOverviewHistoricalQueryParams *GetOrganizationAssuranceAlertsOverviewHistoricalQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistorical, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/historical"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewHistoricalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistorical{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlertsOverviewHistorical")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistorical)
+	return result, response, err
+
+}
+
+//GetOrganizationAssuranceAlert Return a singular Health Alert by its id
+/* Return a singular Health Alert by its id
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+
+
+*/
+func (s *OrganizationsService) GetOrganizationAssuranceAlert(organizationID string, id string) (*ResponseOrganizationsGetOrganizationAssuranceAlert, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseOrganizationsGetOrganizationAssuranceAlert{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationAssuranceAlert")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationAssuranceAlert)
+	return result, response, err
+
+}
+
 //GetOrganizationBrandingPolicies List the branding policies of an organization
 /* List the branding policies of an organization
 
@@ -3786,8 +4606,8 @@ func (s *OrganizationsService) GetOrganizationClientsBandwidthUsageHistory(organ
 
 }
 
-//GetOrganizationClientsOverview Return summary information around client data usage (in mb) across the given organization.
-/* Return summary information around client data usage (in mb) across the given organization.
+//GetOrganizationClientsOverview Return summary information around client data usage (in kb) across the given organization.
+/* Return summary information around client data usage (in kb) across the given organization.
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationClientsOverviewQueryParams Filtering parameter
@@ -3962,8 +4782,8 @@ func (s *OrganizationsService) GetOrganizationConfigurationChanges(organizationI
 
 }
 
-//GetOrganizationDevices List the devices in an organization
-/* List the devices in an organization
+//GetOrganizationDevices List the devices in an organization that have been assigned to a network.
+/* List the devices in an organization that have been assigned to a network.
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationDevicesQueryParams Filtering parameter
@@ -4070,25 +4890,25 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistory
 
 }
 
-//GetOrganizationDevicesBootsHistory Returns the history of device boots in reverse chronological order (most recent first)
-/* Returns the history of device boots in reverse chronological order (most recent first). Currently supported for MS devices only.
+//GetOrganizationDevicesOverviewByModel Lists the count for each device model
+/* Lists the count for each device model
 
 @param organizationID organizationId path parameter. Organization ID
-@param getOrganizationDevicesBootsHistoryQueryParams Filtering parameter
+@param getOrganizationDevicesOverviewByModelQueryParams Filtering parameter
 
 
 */
-func (s *OrganizationsService) GetOrganizationDevicesBootsHistory(organizationID string, getOrganizationDevicesBootsHistoryQueryParams *GetOrganizationDevicesBootsHistoryQueryParams) (*ResponseOrganizationsGetOrganizationDevicesBootsHistory, *resty.Response, error) {
-	path := "/api/v1/organizations/{organizationId}/devices/boots/history"
+func (s *OrganizationsService) GetOrganizationDevicesOverviewByModel(organizationID string, getOrganizationDevicesOverviewByModelQueryParams *GetOrganizationDevicesOverviewByModelQueryParams) (*ResponseOrganizationsGetOrganizationDevicesOverviewByModel, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/overview/byModel"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
-	queryString, _ := query.Values(getOrganizationDevicesBootsHistoryQueryParams)
+	queryString, _ := query.Values(getOrganizationDevicesOverviewByModelQueryParams)
 
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationDevicesBootsHistory{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationDevicesOverviewByModel{}).
 		SetError(&Error).
 		Get(path)
 
@@ -4098,10 +4918,10 @@ func (s *OrganizationsService) GetOrganizationDevicesBootsHistory(organizationID
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesBootsHistory")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesOverviewByModel")
 	}
 
-	result := response.Result().(*ResponseOrganizationsGetOrganizationDevicesBootsHistory)
+	result := response.Result().(*ResponseOrganizationsGetOrganizationDevicesOverviewByModel)
 	return result, response, err
 
 }
@@ -4491,6 +5311,78 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgradesByDevice(organizat
 	}
 
 	result := response.Result().(*ResponseOrganizationsGetOrganizationFirmwareUpgradesByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationFloorPlansAutoLocateDevices List auto locate details for each device in your organization
+/* List auto locate details for each device in your organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationFloorPlansAutoLocateDevicesQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateDevices(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams *GetOrganizationFloorPlansAutoLocateDevicesQueryParams) (*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/devices"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateDevicesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationFloorPlansAutoLocateDevices")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices)
+	return result, response, err
+
+}
+
+//GetOrganizationFloorPlansAutoLocateStatuses List the status of auto locate for each floorplan in your organization
+/* List the status of auto locate for each floorplan in your organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationFloorPlansAutoLocateStatusesQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateStatuses(organizationID string, getOrganizationFloorPlansAutoLocateStatusesQueryParams *GetOrganizationFloorPlansAutoLocateStatusesQueryParams) (*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/statuses"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateStatusesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationFloorPlansAutoLocateStatuses")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses)
 	return result, response, err
 
 }
@@ -4926,7 +5818,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObjects(organizationID strin
 
 
 */
-func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID string, getOrganizationPolicyObjectsGroupsQueryParams *GetOrganizationPolicyObjectsGroupsQueryParams) (*ResponseOrganizationsGetOrganizationPolicyObjectsGroupsArray, *resty.Response, error) {
+func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID string, getOrganizationPolicyObjectsGroupsQueryParams *GetOrganizationPolicyObjectsGroupsQueryParams) (*ResponseOrganizationsGetOrganizationPolicyObjectsGroups, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/groups"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -4936,7 +5828,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationPolicyObjectsGroupsArray{}).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationPolicyObjectsGroups{}).
 		SetError(&Error).
 		Get(path)
 
@@ -4949,7 +5841,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID
 		return nil, response, fmt.Errorf("error with operation GetOrganizationPolicyObjectsGroups")
 	}
 
-	result := response.Result().(*ResponseOrganizationsGetOrganizationPolicyObjectsGroupsArray)
+	result := response.Result().(*ResponseOrganizationsGetOrganizationPolicyObjectsGroups)
 	return result, response, err
 
 }
@@ -5226,6 +6118,74 @@ func (s *OrganizationsService) GetOrganizationSNMP(organizationID string) (*Resp
 
 }
 
+//GetOrganizationSplashAsset Get a Splash Theme Asset
+/* Get a Splash Theme Asset
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+
+
+*/
+func (s *OrganizationsService) GetOrganizationSplashAsset(organizationID string, id string) (*ResponseOrganizationsGetOrganizationSplashAsset, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/splash/assets/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseOrganizationsGetOrganizationSplashAsset{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSplashAsset")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationSplashAsset)
+	return result, response, err
+
+}
+
+//GetOrganizationSplashThemes List Splash Themes
+/* List Splash Themes
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+func (s *OrganizationsService) GetOrganizationSplashThemes(organizationID string) (*ResponseOrganizationsGetOrganizationSplashThemes, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/splash/themes"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseOrganizationsGetOrganizationSplashThemes{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSplashThemes")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationSplashThemes)
+	return result, response, err
+
+}
+
 //GetOrganizationSummaryTopAppliancesByUtilization Return the top 10 appliances sorted by utilization over given time range.
 /* Return the top 10 appliances sorted by utilization over given time range.
 
@@ -5258,6 +6218,78 @@ func (s *OrganizationsService) GetOrganizationSummaryTopAppliancesByUtilization(
 	}
 
 	result := response.Result().(*ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization)
+	return result, response, err
+
+}
+
+//GetOrganizationSummaryTopApplicationsByUsage Return the top applications sorted by data usage over given time range
+/* Return the top applications sorted by data usage over given time range. Default unit is megabytes.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSummaryTopApplicationsByUsageQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsByUsage(organizationID string, getOrganizationSummaryTopApplicationsByUsageQueryParams *GetOrganizationSummaryTopApplicationsByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/summary/top/applications/byUsage"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSummaryTopApplicationsByUsageQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSummaryTopApplicationsByUsage")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage)
+	return result, response, err
+
+}
+
+//GetOrganizationSummaryTopApplicationsCategoriesByUsage Return the top application categories sorted by data usage over given time range
+/* Return the top application categories sorted by data usage over given time range. Default unit is megabytes.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams Filtering parameter
+
+
+*/
+func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsCategoriesByUsage(organizationID string, getOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams *GetOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/summary/top/applications/categories/byUsage"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSummaryTopApplicationsCategoriesByUsage")
+	}
+
+	result := response.Result().(*ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage)
 	return result, response, err
 
 }
@@ -5768,7 +6800,7 @@ func (s *OrganizationsService) CreateOrganizationAdaptivePolicyACL(organizationI
 
 */
 
-func (s *OrganizationsService) CreateOrganizationAdaptivePolicyGroup(organizationID string, requestOrganizationsCreateOrganizationAdaptivePolicyGroup *RequestOrganizationsCreateOrganizationAdaptivePolicyGroup) (*resty.Response, error) {
+func (s *OrganizationsService) CreateOrganizationAdaptivePolicyGroup(organizationID string, requestOrganizationsCreateOrganizationAdaptivePolicyGroup *RequestOrganizationsCreateOrganizationAdaptivePolicyGroup) (*ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/groups"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -5777,20 +6809,21 @@ func (s *OrganizationsService) CreateOrganizationAdaptivePolicyGroup(organizatio
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsCreateOrganizationAdaptivePolicyGroup).
-		// SetResult(&ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup{}).
+		SetResult(&ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CreateOrganizationAdaptivePolicyGroup")
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationAdaptivePolicyGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationAdaptivePolicyGroup)
+	return result, response, err
 
 }
 
@@ -5896,6 +6929,72 @@ func (s *OrganizationsService) CreateOrganizationAlertsProfile(organizationID st
 
 	result := response.Result().(*ResponseOrganizationsCreateOrganizationAlertsProfile)
 	return result, response, err
+
+}
+
+//DismissOrganizationAssuranceAlerts Dismiss health alerts
+/* Dismiss health alerts
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *OrganizationsService) DismissOrganizationAssuranceAlerts(organizationID string, requestOrganizationsDismissOrganizationAssuranceAlerts *RequestOrganizationsDismissOrganizationAssuranceAlerts) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/dismiss"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsDismissOrganizationAssuranceAlerts).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DismissOrganizationAssuranceAlerts")
+	}
+
+	return response, err
+
+}
+
+//RestoreOrganizationAssuranceAlerts Restore health alerts from dismissed
+/* Restore health alerts from dismissed
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *OrganizationsService) RestoreOrganizationAssuranceAlerts(organizationID string, requestOrganizationsRestoreOrganizationAssuranceAlerts *RequestOrganizationsRestoreOrganizationAssuranceAlerts) (*resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/assurance/alerts/restore"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsRestoreOrganizationAssuranceAlerts).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation RestoreOrganizationAssuranceAlerts")
+	}
+
+	return response, err
 
 }
 
@@ -6035,6 +7134,41 @@ func (s *OrganizationsService) CreateOrganizationConfigTemplate(organizationID s
 	}
 
 	result := response.Result().(*ResponseOrganizationsCreateOrganizationConfigTemplate)
+	return result, response, err
+
+}
+
+//BulkUpdateOrganizationDevicesDetails Updating device details (currently only used for Catalyst devices)
+/* Updating device details (currently only used for Catalyst devices)
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *OrganizationsService) BulkUpdateOrganizationDevicesDetails(organizationID string, requestOrganizationsBulkUpdateOrganizationDevicesDetails *RequestOrganizationsBulkUpdateOrganizationDevicesDetails) (*ResponseOrganizationsBulkUpdateOrganizationDevicesDetails, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/devices/details/bulkUpdate"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsBulkUpdateOrganizationDevicesDetails).
+		SetResult(&ResponseOrganizationsBulkUpdateOrganizationDevicesDetails{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation BulkUpdateOrganizationDevicesDetails")
+	}
+
+	result := response.Result().(*ResponseOrganizationsBulkUpdateOrganizationDevicesDetails)
 	return result, response, err
 
 }
@@ -6633,6 +7767,78 @@ func (s *OrganizationsService) CreateOrganizationSamlRole(organizationID string,
 
 }
 
+//CreateOrganizationSplashTheme Create a Splash Theme
+/* Create a Splash Theme
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *OrganizationsService) CreateOrganizationSplashTheme(organizationID string, requestOrganizationsCreateOrganizationSplashTheme *RequestOrganizationsCreateOrganizationSplashTheme) (*ResponseOrganizationsCreateOrganizationSplashTheme, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/splash/themes"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsCreateOrganizationSplashTheme).
+		SetResult(&ResponseOrganizationsCreateOrganizationSplashTheme{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationSplashTheme")
+	}
+
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationSplashTheme)
+	return result, response, err
+
+}
+
+//CreateOrganizationSplashThemeAsset Create a Splash Theme Asset
+/* Create a Splash Theme Asset
+
+@param organizationID organizationId path parameter. Organization ID
+@param themeIDentifier themeIdentifier path parameter. Theme identifier
+
+
+*/
+
+func (s *OrganizationsService) CreateOrganizationSplashThemeAsset(organizationID string, themeIDentifier string, requestOrganizationsCreateOrganizationSplashThemeAsset *RequestOrganizationsCreateOrganizationSplashThemeAsset) (*ResponseOrganizationsCreateOrganizationSplashThemeAsset, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/splash/themes/{themeIdentifier}/assets"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{themeIdentifier}", fmt.Sprintf("%v", themeIDentifier), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestOrganizationsCreateOrganizationSplashThemeAsset).
+		SetResult(&ResponseOrganizationsCreateOrganizationSplashThemeAsset{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateOrganizationSplashThemeAsset")
+	}
+
+	result := response.Result().(*ResponseOrganizationsCreateOrganizationSplashThemeAsset)
+	return result, response, err
+
+}
+
 //UpdateOrganization Update an organization
 /* Update an organization
 
@@ -6739,7 +7945,7 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyACL(organizationI
 @param organizationID organizationId path parameter. Organization ID
 @param id id path parameter.
 */
-func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyGroup(organizationID string, id string, requestOrganizationsUpdateOrganizationAdaptivePolicyGroup *RequestOrganizationsUpdateOrganizationAdaptivePolicyGroup) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyGroup(organizationID string, id string, requestOrganizationsUpdateOrganizationAdaptivePolicyGroup *RequestOrganizationsUpdateOrganizationAdaptivePolicyGroup) (*ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/groups/{id}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6749,19 +7955,21 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyGroup(organizatio
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationAdaptivePolicyGroup).
+		SetResult(&ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroup{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicyGroup")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicyGroup")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationAdaptivePolicyGroup)
+	return result, response, err
 
 }
 
@@ -6771,7 +7979,7 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyGroup(organizatio
 @param organizationID organizationId path parameter. Organization ID
 @param id id path parameter.
 */
-func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyPolicy(organizationID string, id string, requestOrganizationsUpdateOrganizationAdaptivePolicyPolicy *RequestOrganizationsUpdateOrganizationAdaptivePolicyPolicy) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyPolicy(organizationID string, id string, requestOrganizationsUpdateOrganizationAdaptivePolicyPolicy *RequestOrganizationsUpdateOrganizationAdaptivePolicyPolicy) (*ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicy, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/policies/{id}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6781,19 +7989,21 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyPolicy(organizati
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationAdaptivePolicyPolicy).
+		SetResult(&ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicy{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicyPolicy")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicyPolicy")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationAdaptivePolicyPolicy)
+	return result, response, err
 
 }
 
@@ -6802,7 +8012,7 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicyPolicy(organizati
 
 @param organizationID organizationId path parameter. Organization ID
 */
-func (s *OrganizationsService) UpdateOrganizationAdaptivePolicySettings(organizationID string, requestOrganizationsUpdateOrganizationAdaptivePolicySettings *RequestOrganizationsUpdateOrganizationAdaptivePolicySettings) (*resty.Response, error) {
+func (s *OrganizationsService) UpdateOrganizationAdaptivePolicySettings(organizationID string, requestOrganizationsUpdateOrganizationAdaptivePolicySettings *RequestOrganizationsUpdateOrganizationAdaptivePolicySettings) (*ResponseOrganizationsUpdateOrganizationAdaptivePolicySettings, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/settings"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6811,19 +8021,21 @@ func (s *OrganizationsService) UpdateOrganizationAdaptivePolicySettings(organiza
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestOrganizationsUpdateOrganizationAdaptivePolicySettings).
+		SetResult(&ResponseOrganizationsUpdateOrganizationAdaptivePolicySettings{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicySettings")
+		return nil, response, fmt.Errorf("error with operation UpdateOrganizationAdaptivePolicySettings")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseOrganizationsUpdateOrganizationAdaptivePolicySettings)
+	return result, response, err
 
 }
 
@@ -7769,20 +8981,20 @@ func (s *OrganizationsService) DeleteOrganizationSamlRole(organizationID string,
 
 }
 
-//DeleteOrganizationUser Delete a user and all of its authentication methods.
-/* Delete a user and all of its authentication methods.
+//DeleteOrganizationSplashAsset Delete a Splash Theme Asset
+/* Delete a Splash Theme Asset
 
 @param organizationID organizationId path parameter. Organization ID
-@param userID userId path parameter. User ID
+@param id id path parameter.
 
 
 */
-func (s *OrganizationsService) DeleteOrganizationUser(organizationID string, userID string) (*resty.Response, error) {
-	//organizationID string,userID string
-	path := "/api/v1/organizations/{organizationId}/users/{userId}"
+func (s *OrganizationsService) DeleteOrganizationSplashAsset(organizationID string, id string) (*resty.Response, error) {
+	//organizationID string,id string
+	path := "/api/v1/organizations/{organizationId}/splash/assets/{id}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
-	path = strings.Replace(path, "{userId}", fmt.Sprintf("%v", userID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
 
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
@@ -7796,7 +9008,41 @@ func (s *OrganizationsService) DeleteOrganizationUser(organizationID string, use
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation DeleteOrganizationUser")
+		return response, fmt.Errorf("error with operation DeleteOrganizationSplashAsset")
+	}
+
+	return response, err
+
+}
+
+//DeleteOrganizationSplashTheme Delete a Splash Theme
+/* Delete a Splash Theme
+
+@param organizationID organizationId path parameter. Organization ID
+@param id id path parameter.
+
+
+*/
+func (s *OrganizationsService) DeleteOrganizationSplashTheme(organizationID string, id string) (*resty.Response, error) {
+	//organizationID string,id string
+	path := "/api/v1/organizations/{organizationId}/splash/themes/{id}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+	path = strings.Replace(path, "{id}", fmt.Sprintf("%v", id), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteOrganizationSplashTheme")
 	}
 
 	return response, err

--- a/sdk/sensor.go
+++ b/sdk/sensor.go
@@ -10,11 +10,21 @@ import (
 
 type SensorService service
 
+type GetDeviceSensorCommandsQueryParams struct {
+	Operations    []string `url:"operations[],omitempty"`  //Optional parameter to filter commands by operation. Allowed values are disableDownstreamPower, enableDownstreamPower, cycleDownstreamPower, and refreshData.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 10.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder     string   `url:"sortOrder,omitempty"`     //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'descending'.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 30 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 30 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 30 days. The default is 30 days.
+}
 type GetNetworkSensorAlertsOverviewByMetricQueryParams struct {
-	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data. The maximum lookback period is 365 days from today.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
-	Interval int     `url:"interval,omitempty"` //The time interval in seconds for returned data. The valid intervals are: 86400, 604800. The default is 604800.
+	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data. The maximum lookback period is 731 days from today.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 366 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 366 days. The default is 7 days. If interval is provided, the timespan will be autocalculated.
+	Interval int     `url:"interval,omitempty"` //The time interval in seconds for returned data. The valid intervals are: 900, 3600, 86400, 604800, 2592000. The default is 604800. Interval is calculated if time params are provided.
 }
 type GetOrganizationSensorReadingsHistoryQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
@@ -36,6 +46,49 @@ type GetOrganizationSensorReadingsLatestQueryParams struct {
 	Metrics       []string `url:"metrics[],omitempty"`     //Types of sensor readings to retrieve. If no metrics are supplied, all available types of readings will be retrieved. Allowed values are apparentPower, battery, button, co2, current, door, downstreamPower, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, remoteLockoutSwitch, temperature, tvoc, voltage, and water.
 }
 
+type ResponseSensorGetDeviceSensorCommands []ResponseItemSensorGetDeviceSensorCommands // Array of ResponseSensorGetDeviceSensorCommands
+type ResponseItemSensorGetDeviceSensorCommands struct {
+	CommandID   string                                              `json:"commandId,omitempty"`   // ID to check the status of the command request
+	CompletedAt string                                              `json:"completedAt,omitempty"` // Time when the command was completed
+	CreatedAt   string                                              `json:"createdAt,omitempty"`   // Time when the command was triggered
+	CreatedBy   *ResponseItemSensorGetDeviceSensorCommandsCreatedBy `json:"createdBy,omitempty"`   // Information about the admin who triggered the command
+	Errors      []string                                            `json:"errors,omitempty"`      // Array of errors if failed
+	Operation   string                                              `json:"operation,omitempty"`   // Operation run on the sensor
+	Status      string                                              `json:"status,omitempty"`      // Status of the command request
+}
+type ResponseItemSensorGetDeviceSensorCommandsCreatedBy struct {
+	AdminID string `json:"adminId,omitempty"` // ID of the admin
+	Email   string `json:"email,omitempty"`   // Email of the admin
+	Name    string `json:"name,omitempty"`    // Name of the admin
+}
+type ResponseSensorCreateDeviceSensorCommand struct {
+	CommandID   string                                            `json:"commandId,omitempty"`   // ID to check the status of the command request
+	CompletedAt string                                            `json:"completedAt,omitempty"` // Time when the command was completed
+	CreatedAt   string                                            `json:"createdAt,omitempty"`   // Time when the command was triggered
+	CreatedBy   *ResponseSensorCreateDeviceSensorCommandCreatedBy `json:"createdBy,omitempty"`   // Information about the admin who triggered the command
+	Errors      []string                                          `json:"errors,omitempty"`      // Array of errors if failed
+	Operation   string                                            `json:"operation,omitempty"`   // Operation run on the sensor
+	Status      string                                            `json:"status,omitempty"`      // Status of the command request
+}
+type ResponseSensorCreateDeviceSensorCommandCreatedBy struct {
+	AdminID string `json:"adminId,omitempty"` // ID of the admin
+	Email   string `json:"email,omitempty"`   // Email of the admin
+	Name    string `json:"name,omitempty"`    // Name of the admin
+}
+type ResponseSensorGetDeviceSensorCommand struct {
+	CommandID   string                                         `json:"commandId,omitempty"`   // ID to check the status of the command request
+	CompletedAt string                                         `json:"completedAt,omitempty"` // Time when the command was completed
+	CreatedAt   string                                         `json:"createdAt,omitempty"`   // Time when the command was triggered
+	CreatedBy   *ResponseSensorGetDeviceSensorCommandCreatedBy `json:"createdBy,omitempty"`   // Information about the admin who triggered the command
+	Errors      []string                                       `json:"errors,omitempty"`      // Array of errors if failed
+	Operation   string                                         `json:"operation,omitempty"`   // Operation run on the sensor
+	Status      string                                         `json:"status,omitempty"`      // Status of the command request
+}
+type ResponseSensorGetDeviceSensorCommandCreatedBy struct {
+	AdminID string `json:"adminId,omitempty"` // ID of the admin
+	Email   string `json:"email,omitempty"`   // Email of the admin
+	Name    string `json:"name,omitempty"`    // Name of the admin
+}
 type ResponseSensorGetDeviceSensorRelationships struct {
 	Livestream *ResponseSensorGetDeviceSensorRelationshipsLivestream `json:"livestream,omitempty"` // A role defined between an MT sensor and an MV camera that adds the camera's livestream to the sensor's details page. Snapshots from the camera will also appear in alert notifications that the sensor triggers.
 }
@@ -120,11 +173,12 @@ type ResponseItemSensorGetNetworkSensorAlertsProfiles struct {
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditions struct {
 	Direction string                                                               `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                                 `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                               `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                               `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThreshold struct {
 	ApparentPower    *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -142,6 +196,10 @@ type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThreshold struct 
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type ResponseItemSensorGetNetworkSensorAlertsProfilesConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -215,11 +273,12 @@ type ResponseSensorCreateNetworkSensorAlertsProfile struct {
 type ResponseSensorCreateNetworkSensorAlertsProfileConditions struct {
 	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
 	ApparentPower    *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -237,6 +296,10 @@ type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type ResponseSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -310,11 +373,12 @@ type ResponseSensorGetNetworkSensorAlertsProfile struct {
 type ResponseSensorGetNetworkSensorAlertsProfileConditions struct {
 	Direction string                                                          `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                            `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                          `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                          `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *ResponseSensorGetNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThreshold struct {
 	ApparentPower    *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -332,6 +396,10 @@ type ResponseSensorGetNetworkSensorAlertsProfileConditionsThreshold struct {
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type ResponseSensorGetNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -405,11 +473,12 @@ type ResponseSensorUpdateNetworkSensorAlertsProfile struct {
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditions struct {
 	Direction string                                                             `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                               `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                             `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
 	ApparentPower    *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -427,6 +496,10 @@ type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type ResponseSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -707,6 +780,9 @@ type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsVoltage struct
 type ResponseItemSensorGetOrganizationSensorReadingsLatestReadingsWater struct {
 	Present *bool `json:"present,omitempty"` // True if water is detected.
 }
+type RequestSensorCreateDeviceSensorCommand struct {
+	Operation string `json:"operation,omitempty"` // Operation to run on the sensor. 'enableDownstreamPower', 'disableDownstreamPower', and 'cycleDownstreamPower' turn power on/off to the device that is connected downstream of an MT40 power monitor. 'refreshData' causes an MT15 or MT40 device to upload its latest readings so that they are immediately available in the Dashboard API.
+}
 type RequestSensorUpdateDeviceSensorRelationships struct {
 	Livestream *RequestSensorUpdateDeviceSensorRelationshipsLivestream `json:"livestream,omitempty"` // A role defined between an MT sensor and an MV camera that adds the camera's livestream to the sensor's details page. Snapshots from the camera will also appear in alert notifications that the sensor triggers.
 }
@@ -726,11 +802,12 @@ type RequestSensorCreateNetworkSensorAlertsProfile struct {
 type RequestSensorCreateNetworkSensorAlertsProfileConditions struct {
 	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *RequestSensorCreateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
 	ApparentPower    *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -748,6 +825,10 @@ type RequestSensorCreateNetworkSensorAlertsProfileConditionsThreshold struct {
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type RequestSensorCreateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -819,11 +900,12 @@ type RequestSensorUpdateNetworkSensorAlertsProfile struct {
 type RequestSensorUpdateNetworkSensorAlertsProfileConditions struct {
 	Direction string                                                            `json:"direction,omitempty"` // If 'above', an alert will be sent when a sensor reads above the threshold. If 'below', an alert will be sent when a sensor reads below the threshold. Only applicable for temperature, humidity, realPower, apparentPower, powerFactor, voltage, current, and frequency thresholds.
 	Duration  *int                                                              `json:"duration,omitempty"`  // Length of time in seconds that the triggering state must persist before an alert is sent. Available options are 0 seconds, 1 minute, 2 minutes, 3 minutes, 4 minutes, 5 minutes, 10 minutes, 15 minutes, 30 minutes, 1 hour, 2 hours, 4 hours, and 8 hours. Default is 0.
-	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes. Available metrics are apparentPower, co2, current, door, frequency, humidity, indoorAirQuality, noise, pm25, powerFactor, realPower, temperature, tvoc, upstreamPower, voltage, and water.
+	Metric    string                                                            `json:"metric,omitempty"`    // The type of sensor metric that will be monitored for changes.
 	Threshold *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThreshold `json:"threshold,omitempty"` // Threshold for sensor readings that will cause an alert to be sent. This object should contain a single property key matching the condition's 'metric' value.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
 	ApparentPower    *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower    `json:"apparentPower,omitempty"`    // Apparent power threshold. 'draw' must be provided.
+	Co2              *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCo2              `json:"co2,omitempty"`              // CO2 concentration threshold. One of 'concentration' or 'quality' must be provided.
 	Current          *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent          `json:"current,omitempty"`          // Electrical current threshold. 'level' must be provided.
 	Door             *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdDoor             `json:"door,omitempty"`             // Door open threshold. 'open' must be provided and set to true.
 	Frequency        *RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdFrequency        `json:"frequency,omitempty"`        // Electrical frequency threshold. 'level' must be provided.
@@ -841,6 +923,10 @@ type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThreshold struct {
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdApparentPower struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in volt-amps. Must be between 0 and 3750.
+}
+type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCo2 struct {
+	Concentration *int   `json:"concentration,omitempty"` // Alerting threshold as CO2 parts per million.
+	Quality       string `json:"quality,omitempty"`       // Alerting threshold as a qualitative CO2 level.
 }
 type RequestSensorUpdateNetworkSensorAlertsProfileConditionsThresholdCurrent struct {
 	Draw *float64 `json:"draw,omitempty"` // Alerting threshold in amps. Must be between 0 and 15.
@@ -904,6 +990,77 @@ type RequestSensorUpdateNetworkSensorAlertsProfileSchedule struct {
 }
 type RequestSensorUpdateNetworkSensorMqttBroker struct {
 	Enabled *bool `json:"enabled,omitempty"` // Set to true to enable MQTT broker for sensor network
+}
+
+//GetDeviceSensorCommands Returns a historical log of all commands
+/* Returns a historical log of all commands
+
+@param serial serial path parameter.
+@param getDeviceSensorCommandsQueryParams Filtering parameter
+
+
+*/
+func (s *SensorService) GetDeviceSensorCommands(serial string, getDeviceSensorCommandsQueryParams *GetDeviceSensorCommandsQueryParams) (*ResponseSensorGetDeviceSensorCommands, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/sensor/commands"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	queryString, _ := query.Values(getDeviceSensorCommandsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSensorGetDeviceSensorCommands{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceSensorCommands")
+	}
+
+	result := response.Result().(*ResponseSensorGetDeviceSensorCommands)
+	return result, response, err
+
+}
+
+//GetDeviceSensorCommand Returns information about the command's execution, including the status
+/* Returns information about the command's execution, including the status
+
+@param serial serial path parameter.
+@param commandID commandId path parameter. Command ID
+
+
+*/
+func (s *SensorService) GetDeviceSensorCommand(serial string, commandID string) (*ResponseSensorGetDeviceSensorCommand, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/sensor/commands/{commandId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+	path = strings.Replace(path, "{commandId}", fmt.Sprintf("%v", commandID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseSensorGetDeviceSensorCommand{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceSensorCommand")
+	}
+
+	result := response.Result().(*ResponseSensorGetDeviceSensorCommand)
+	return result, response, err
+
 }
 
 //GetDeviceSensorRelationships List the sensor roles for a given sensor or camera device.
@@ -1245,6 +1402,41 @@ func (s *SensorService) GetOrganizationSensorReadingsLatest(organizationID strin
 	}
 
 	result := response.Result().(*ResponseSensorGetOrganizationSensorReadingsLatest)
+	return result, response, err
+
+}
+
+//CreateDeviceSensorCommand Sends a command to a sensor
+/* Sends a command to a sensor
+
+@param serial serial path parameter.
+
+
+*/
+
+func (s *SensorService) CreateDeviceSensorCommand(serial string, requestSensorCreateDeviceSensorCommand *RequestSensorCreateDeviceSensorCommand) (*ResponseSensorCreateDeviceSensorCommand, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/sensor/commands"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestSensorCreateDeviceSensorCommand).
+		SetResult(&ResponseSensorCreateDeviceSensorCommand{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateDeviceSensorCommand")
+	}
+
+	result := response.Result().(*ResponseSensorCreateDeviceSensorCommand)
 	return result, response, err
 
 }

--- a/sdk/sm.go
+++ b/sdk/sm.go
@@ -207,6 +207,7 @@ type ResponseItemSmGetNetworkSmDeviceDeviceProfiles struct {
 	ProfileIDentifier string `json:"profileIdentifier,omitempty"` // The identifier of the profile.
 	Version           string `json:"version,omitempty"`           // The verison of the profile.
 }
+type ResponseSmInstallNetworkSmDeviceApps interface{}
 type ResponseSmGetNetworkSmDeviceNetworkAdapters []ResponseItemSmGetNetworkSmDeviceNetworkAdapters // Array of ResponseSmGetNetworkSmDeviceNetworkAdapters
 type ResponseItemSmGetNetworkSmDeviceNetworkAdapters struct {
 	DhcpServer string `json:"dhcpServer,omitempty"` // The IP address of the DCHP Server.
@@ -238,17 +239,15 @@ type ResponseItemSmGetNetworkSmDevicePerformanceHistoryDiskUsageC struct {
 	Space *int `json:"space,omitempty"` // The available disk space.
 	Used  *int `json:"used,omitempty"`  // The used disk space.
 }
-type ResponseSmGetNetworkSmDeviceRestrictions []ResponseItemSmGetNetworkSmDeviceRestrictions // Array of ResponseSmGetNetworkSmDeviceRestrictions
-type ResponseItemSmGetNetworkSmDeviceRestrictions struct {
-	Profile      string                                                    `json:"profile,omitempty"`      //
-	Restrictions *ResponseItemSmGetNetworkSmDeviceRestrictionsRestrictions `json:"restrictions,omitempty"` //
+type ResponseSmRefreshNetworkSmDeviceDetails interface{}
+type ResponseSmGetNetworkSmDeviceRestrictions struct {
+	Restrictions *[]ResponseSmGetNetworkSmDeviceRestrictionsRestrictions `json:"restrictions,omitempty"` // The list of restrictions for the device
 }
-type ResponseItemSmGetNetworkSmDeviceRestrictionsRestrictions struct {
-	MyRestriction *ResponseItemSmGetNetworkSmDeviceRestrictionsRestrictionsMyRestriction `json:"myRestriction,omitempty"` //
+type ResponseSmGetNetworkSmDeviceRestrictionsRestrictions struct {
+	Profile      string                                                            `json:"profile,omitempty"`      // The profile identifier.
+	Restrictions *ResponseSmGetNetworkSmDeviceRestrictionsRestrictionsRestrictions `json:"restrictions,omitempty"` // The restrictions for the profile.
 }
-type ResponseItemSmGetNetworkSmDeviceRestrictionsRestrictionsMyRestriction struct {
-	Value *bool `json:"value,omitempty"` //
-}
+type ResponseSmGetNetworkSmDeviceRestrictionsRestrictionsRestrictions interface{}
 type ResponseSmGetNetworkSmDeviceSecurityCenters []ResponseItemSmGetNetworkSmDeviceSecurityCenters // Array of ResponseSmGetNetworkSmDeviceSecurityCenters
 type ResponseItemSmGetNetworkSmDeviceSecurityCenters struct {
 	AntiVirusName        string `json:"antiVirusName,omitempty"`        // The name of the Antivirus.
@@ -291,6 +290,7 @@ type ResponseItemSmGetNetworkSmDeviceSoftwares struct {
 type ResponseSmUnenrollNetworkSmDevice struct {
 	Success *bool `json:"success,omitempty"` // Boolean indicating whether the operation was completed successfully.
 }
+type ResponseSmUninstallNetworkSmDeviceApps interface{}
 type ResponseSmGetNetworkSmDeviceWLANLists []ResponseItemSmGetNetworkSmDeviceWLANLists // Array of ResponseSmGetNetworkSmDeviceWlanLists
 type ResponseItemSmGetNetworkSmDeviceWLANLists struct {
 	CreatedAt string `json:"createdAt,omitempty"` // When the Meraki record for the wlanList was created.
@@ -1952,6 +1952,7 @@ func (s *SmService) InstallNetworkSmDeviceApps(networkID string, deviceID string
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSmInstallNetworkSmDeviceApps).
+		// SetResult(&ResponseSmInstallNetworkSmDeviceApps{}).
 		SetError(&Error).
 		Post(path)
 
@@ -1986,6 +1987,8 @@ func (s *SmService) RefreshNetworkSmDeviceDetails(networkID string, deviceID str
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+
+		// SetResult(&ResponseSmRefreshNetworkSmDeviceDetails{}).
 		SetError(&Error).
 		Post(path)
 
@@ -2057,6 +2060,7 @@ func (s *SmService) UninstallNetworkSmDeviceApps(networkID string, deviceID stri
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSmUninstallNetworkSmDeviceApps).
+		// SetResult(&ResponseSmUninstallNetworkSmDeviceApps{}).
 		SetError(&Error).
 		Post(path)
 

--- a/sdk/switch.go
+++ b/sdk/switch.go
@@ -1,7 +1,6 @@
 package meraki
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -38,54 +37,113 @@ type GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams st
 }
 type GetOrganizationSummarySwitchPowerHistoryQueryParams struct {
 	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
-	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 186 days. The default is 1 day.
 }
 type GetOrganizationSwitchPortsBySwitchQueryParams struct {
 	PerPage                   int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 50. Default is 50.
 	StartingAfter             string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore              string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter switchports by network.
-	PortProfileIDs            []string `url:"portProfileIds[],omitempty"`          //Optional parameter to filter switchports belonging to the specified port profiles.
-	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter switchports belonging to switches by name. All returned switches will have a name that contains the search term or is an exact match.
-	Mac                       string   `url:"mac,omitempty"`                       //Optional parameter to filter switchports belonging to switches by MAC address. All returned switches will have a MAC address that contains the search term or is an exact match.
-	Macs                      []string `url:"macs[],omitempty"`                    //Optional parameter to filter switchports by one or more MAC addresses belonging to devices. All switchports returned belong to MAC addresses of switches that are an exact match.
-	Serial                    string   `url:"serial,omitempty"`                    //Optional parameter to filter switchports belonging to switches by serial number. All returned switches will have a serial number that contains the search term or is an exact match.
-	Serials                   []string `url:"serials[],omitempty"`                 //Optional parameter to filter switchports belonging to switches with one or more serial numbers. All switchports returned belong to serial numbers of switches that are an exact match.
-	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Optional parameter to filter results by switches where the configuration has been updated after the given timestamp.
+	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Optional parameter to filter items to switches where the configuration has been updated after the given timestamp.
+	Mac                       string   `url:"mac,omitempty"`                       //Optional parameter to filter items to switches with MAC addresses that contain the search term or are an exact match.
+	Macs                      []string `url:"macs[],omitempty"`                    //Optional parameter to filter items to switches that have one of the provided MAC addresses.
+	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter items to switches with names that contain the search term or are an exact match.
+	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter items to switches in one of the provided networks.
+	PortProfileIDs            []string `url:"portProfileIds[],omitempty"`          //Optional parameter to filter items to switches that contain switchports belonging to one of the specified port profiles.
+	Serial                    string   `url:"serial,omitempty"`                    //Optional parameter to filter items to switches with serial number that contains the search term or are an exact match.
+	Serials                   []string `url:"serials[],omitempty"`                 //Optional parameter to filter items to switches that have one of the provided serials.
+}
+type GetOrganizationSwitchPortsClientsOverviewByDeviceQueryParams struct {
+	T0                        string   `url:"t0,omitempty"`                        //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	Timespan                  float64  `url:"timespan,omitempty"`                  //The timespan for which the information will be fetched. If specifying timespan, do not specify parameter t0. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	PerPage                   int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 20. Default is 20.
+	StartingAfter             string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore              string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Optional parameter to filter items to switches where the configuration has been updated after the given timestamp.
+	Mac                       string   `url:"mac,omitempty"`                       //Optional parameter to filter items to switches with MAC addresses that contain the search term or are an exact match.
+	Macs                      []string `url:"macs[],omitempty"`                    //Optional parameter to filter items to switches that have one of the provided MAC addresses.
+	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter items to switches with names that contain the search term or are an exact match.
+	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter items to switches in one of the provided networks.
+	PortProfileIDs            []string `url:"portProfileIds[],omitempty"`          //Optional parameter to filter items to switches that contain switchports belonging to one of the specified port profiles.
+	Serial                    string   `url:"serial,omitempty"`                    //Optional parameter to filter items to switches with serial number that contains the search term or are an exact match.
+	Serials                   []string `url:"serials[],omitempty"`                 //Optional parameter to filter items to switches that have one of the provided serials.
+}
+type GetOrganizationSwitchPortsOverviewQueryParams struct {
+	T0       string  `url:"t0,omitempty"`       //The beginning of the timespan for the data.
+	T1       string  `url:"t1,omitempty"`       //The end of the timespan for the data. t1 can be a maximum of 186 days after t0.
+	Timespan float64 `url:"timespan,omitempty"` //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 12 hours and be less than or equal to 186 days. The default is 1 day.
+}
+type GetOrganizationSwitchPortsStatusesBySwitchQueryParams struct {
+	PerPage                   int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 20. Default is 10.
+	StartingAfter             string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore              string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Optional parameter to filter items to switches where the configuration has been updated after the given timestamp.
+	Mac                       string   `url:"mac,omitempty"`                       //Optional parameter to filter items to switches with MAC addresses that contain the search term or are an exact match.
+	Macs                      []string `url:"macs[],omitempty"`                    //Optional parameter to filter items to switches that have one of the provided MAC addresses.
+	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter items to switches with names that contain the search term or are an exact match.
+	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter items to switches in one of the provided networks.
+	PortProfileIDs            []string `url:"portProfileIds[],omitempty"`          //Optional parameter to filter items to switches that contain switchports belonging to one of the specified port profiles.
+	Serial                    string   `url:"serial,omitempty"`                    //Optional parameter to filter items to switches with serial number that contains the search term or are an exact match.
+	Serials                   []string `url:"serials[],omitempty"`                 //Optional parameter to filter items to switches that have one of the provided serials.
+}
+type GetOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams struct {
+	T0                        string   `url:"t0,omitempty"`                        //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	Timespan                  float64  `url:"timespan,omitempty"`                  //The timespan for which the information will be fetched. If specifying timespan, do not specify parameter t0. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
+	PerPage                   int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 20. Default is 10.
+	StartingAfter             string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore              string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	ConfigurationUpdatedAfter string   `url:"configurationUpdatedAfter,omitempty"` //Optional parameter to filter items to switches where the configuration has been updated after the given timestamp.
+	Mac                       string   `url:"mac,omitempty"`                       //Optional parameter to filter items to switches with MAC addresses that contain the search term or are an exact match.
+	Macs                      []string `url:"macs[],omitempty"`                    //Optional parameter to filter items to switches that have one of the provided MAC addresses.
+	Name                      string   `url:"name,omitempty"`                      //Optional parameter to filter items to switches with names that contain the search term or are an exact match.
+	NetworkIDs                []string `url:"networkIds[],omitempty"`              //Optional parameter to filter items to switches in one of the provided networks.
+	PortProfileIDs            []string `url:"portProfileIds[],omitempty"`          //Optional parameter to filter items to switches that contain switchports belonging to one of the specified port profiles.
+	Serial                    string   `url:"serial,omitempty"`                    //Optional parameter to filter items to switches with serial number that contains the search term or are an exact match.
+	Serials                   []string `url:"serials[],omitempty"`                 //Optional parameter to filter items to switches that have one of the provided serials.
 }
 
 type ResponseSwitchGetDeviceSwitchPorts []ResponseItemSwitchGetDeviceSwitchPorts // Array of ResponseSwitchGetDeviceSwitchPorts
 type ResponseItemSwitchGetDeviceSwitchPorts struct {
-	AccessPolicyNumber          *int                                           `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                         `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AdaptivePolicyGroupID       string                                         `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
-	AllowedVLANs                string                                         `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                          `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                          `json:"enabled,omitempty"`                     // The status of the switch port.
-	FlexibleStackingEnabled     *bool                                          `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                          `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
-	LinkNegotiation             string                                         `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
-	LinkNegotiationCapabilities []string                                       `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
-	MacAllowList                []string                                       `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseItemSwitchGetDeviceSwitchPortsMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseItemSwitchGetDeviceSwitchPortsModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                         `json:"name,omitempty"`                        // The name of the switch port.
-	PeerSgtCapable              *bool                                          `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
-	PoeEnabled                  *bool                                          `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
-	PortID                      string                                         `json:"portId,omitempty"`                      // The identifier of the switch port.
-	PortScheduleID              string                                         `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseItemSwitchGetDeviceSwitchPortsProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                          `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                       `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                           `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                          `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
-	StpGuard                    string                                         `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                       `json:"tags,omitempty"`                        // The list of tags of the switch port.
-	Type                        string                                         `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
-	Udld                        string                                         `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                           `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                           `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                       `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                     `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AdaptivePolicyGroup         *ResponseItemSwitchGetDeviceSwitchPortsAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"`         // The adaptive policy group data of the port.
+	AdaptivePolicyGroupID       string                                                     `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
+	AllowedVLANs                string                                                     `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                      `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseItemSwitchGetDeviceSwitchPortsDot3Az              `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                      `json:"enabled,omitempty"`                     // The status of the switch port.
+	FlexibleStackingEnabled     *bool                                                      `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                      `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
+	LinkNegotiation             string                                                     `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
+	LinkNegotiationCapabilities []string                                                   `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
+	MacAllowList                []string                                                   `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseItemSwitchGetDeviceSwitchPortsMirror              `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseItemSwitchGetDeviceSwitchPortsModule              `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                     `json:"name,omitempty"`                        // The name of the switch port.
+	PeerSgtCapable              *bool                                                      `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
+	PoeEnabled                  *bool                                                      `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
+	PortID                      string                                                     `json:"portId,omitempty"`                      // The identifier of the switch port.
+	PortScheduleID              string                                                     `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseItemSwitchGetDeviceSwitchPortsProfile             `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                      `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseItemSwitchGetDeviceSwitchPortsSchedule            `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseItemSwitchGetDeviceSwitchPortsStackwiseVirtual    `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                                   `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                       `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                      `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
+	StpGuard                    string                                                     `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                                   `json:"tags,omitempty"`                        // The list of tags of the switch port.
+	Type                        string                                                     `json:"type,omitempty"`                        // The type of the switch port ('trunk', 'access' or 'stack').
+	Udld                        string                                                     `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                       `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                       `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // The ID of the adaptive policy group.
+	Name string `json:"name,omitempty"` // The name of the adaptive policy group.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch port.
 }
 type ResponseItemSwitchGetDeviceSwitchPortsMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -97,6 +155,14 @@ type ResponseItemSwitchGetDeviceSwitchPortsProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseItemSwitchGetDeviceSwitchPortsStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
 }
 type ResponseSwitchCycleDeviceSwitchPorts struct {
 	Ports []string `json:"ports,omitempty"` // List of switch ports
@@ -110,6 +176,7 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatuses struct {
 	Errors         []string                                                     `json:"errors,omitempty"`         // All errors present on the port.
 	IsUplink       *bool                                                        `json:"isUplink,omitempty"`       // Whether the port is the switch's uplink.
 	Lldp           *ResponseItemSwitchGetDeviceSwitchPortsStatusesLldp          `json:"lldp,omitempty"`           // The Link Layer Discovery Protocol (LLDP) information of the connected device.
+	Poe            *ResponseItemSwitchGetDeviceSwitchPortsStatusesPoe           `json:"poe,omitempty"`            // PoE status of the port.
 	PortID         string                                                       `json:"portId,omitempty"`         // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
 	PowerUsageInWh *float64                                                     `json:"powerUsageInWh,omitempty"` // How much power (in watt-hours) has been delivered by this port during the timespan.
 	SecurePort     *ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePort    `json:"securePort,omitempty"`     // The Secure Port status of the port.
@@ -143,6 +210,9 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatusesLldp struct {
 	SystemDescription  string `json:"systemDescription,omitempty"`  // The device's system description.
 	SystemName         string `json:"systemName,omitempty"`         // The device's system name.
 }
+type ResponseItemSwitchGetDeviceSwitchPortsStatusesPoe struct {
+	IsAllocated *bool `json:"isAllocated,omitempty"` // Whether the port is drawing power
+}
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePort struct {
 	Active               *bool                                                                    `json:"active,omitempty"`               // Whether Secure Port is currently active for this port.
 	AuthenticationStatus string                                                                   `json:"authenticationStatus,omitempty"` // The current Secure Port status.
@@ -151,7 +221,7 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePort struct {
 }
 type ResponseItemSwitchGetDeviceSwitchPortsStatusesSecurePortConfigOverrides struct {
 	AllowedVLANs string `json:"allowedVlans,omitempty"` // The VLANs allowed on the . Only applicable to trunk ports.
-	Type         string `json:"type,omitempty"`         // The type of the  ('trunk' or 'access').
+	Type         string `json:"type,omitempty"`         // The type of the  ('trunk', 'access' or 'stack').
 	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the . For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN    *int   `json:"voiceVlan,omitempty"`    // The voice VLAN of the . Only applicable to access ports.
 }
@@ -186,35 +256,46 @@ type ResponseItemSwitchGetDeviceSwitchPortsStatusesPacketsPacketsRatePerSec stru
 	Total *int `json:"total,omitempty"` // The rate of all packets sent and received during the timespan
 }
 type ResponseSwitchGetDeviceSwitchPort struct {
-	AccessPolicyNumber          *int                                      `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                    `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AdaptivePolicyGroupID       string                                    `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
-	AllowedVLANs                string                                    `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                     `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                     `json:"enabled,omitempty"`                     // The status of the switch port.
-	FlexibleStackingEnabled     *bool                                     `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                     `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
-	LinkNegotiation             string                                    `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
-	LinkNegotiationCapabilities []string                                  `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
-	MacAllowList                []string                                  `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseSwitchGetDeviceSwitchPortMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseSwitchGetDeviceSwitchPortModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                    `json:"name,omitempty"`                        // The name of the switch port.
-	PeerSgtCapable              *bool                                     `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
-	PoeEnabled                  *bool                                     `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
-	PortID                      string                                    `json:"portId,omitempty"`                      // The identifier of the switch port.
-	PortScheduleID              string                                    `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseSwitchGetDeviceSwitchPortProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                     `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                  `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                      `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                     `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
-	StpGuard                    string                                    `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                  `json:"tags,omitempty"`                        // The list of tags of the switch port.
-	Type                        string                                    `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
-	Udld                        string                                    `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                      `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                      `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                  `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AdaptivePolicyGroup         *ResponseSwitchGetDeviceSwitchPortAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"`         // The adaptive policy group data of the port.
+	AdaptivePolicyGroupID       string                                                `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
+	AllowedVLANs                string                                                `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                 `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseSwitchGetDeviceSwitchPortDot3Az              `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                 `json:"enabled,omitempty"`                     // The status of the switch port.
+	FlexibleStackingEnabled     *bool                                                 `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                 `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
+	LinkNegotiation             string                                                `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
+	LinkNegotiationCapabilities []string                                              `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
+	MacAllowList                []string                                              `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchGetDeviceSwitchPortMirror              `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchGetDeviceSwitchPortModule              `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                `json:"name,omitempty"`                        // The name of the switch port.
+	PeerSgtCapable              *bool                                                 `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
+	PoeEnabled                  *bool                                                 `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
+	PortID                      string                                                `json:"portId,omitempty"`                      // The identifier of the switch port.
+	PortScheduleID              string                                                `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseSwitchGetDeviceSwitchPortProfile             `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                 `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseSwitchGetDeviceSwitchPortSchedule            `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseSwitchGetDeviceSwitchPortStackwiseVirtual    `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                              `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                  `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                 `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
+	StpGuard                    string                                                `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                              `json:"tags,omitempty"`                        // The list of tags of the switch port.
+	Type                        string                                                `json:"type,omitempty"`                        // The type of the switch port ('trunk', 'access' or 'stack').
+	Udld                        string                                                `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                  `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                  `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseSwitchGetDeviceSwitchPortAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // The ID of the adaptive policy group.
+	Name string `json:"name,omitempty"` // The name of the adaptive policy group.
+}
+type ResponseSwitchGetDeviceSwitchPortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch port.
 }
 type ResponseSwitchGetDeviceSwitchPortMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -227,36 +308,55 @@ type ResponseSwitchGetDeviceSwitchPortProfile struct {
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
+type ResponseSwitchGetDeviceSwitchPortSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseSwitchGetDeviceSwitchPortStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
+}
 type ResponseSwitchUpdateDeviceSwitchPort struct {
-	AccessPolicyNumber          *int                                         `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                       `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AdaptivePolicyGroupID       string                                       `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
-	AllowedVLANs                string                                       `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                        `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                        `json:"enabled,omitempty"`                     // The status of the switch port.
-	FlexibleStackingEnabled     *bool                                        `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                        `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
-	LinkNegotiation             string                                       `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
-	LinkNegotiationCapabilities []string                                     `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
-	MacAllowList                []string                                     `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseSwitchUpdateDeviceSwitchPortMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseSwitchUpdateDeviceSwitchPortModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                       `json:"name,omitempty"`                        // The name of the switch port.
-	PeerSgtCapable              *bool                                        `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
-	PoeEnabled                  *bool                                        `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
-	PortID                      string                                       `json:"portId,omitempty"`                      // The identifier of the switch port.
-	PortScheduleID              string                                       `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseSwitchUpdateDeviceSwitchPortProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                        `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                     `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                         `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                        `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
-	StpGuard                    string                                       `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                     `json:"tags,omitempty"`                        // The list of tags of the switch port.
-	Type                        string                                       `json:"type,omitempty"`                        // The type of the switch port ('trunk' or 'access').
-	Udld                        string                                       `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                         `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                         `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                     `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                   `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AdaptivePolicyGroup         *ResponseSwitchUpdateDeviceSwitchPortAdaptivePolicyGroup `json:"adaptivePolicyGroup,omitempty"`         // The adaptive policy group data of the port.
+	AdaptivePolicyGroupID       string                                                   `json:"adaptivePolicyGroupId,omitempty"`       // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
+	AllowedVLANs                string                                                   `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                    `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseSwitchUpdateDeviceSwitchPortDot3Az              `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                    `json:"enabled,omitempty"`                     // The status of the switch port.
+	FlexibleStackingEnabled     *bool                                                    `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                    `json:"isolationEnabled,omitempty"`            // The isolation status of the switch port.
+	LinkNegotiation             string                                                   `json:"linkNegotiation,omitempty"`             // The link speed for the switch port.
+	LinkNegotiationCapabilities []string                                                 `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch port.
+	MacAllowList                []string                                                 `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchUpdateDeviceSwitchPortMirror              `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchUpdateDeviceSwitchPortModule              `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                   `json:"name,omitempty"`                        // The name of the switch port.
+	PeerSgtCapable              *bool                                                    `json:"peerSgtCapable,omitempty"`              // If true, Peer SGT is enabled for traffic through this switch port. Applicable to trunk port only, not access port. Cannot be applied to a port on a switch bound to profile.
+	PoeEnabled                  *bool                                                    `json:"poeEnabled,omitempty"`                  // The PoE status of the switch port.
+	PortID                      string                                                   `json:"portId,omitempty"`                      // The identifier of the switch port.
+	PortScheduleID              string                                                   `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseSwitchUpdateDeviceSwitchPortProfile             `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                    `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseSwitchUpdateDeviceSwitchPortSchedule            `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseSwitchUpdateDeviceSwitchPortStackwiseVirtual    `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                                 `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                     `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                    `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch port.
+	StpGuard                    string                                                   `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                                 `json:"tags,omitempty"`                        // The list of tags of the switch port.
+	Type                        string                                                   `json:"type,omitempty"`                        // The type of the switch port ('trunk', 'access' or 'stack').
+	Udld                        string                                                   `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                     `json:"vlan,omitempty"`                        // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                     `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseSwitchUpdateDeviceSwitchPortAdaptivePolicyGroup struct {
+	ID   string `json:"id,omitempty"`   // The ID of the adaptive policy group.
+	Name string `json:"name,omitempty"` // The name of the adaptive policy group.
+}
+type ResponseSwitchUpdateDeviceSwitchPortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch port.
 }
 type ResponseSwitchUpdateDeviceSwitchPortMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -269,6 +369,14 @@ type ResponseSwitchUpdateDeviceSwitchPortProfile struct {
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
+type ResponseSwitchUpdateDeviceSwitchPortSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseSwitchUpdateDeviceSwitchPortStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
+}
 type ResponseSwitchGetDeviceSwitchRoutingInterfaces []ResponseItemSwitchGetDeviceSwitchRoutingInterfaces // Array of ResponseSwitchGetDeviceSwitchRoutingInterfaces
 type ResponseItemSwitchGetDeviceSwitchRoutingInterfaces struct {
 	DefaultGateway   string                                                          `json:"defaultGateway,omitempty"`   // IPv4 default gateway
@@ -280,6 +388,8 @@ type ResponseItemSwitchGetDeviceSwitchRoutingInterfaces struct {
 	OspfSettings     *ResponseItemSwitchGetDeviceSwitchRoutingInterfacesOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseItemSwitchGetDeviceSwitchRoutingInterfacesOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                          `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                           `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                           `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                            `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseItemSwitchGetDeviceSwitchRoutingInterfacesIPv6 struct {
@@ -308,6 +418,8 @@ type ResponseSwitchCreateDeviceSwitchRoutingInterface struct {
 	OspfSettings     *ResponseSwitchCreateDeviceSwitchRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchCreateDeviceSwitchRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                        `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                         `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                         `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                          `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchCreateDeviceSwitchRoutingInterfaceIPv6 struct {
@@ -336,6 +448,8 @@ type ResponseSwitchGetDeviceSwitchRoutingInterface struct {
 	OspfSettings     *ResponseSwitchGetDeviceSwitchRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchGetDeviceSwitchRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                     `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                      `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                      `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                       `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchGetDeviceSwitchRoutingInterfaceIPv6 struct {
@@ -364,6 +478,8 @@ type ResponseSwitchUpdateDeviceSwitchRoutingInterface struct {
 	OspfSettings     *ResponseSwitchUpdateDeviceSwitchRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchUpdateDeviceSwitchRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                        `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                         `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                         `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                          `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceIPv6 struct {
@@ -441,32 +557,36 @@ type ResponseSwitchUpdateDeviceSwitchRoutingInterfaceDhcpReservedIPRanges struct
 type ResponseSwitchGetDeviceSwitchRoutingStaticRoutes []ResponseItemSwitchGetDeviceSwitchRoutingStaticRoutes // Array of ResponseSwitchGetDeviceSwitchRoutingStaticRoutes
 type ResponseItemSwitchGetDeviceSwitchRoutingStaticRoutes struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchCreateDeviceSwitchRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchGetDeviceSwitchRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchUpdateDeviceSwitchRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
@@ -495,31 +615,6 @@ type ResponseSwitchGetNetworkSwitchAccessControlListsRules struct {
 	SrcPort   string `json:"srcPort,omitempty"`   // Source port
 	VLAN      string `json:"vlan,omitempty"`      // ncoming traffic VLAN
 }
-
-func (r *ResponseSwitchGetNetworkSwitchAccessControlListsRules) UnmarshalJSON(data []byte) error {
-	type Alias ResponseSwitchGetNetworkSwitchAccessControlListsRules
-	aux := &struct {
-		SrcPort interface{} `json:"srcPort"`
-		VLAN    interface{} `json:"vlan"`
-		DstCidr interface{} `json:"dstCidr"`
-		DstPort interface{} `json:"dstPort"`
-		SrcCidr interface{} `json:"srcCidr"`
-
-		*Alias
-	}{
-		Alias: (*Alias)(r),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	r.SrcPort = convertToString(aux.SrcPort)
-	r.VLAN = convertToString(aux.VLAN)
-	r.DstCidr = convertToString(aux.DstCidr)
-	r.DstPort = convertToString(aux.DstPort)
-	r.SrcCidr = convertToString(aux.SrcCidr)
-	return nil
-}
-
 type ResponseSwitchUpdateNetworkSwitchAccessControlLists struct {
 	Rules *[]ResponseSwitchUpdateNetworkSwitchAccessControlListsRules `json:"rules,omitempty"` // An ordered array of the access control list rules
 }
@@ -566,9 +661,14 @@ type ResponseItemSwitchGetNetworkSwitchAccessPoliciesDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadius struct {
+	Cache                    *ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                                `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                                `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -576,12 +676,16 @@ type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusAccountingServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS accounting server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS Accounting server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS accounting server
 }
 type ResponseItemSwitchGetNetworkSwitchAccessPoliciesRadiusServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS server
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                                  `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
@@ -613,9 +717,14 @@ type ResponseSwitchCreateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicyRadius struct {
+	Cache                    *ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                             `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                             `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -623,15 +732,19 @@ type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusAccountingServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS accounting server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS Accounting server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS accounting server
 }
 type ResponseSwitchCreateNetworkSwitchAccessPolicyRadiusServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS server
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicy struct {
-	AccessPolicyNumber             string                                                               `json:"accessPolicyNumber,omitempty"`             // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
+	AccessPolicyNumber             string                                                               `json:"accessPolicyNumber,omitempty"`             //
 	AccessPolicyType               string                                                               `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
 	Counts                         *ResponseSwitchGetNetworkSwitchAccessPolicyCounts                    `json:"counts,omitempty"`                         // Counts associated with the access policy
 	Dot1X                          *ResponseSwitchGetNetworkSwitchAccessPolicyDot1X                     `json:"dot1x,omitempty"`                          // 802.1x Settings
@@ -661,9 +774,14 @@ type ResponseSwitchGetNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicyRadius struct {
+	Cache                    *ResponseSwitchGetNetworkSwitchAccessPolicyRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *ResponseSwitchGetNetworkSwitchAccessPolicyRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                          `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                          `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -671,12 +789,16 @@ type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusAccountingServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS accounting server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS Accounting server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS accounting server
 }
 type ResponseSwitchGetNetworkSwitchAccessPolicyRadiusServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS server
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                                  `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
@@ -685,7 +807,7 @@ type ResponseSwitchUpdateNetworkSwitchAccessPolicy struct {
 	GuestPortBouncing              *bool                                                                   `json:"guestPortBouncing,omitempty"`              // If enabled, Meraki devices will periodically send access-request messages to these RADIUS servers
 	GuestVLANID                    *int                                                                    `json:"guestVlanId,omitempty"`                    // ID for the guest VLAN allow unauthorized devices access to limited network resources
 	HostMode                       string                                                                  `json:"hostMode,omitempty"`                       // Choose the Host Mode for the access policy.
-	IncreaseAccessSpeed            *bool                                                                   `json:"increaseAccessSpeed,omitempty"`            // Enabling this option will make switches execute 802.1X and MAC-bypass authentication simultaneously so that clients authenticate faster. Only required when accessPolicyType is Hybrid Authentication.
+	IncreaseAccessSpeed            *bool                                                                   `json:"increaseAccessSpeed,omitempty"`            // Enabling this option will make switches execute 802.1X and MAC-bypass authentication simultaneously so that clients authenticate faster. Only required when accessPolicyType is 'Hybrid Authentication.
 	Name                           string                                                                  `json:"name,omitempty"`                           // Name of the access policy
 	Radius                         *ResponseSwitchUpdateNetworkSwitchAccessPolicyRadius                    `json:"radius,omitempty"`                         // Object for RADIUS Settings
 	RadiusAccountingEnabled        *bool                                                                   `json:"radiusAccountingEnabled,omitempty"`        // Enable to send start, interim-update and stop messages to a configured RADIUS accounting server for tracking connected clients
@@ -708,9 +830,14 @@ type ResponseSwitchUpdateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadius struct {
+	Cache                    *ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                             `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                             `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -718,12 +845,16 @@ type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusAccountingServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS accounting server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS Accounting server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS accounting server
 }
 type ResponseSwitchUpdateNetworkSwitchAccessPolicyRadiusServers struct {
-	Host string `json:"host,omitempty"` // Public IP address of the RADIUS server
-	Port *int   `json:"port,omitempty"` // UDP port that the RADIUS server listens on for access requests
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. This value will be empty if this RADIUS server is not an organization wide RADIUS server
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS server
 }
 type ResponseSwitchGetNetworkSwitchAlternateManagementInterface struct {
 	Enabled   *bool                                                                 `json:"enabled,omitempty"`   // Boolean value to enable or disable AMI configuration. If enabled, VLAN and protocols must be set
@@ -737,7 +868,18 @@ type ResponseSwitchGetNetworkSwitchAlternateManagementInterfaceSwitches struct {
 	Serial                string `json:"serial,omitempty"`                // Switch serial number
 	SubnetMask            string `json:"subnetMask,omitempty"`            // Switch subnet mask must be in IP format. Only and must be specified for Polaris switches
 }
-type ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface interface{}
+type ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface struct {
+	Enabled   *bool                                                                    `json:"enabled,omitempty"`   // Boolean value to enable or disable AMI configuration. If enabled, VLAN and protocols must be set
+	Protocols []string                                                                 `json:"protocols,omitempty"` // Can be one or more of the following values: 'radius', 'snmp' or 'syslog'
+	Switches  *[]ResponseSwitchUpdateNetworkSwitchAlternateManagementInterfaceSwitches `json:"switches,omitempty"`  // Array of switch serial number and IP assignment. If parameter is present, it cannot have empty body. Note: switches parameter is not applicable for template networks, in other words, do not put 'switches' in the body when updating template networks. Also, an empty 'switches' array will remove all previous assignments
+	VLANID    *int                                                                     `json:"vlanId,omitempty"`    // Alternate management VLAN, must be between 1 and 4094
+}
+type ResponseSwitchUpdateNetworkSwitchAlternateManagementInterfaceSwitches struct {
+	AlternateManagementIP string `json:"alternateManagementIp,omitempty"` // Switch alternative management IP. To remove a prior IP setting, provide an empty string
+	Gateway               string `json:"gateway,omitempty"`               // Switch gateway must be in IP format. Only and must be specified for Polaris switches
+	Serial                string `json:"serial,omitempty"`                // Switch serial number
+	SubnetMask            string `json:"subnetMask,omitempty"`            // Switch subnet mask must be in IP format. Only and must be specified for Polaris switches
+}
 type ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen []ResponseItemSwitchGetNetworkSwitchDhcpV4ServersSeen // Array of ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen
 type ResponseItemSwitchGetNetworkSwitchDhcpV4ServersSeen struct {
 	ClientID     string                                                         `json:"clientId,omitempty"`     // Client id of the server if available.
@@ -924,25 +1066,39 @@ type ResponseSwitchGetNetworkSwitchDscpToCosMappingsMappings struct {
 	Dscp  *int   `json:"dscp,omitempty"`  // The Differentiated Services Code Point (DSCP) tag in the IP header that will be mapped to a particular Class-of-Service (CoS) queue. Value can be in the range of 0 to 63 inclusive.
 	Title string `json:"title,omitempty"` // Label for the mapping (optional).
 }
-type ResponseSwitchUpdateNetworkSwitchDscpToCosMappings interface{}
+type ResponseSwitchUpdateNetworkSwitchDscpToCosMappings struct {
+	Mappings *[]ResponseSwitchUpdateNetworkSwitchDscpToCosMappingsMappings `json:"mappings,omitempty"` // An array of DSCP to CoS mappings. An empty array will reset the mappings to default.
+}
+type ResponseSwitchUpdateNetworkSwitchDscpToCosMappingsMappings struct {
+	Cos   *int   `json:"cos,omitempty"`   // The actual layer-2 CoS queue the DSCP value is mapped to. These are not bits set on outgoing frames. Value can be in the range of 0 to 5 inclusive.
+	Dscp  *int   `json:"dscp,omitempty"`  // The Differentiated Services Code Point (DSCP) tag in the IP header that will be mapped to a particular Class-of-Service (CoS) queue. Value can be in the range of 0 to 63 inclusive.
+	Title string `json:"title,omitempty"` // Label for the mapping (optional).
+}
 type ResponseSwitchGetNetworkSwitchLinkAggregations []ResponseItemSwitchGetNetworkSwitchLinkAggregations // Array of ResponseSwitchGetNetworkSwitchLinkAggregations
 type ResponseItemSwitchGetNetworkSwitchLinkAggregations struct {
-	ID          string                                                           `json:"id,omitempty"`          //
-	SwitchPorts *[]ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts `json:"switchPorts,omitempty"` //
+	ID          string                                                           `json:"id,omitempty"`          // The ID for the link aggregation.
+	SwitchPorts *[]ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts `json:"switchPorts,omitempty"` // The ID for the link aggregation.
 }
 type ResponseItemSwitchGetNetworkSwitchLinkAggregationsSwitchPorts struct {
-	PortID string `json:"portId,omitempty"` //
-	Serial string `json:"serial,omitempty"` //
+	PortID string `json:"portId,omitempty"` // The ID for the switch port.
+	Serial string `json:"serial,omitempty"` // The serial number for the switch port.
 }
 type ResponseSwitchCreateNetworkSwitchLinkAggregation struct {
-	ID          string                                                         `json:"id,omitempty"`          //
-	SwitchPorts *[]ResponseSwitchCreateNetworkSwitchLinkAggregationSwitchPorts `json:"switchPorts,omitempty"` //
+	ID          string                                                         `json:"id,omitempty"`          // The ID for the link aggregation.
+	SwitchPorts *[]ResponseSwitchCreateNetworkSwitchLinkAggregationSwitchPorts `json:"switchPorts,omitempty"` // The ID for the link aggregation.
 }
 type ResponseSwitchCreateNetworkSwitchLinkAggregationSwitchPorts struct {
-	PortID string `json:"portId,omitempty"` //
-	Serial string `json:"serial,omitempty"` //
+	PortID string `json:"portId,omitempty"` // The ID for the switch port.
+	Serial string `json:"serial,omitempty"` // The serial number for the switch port.
 }
-type ResponseSwitchUpdateNetworkSwitchLinkAggregation interface{}
+type ResponseSwitchUpdateNetworkSwitchLinkAggregation struct {
+	ID          string                                                         `json:"id,omitempty"`          // The ID for the link aggregation.
+	SwitchPorts *[]ResponseSwitchUpdateNetworkSwitchLinkAggregationSwitchPorts `json:"switchPorts,omitempty"` // The ID for the link aggregation.
+}
+type ResponseSwitchUpdateNetworkSwitchLinkAggregationSwitchPorts struct {
+	PortID string `json:"portId,omitempty"` // The ID for the switch port.
+	Serial string `json:"serial,omitempty"` // The serial number for the switch port.
+}
 type ResponseSwitchGetNetworkSwitchMtu struct {
 	DefaultMtuSize *int                                          `json:"defaultMtuSize,omitempty"` // MTU size for the entire network. Default value is 9578.
 	Overrides      *[]ResponseSwitchGetNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch templates.       An empty array will clear overrides.
@@ -952,7 +1108,15 @@ type ResponseSwitchGetNetworkSwitchMtuOverrides struct {
 	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs. Applicable only for template network.
 	Switches       []string `json:"switches,omitempty"`       // List of switch serials. Applicable only for switch network.
 }
-type ResponseSwitchUpdateNetworkSwitchMtu interface{}
+type ResponseSwitchUpdateNetworkSwitchMtu struct {
+	DefaultMtuSize *int                                             `json:"defaultMtuSize,omitempty"` // MTU size for the entire network. Default value is 9578.
+	Overrides      *[]ResponseSwitchUpdateNetworkSwitchMtuOverrides `json:"overrides,omitempty"`      // Override MTU size for individual switches or switch templates.       An empty array will clear overrides.
+}
+type ResponseSwitchUpdateNetworkSwitchMtuOverrides struct {
+	MtuSize        *int     `json:"mtuSize,omitempty"`        // MTU size for the switches or switch templates.
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs. Applicable only for template network.
+	Switches       []string `json:"switches,omitempty"`       // List of switch serials. Applicable only for switch network.
+}
 type ResponseSwitchGetNetworkSwitchPortSchedules []ResponseItemSwitchGetNetworkSwitchPortSchedules // Array of ResponseSwitchGetNetworkSwitchPortSchedules
 type ResponseItemSwitchGetNetworkSwitchPortSchedules struct {
 	ID           string                                                       `json:"id,omitempty"`           // Switch port schedule ID
@@ -1106,31 +1270,7 @@ type ResponseSwitchUpdateNetworkSwitchPortSchedulePortScheduleWednesday struct {
 }
 type ResponseSwitchGetNetworkSwitchQosRules []ResponseItemSwitchGetNetworkSwitchQosRules // Array of ResponseSwitchGetNetworkSwitchQosRules
 type ResponseItemSwitchGetNetworkSwitchQosRules struct {
-	Dscp         *int   `json:"dscp,omitempty"`         //
-	DstPort      *int   `json:"dstPort,omitempty"`      //
-	DstPortRange string `json:"dstPortRange,omitempty"` //
-	ID           string `json:"id,omitempty"`           //
-	Protocol     string `json:"protocol,omitempty"`     //
-	SrcPort      *int   `json:"srcPort,omitempty"`      //
-	SrcPortRange string `json:"srcPortRange,omitempty"` //
-	VLAN         *int   `json:"vlan,omitempty"`         //
-}
-type ResponseSwitchCreateNetworkSwitchQosRule struct {
-	Dscp         *int   `json:"dscp,omitempty"`         //
-	DstPort      *int   `json:"dstPort,omitempty"`      //
-	DstPortRange string `json:"dstPortRange,omitempty"` //
-	ID           string `json:"id,omitempty"`           //
-	Protocol     string `json:"protocol,omitempty"`     //
-	SrcPort      *int   `json:"srcPort,omitempty"`      //
-	SrcPortRange string `json:"srcPortRange,omitempty"` //
-	VLAN         *int   `json:"vlan,omitempty"`         //
-}
-type ResponseSwitchGetNetworkSwitchQosRulesOrder struct {
-	RuleIDs []string `json:"ruleIds,omitempty"` //
-}
-type ResponseSwitchUpdateNetworkSwitchQosRulesOrder interface{}
-type ResponseSwitchGetNetworkSwitchQosRule struct {
-	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag. Set this to -1 to trust incoming DSCP. Default value is 0
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag for the incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
 	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
 	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
 	ID           string `json:"id,omitempty"`           // Qos Rule id
@@ -1139,7 +1279,42 @@ type ResponseSwitchGetNetworkSwitchQosRule struct {
 	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
 	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
 }
-type ResponseSwitchUpdateNetworkSwitchQosRule interface{}
+type ResponseSwitchCreateNetworkSwitchQosRule struct {
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag for the incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
+	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	ID           string `json:"id,omitempty"`           // Qos Rule id
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY"
+	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
+}
+type ResponseSwitchGetNetworkSwitchQosRulesOrder struct {
+	RuleIDs []string `json:"ruleIds,omitempty"` // Qos Rule ids
+}
+type ResponseSwitchUpdateNetworkSwitchQosRulesOrder struct {
+	RuleIDs []string `json:"ruleIds,omitempty"` // Qos Rule ids
+}
+type ResponseSwitchGetNetworkSwitchQosRule struct {
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag for the incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
+	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	ID           string `json:"id,omitempty"`           // Qos Rule id
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY"
+	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
+}
+type ResponseSwitchUpdateNetworkSwitchQosRule struct {
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag for the incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
+	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	ID           string `json:"id,omitempty"`           // Qos Rule id
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY"
+	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
+}
 type ResponseSwitchGetNetworkSwitchRoutingMulticast struct {
 	DefaultSettings *ResponseSwitchGetNetworkSwitchRoutingMulticastDefaultSettings `json:"defaultSettings,omitempty"` // Default multicast setting for entire network. IGMP snooping and Flood unknown       multicast traffic settings are enabled by default.
 	Overrides       *[]ResponseSwitchGetNetworkSwitchRoutingMulticastOverrides     `json:"overrides,omitempty"`       // Array of paired switches/stacks/profiles and corresponding multicast settings.       An empty array will clear the multicast settings.
@@ -1200,35 +1375,63 @@ type ResponseSwitchUpdateNetworkSwitchRoutingMulticastRendezvousPoint struct {
 	Serial            string `json:"serial,omitempty"`            // The serial.
 }
 type ResponseSwitchGetNetworkSwitchRoutingOspf struct {
-	Areas                    *[]ResponseSwitchGetNetworkSwitchRoutingOspfAreas              `json:"areas,omitempty"`                    //
-	DeadTimerInSeconds       *int                                                           `json:"deadTimerInSeconds,omitempty"`       //
-	Enabled                  *bool                                                          `json:"enabled,omitempty"`                  //
-	HelloTimerInSeconds      *int                                                           `json:"helloTimerInSeconds,omitempty"`      //
-	Md5AuthenticationEnabled *bool                                                          `json:"md5AuthenticationEnabled,omitempty"` //
-	Md5AuthenticationKey     *ResponseSwitchGetNetworkSwitchRoutingOspfMd5AuthenticationKey `json:"md5AuthenticationKey,omitempty"`     //
-	V3                       *ResponseSwitchGetNetworkSwitchRoutingOspfV3                   `json:"v3,omitempty"`                       //
+	Areas                    *[]ResponseSwitchGetNetworkSwitchRoutingOspfAreas              `json:"areas,omitempty"`                    // OSPF areas
+	DeadTimerInSeconds       *int                                                           `json:"deadTimerInSeconds,omitempty"`       // Time interval to determine when the peer will be declared inactive/dead. Value must be between 1 and 65535
+	Enabled                  *bool                                                          `json:"enabled,omitempty"`                  // Boolean value to enable or disable OSPF routing. OSPF routing is disabled by default.
+	HelloTimerInSeconds      *int                                                           `json:"helloTimerInSeconds,omitempty"`      // Time interval in seconds at which hello packet will be sent to OSPF neighbors to maintain connectivity. Value must be between 1 and 255. Default is 10 seconds.
+	Md5AuthenticationEnabled *bool                                                          `json:"md5AuthenticationEnabled,omitempty"` // Boolean value to enable or disable MD5 authentication. MD5 authentication is disabled by default.
+	Md5AuthenticationKey     *ResponseSwitchGetNetworkSwitchRoutingOspfMd5AuthenticationKey `json:"md5AuthenticationKey,omitempty"`     // MD5 authentication credentials. This param is only relevant if md5AuthenticationEnabled is true
+	V3                       *ResponseSwitchGetNetworkSwitchRoutingOspfV3                   `json:"v3,omitempty"`                       // OSPF v3 configuration
 }
 type ResponseSwitchGetNetworkSwitchRoutingOspfAreas struct {
-	AreaID   *int   `json:"areaId,omitempty"`   //
-	AreaName string `json:"areaName,omitempty"` //
-	AreaType string `json:"areaType,omitempty"` //
+	AreaID   *int   `json:"areaId,omitempty"`   // OSPF area ID
+	AreaName string `json:"areaName,omitempty"` // Name of the OSPF area
+	AreaType string `json:"areaType,omitempty"` // Area types in OSPF. Must be one of: ["normal", "stub", "nssa"]
 }
 type ResponseSwitchGetNetworkSwitchRoutingOspfMd5AuthenticationKey struct {
-	ID         *int   `json:"id,omitempty"`         //
-	Passphrase string `json:"passphrase,omitempty"` //
+	ID         *int   `json:"id,omitempty"`         // MD5 authentication key index. Key index must be between 1 to 255
+	Passphrase string `json:"passphrase,omitempty"` // MD5 authentication passphrase
 }
 type ResponseSwitchGetNetworkSwitchRoutingOspfV3 struct {
-	Areas               *[]ResponseSwitchGetNetworkSwitchRoutingOspfV3Areas `json:"areas,omitempty"`               //
-	DeadTimerInSeconds  *int                                                `json:"deadTimerInSeconds,omitempty"`  //
-	Enabled             *bool                                               `json:"enabled,omitempty"`             //
-	HelloTimerInSeconds *int                                                `json:"helloTimerInSeconds,omitempty"` //
+	Areas               *[]ResponseSwitchGetNetworkSwitchRoutingOspfV3Areas `json:"areas,omitempty"`               // OSPF v3 areas
+	DeadTimerInSeconds  *int                                                `json:"deadTimerInSeconds,omitempty"`  // Time interval to determine when the peer will be declared inactive/dead. Value must be between 1 and 65535
+	Enabled             *bool                                               `json:"enabled,omitempty"`             // Boolean value to enable or disable V3 OSPF routing. OSPF V3 routing is disabled by default.
+	HelloTimerInSeconds *int                                                `json:"helloTimerInSeconds,omitempty"` // Time interval in seconds at which hello packet will be sent to OSPF neighbors to maintain connectivity. Value must be between 1 and 255. Default is 10 seconds.
 }
 type ResponseSwitchGetNetworkSwitchRoutingOspfV3Areas struct {
-	AreaID   *int   `json:"areaId,omitempty"`   //
-	AreaName string `json:"areaName,omitempty"` //
-	AreaType string `json:"areaType,omitempty"` //
+	AreaID   *int   `json:"areaId,omitempty"`   // OSPF area ID
+	AreaName string `json:"areaName,omitempty"` // Name of the OSPF area
+	AreaType string `json:"areaType,omitempty"` // Area types in OSPF. Must be one of: ["normal", "stub", "nssa"]
 }
-type ResponseSwitchUpdateNetworkSwitchRoutingOspf interface{}
+type ResponseSwitchUpdateNetworkSwitchRoutingOspf struct {
+	Areas                    *[]ResponseSwitchUpdateNetworkSwitchRoutingOspfAreas              `json:"areas,omitempty"`                    // OSPF areas
+	DeadTimerInSeconds       *int                                                              `json:"deadTimerInSeconds,omitempty"`       // Time interval to determine when the peer will be declared inactive/dead. Value must be between 1 and 65535
+	Enabled                  *bool                                                             `json:"enabled,omitempty"`                  // Boolean value to enable or disable OSPF routing. OSPF routing is disabled by default.
+	HelloTimerInSeconds      *int                                                              `json:"helloTimerInSeconds,omitempty"`      // Time interval in seconds at which hello packet will be sent to OSPF neighbors to maintain connectivity. Value must be between 1 and 255. Default is 10 seconds.
+	Md5AuthenticationEnabled *bool                                                             `json:"md5AuthenticationEnabled,omitempty"` // Boolean value to enable or disable MD5 authentication. MD5 authentication is disabled by default.
+	Md5AuthenticationKey     *ResponseSwitchUpdateNetworkSwitchRoutingOspfMd5AuthenticationKey `json:"md5AuthenticationKey,omitempty"`     // MD5 authentication credentials. This param is only relevant if md5AuthenticationEnabled is true
+	V3                       *ResponseSwitchUpdateNetworkSwitchRoutingOspfV3                   `json:"v3,omitempty"`                       // OSPF v3 configuration
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingOspfAreas struct {
+	AreaID   *int   `json:"areaId,omitempty"`   // OSPF area ID
+	AreaName string `json:"areaName,omitempty"` // Name of the OSPF area
+	AreaType string `json:"areaType,omitempty"` // Area types in OSPF. Must be one of: ["normal", "stub", "nssa"]
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingOspfMd5AuthenticationKey struct {
+	ID         *int   `json:"id,omitempty"`         // MD5 authentication key index. Key index must be between 1 to 255
+	Passphrase string `json:"passphrase,omitempty"` // MD5 authentication passphrase
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingOspfV3 struct {
+	Areas               *[]ResponseSwitchUpdateNetworkSwitchRoutingOspfV3Areas `json:"areas,omitempty"`               // OSPF v3 areas
+	DeadTimerInSeconds  *int                                                   `json:"deadTimerInSeconds,omitempty"`  // Time interval to determine when the peer will be declared inactive/dead. Value must be between 1 and 65535
+	Enabled             *bool                                                  `json:"enabled,omitempty"`             // Boolean value to enable or disable V3 OSPF routing. OSPF V3 routing is disabled by default.
+	HelloTimerInSeconds *int                                                   `json:"helloTimerInSeconds,omitempty"` // Time interval in seconds at which hello packet will be sent to OSPF neighbors to maintain connectivity. Value must be between 1 and 255. Default is 10 seconds.
+}
+type ResponseSwitchUpdateNetworkSwitchRoutingOspfV3Areas struct {
+	AreaID   *int   `json:"areaId,omitempty"`   // OSPF area ID
+	AreaName string `json:"areaName,omitempty"` // Name of the OSPF area
+	AreaType string `json:"areaType,omitempty"` // Area types in OSPF. Must be one of: ["normal", "stub", "nssa"]
+}
 type ResponseSwitchGetNetworkSwitchSettings struct {
 	MacBlocklist         *ResponseSwitchGetNetworkSwitchSettingsMacBlocklist         `json:"macBlocklist,omitempty"`         // MAC blocklist
 	PowerExceptions      *[]ResponseSwitchGetNetworkSwitchSettingsPowerExceptions    `json:"powerExceptions,omitempty"`      // Exceptions on a per switch basis to "useCombinedPower"
@@ -1265,29 +1468,74 @@ type ResponseSwitchUpdateNetworkSwitchSettingsUplinkClientSampling struct {
 }
 type ResponseSwitchGetNetworkSwitchStacks []ResponseItemSwitchGetNetworkSwitchStacks // Array of ResponseSwitchGetNetworkSwitchStacks
 type ResponseItemSwitchGetNetworkSwitchStacks struct {
-	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
-	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
-	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+	ID            string                                             `json:"id,omitempty"`            // ID of the Switch stack
+	IsMonitorOnly *bool                                              `json:"isMonitorOnly,omitempty"` // Tells if stack is Monitored Stack.
+	Members       *[]ResponseItemSwitchGetNetworkSwitchStacksMembers `json:"members,omitempty"`       // Members of the Stack
+	Name          string                                             `json:"name,omitempty"`          // Name of the Switch stack
+	Serials       []string                                           `json:"serials,omitempty"`       // Serials of the switches in the switch stack
+}
+type ResponseItemSwitchGetNetworkSwitchStacksMembers struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model of the device
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Role   string `json:"role,omitempty"`   // Role of the device
+	Serial string `json:"serial,omitempty"` // Serial number of the device
 }
 type ResponseSwitchCreateNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
-	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
-	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+	ID            string                                           `json:"id,omitempty"`            // ID of the Switch stack
+	IsMonitorOnly *bool                                            `json:"isMonitorOnly,omitempty"` // Tells if stack is Monitored Stack.
+	Members       *[]ResponseSwitchCreateNetworkSwitchStackMembers `json:"members,omitempty"`       // Members of the Stack
+	Name          string                                           `json:"name,omitempty"`          // Name of the Switch stack
+	Serials       []string                                         `json:"serials,omitempty"`       // Serials of the switches in the switch stack
+}
+type ResponseSwitchCreateNetworkSwitchStackMembers struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model of the device
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Role   string `json:"role,omitempty"`   // Role of the device
+	Serial string `json:"serial,omitempty"` // Serial number of the device
 }
 type ResponseSwitchGetNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
-	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
-	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+	ID            string                                        `json:"id,omitempty"`            // ID of the Switch stack
+	IsMonitorOnly *bool                                         `json:"isMonitorOnly,omitempty"` // Tells if stack is Monitored Stack.
+	Members       *[]ResponseSwitchGetNetworkSwitchStackMembers `json:"members,omitempty"`       // Members of the Stack
+	Name          string                                        `json:"name,omitempty"`          // Name of the Switch stack
+	Serials       []string                                      `json:"serials,omitempty"`       // Serials of the switches in the switch stack
+}
+type ResponseSwitchGetNetworkSwitchStackMembers struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model of the device
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Role   string `json:"role,omitempty"`   // Role of the device
+	Serial string `json:"serial,omitempty"` // Serial number of the device
 }
 type ResponseSwitchAddNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
-	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
-	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+	ID            string                                        `json:"id,omitempty"`            // ID of the Switch stack
+	IsMonitorOnly *bool                                         `json:"isMonitorOnly,omitempty"` // Tells if stack is Monitored Stack.
+	Members       *[]ResponseSwitchAddNetworkSwitchStackMembers `json:"members,omitempty"`       // Members of the Stack
+	Name          string                                        `json:"name,omitempty"`          // Name of the Switch stack
+	Serials       []string                                      `json:"serials,omitempty"`       // Serials of the switches in the switch stack
+}
+type ResponseSwitchAddNetworkSwitchStackMembers struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model of the device
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Role   string `json:"role,omitempty"`   // Role of the device
+	Serial string `json:"serial,omitempty"` // Serial number of the device
 }
 type ResponseSwitchRemoveNetworkSwitchStack struct {
-	ID      string   `json:"id,omitempty"`      // ID of the Switch stack
-	Name    string   `json:"name,omitempty"`    // Name of the Switch stack
-	Serials []string `json:"serials,omitempty"` // Serials of the switches in the switch stack
+	ID            string                                           `json:"id,omitempty"`            // ID of the Switch stack
+	IsMonitorOnly *bool                                            `json:"isMonitorOnly,omitempty"` // Tells if stack is Monitored Stack.
+	Members       *[]ResponseSwitchRemoveNetworkSwitchStackMembers `json:"members,omitempty"`       // Members of the Stack
+	Name          string                                           `json:"name,omitempty"`          // Name of the Switch stack
+	Serials       []string                                         `json:"serials,omitempty"`       // Serials of the switches in the switch stack
+}
+type ResponseSwitchRemoveNetworkSwitchStackMembers struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model of the device
+	Name   string `json:"name,omitempty"`   // Name of the device
+	Role   string `json:"role,omitempty"`   // Role of the device
+	Serial string `json:"serial,omitempty"` // Serial number of the device
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaces []ResponseItemSwitchGetNetworkSwitchStackRoutingInterfaces // Array of ResponseSwitchGetNetworkSwitchStackRoutingInterfaces
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfaces struct {
@@ -1300,6 +1548,8 @@ type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfaces struct {
 	OspfSettings     *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                                `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                                 `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                                 `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                                  `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseItemSwitchGetNetworkSwitchStackRoutingInterfacesIPv6 struct {
@@ -1328,6 +1578,8 @@ type ResponseSwitchCreateNetworkSwitchStackRoutingInterface struct {
 	OspfSettings     *ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                              `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                               `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                               `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                                `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchCreateNetworkSwitchStackRoutingInterfaceIPv6 struct {
@@ -1356,6 +1608,8 @@ type ResponseSwitchGetNetworkSwitchStackRoutingInterface struct {
 	OspfSettings     *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchGetNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                           `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                            `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                            `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                             `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingInterfaceIPv6 struct {
@@ -1383,6 +1637,8 @@ type ResponseSwitchUpdateNetworkSwitchStackRoutingInterface struct {
 	OspfSettings     *ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // IPv4 OSPF Settings
 	OspfV3           *ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // IPv6 OSPF Settings
 	Subnet           string                                                              `json:"subnet,omitempty"`           // IPv4 subnet
+	UplinkV4         *bool                                                               `json:"uplinkV4,omitempty"`         // Whether this is the switch's IPv4 uplink
+	UplinkV6         *bool                                                               `json:"uplinkV6,omitempty"`         // Whether this is the switch's IPv6 uplink
 	VLANID           *int                                                                `json:"vlanId,omitempty"`           // VLAN id
 }
 type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceIPv6 struct {
@@ -1460,55 +1716,72 @@ type ResponseSwitchUpdateNetworkSwitchStackRoutingInterfaceDhcpReservedIPRanges 
 type ResponseSwitchGetNetworkSwitchStackRoutingStaticRoutes []ResponseItemSwitchGetNetworkSwitchStackRoutingStaticRoutes // Array of ResponseSwitchGetNetworkSwitchStackRoutingStaticRoutes
 type ResponseItemSwitchGetNetworkSwitchStackRoutingStaticRoutes struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchCreateNetworkSwitchStackRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchGetNetworkSwitchStackRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchUpdateNetworkSwitchStackRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static routes via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // The name or description of the layer 3 static route
-	NextHopIP                   string `json:"nextHopIp,omitempty"`                   //  The IP address of the router to which traffic for this destination network should be sent
+	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // The IP address of the router to which traffic for this destination network should be sent
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static routes over OSPF routes
 	StaticRouteID               string `json:"staticRouteId,omitempty"`               // The identifier of a layer 3 static route
 	Subnet                      string `json:"subnet,omitempty"`                      // The IP address of the subnetwork specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type ResponseSwitchGetNetworkSwitchStormControl struct {
-	BroadcastThreshold      *int `json:"broadcastThreshold,omitempty"`      // Broadcast threshold.
-	MulticastThreshold      *int `json:"multicastThreshold,omitempty"`      // Multicast threshold.
-	UnknownUnicastThreshold *int `json:"unknownUnicastThreshold,omitempty"` // Unknown Unicast threshold.
+	BroadcastThreshold                   *int     `json:"broadcastThreshold,omitempty"`                   // Broadcast threshold.
+	MulticastThreshold                   *int     `json:"multicastThreshold,omitempty"`                   // Multicast threshold.
+	TreatTheseTrafficTypesAsOneThreshold []string `json:"treatTheseTrafficTypesAsOneThreshold,omitempty"` // Grouped traffic types
+	UnknownUnicastThreshold              *int     `json:"unknownUnicastThreshold,omitempty"`              // Unknown Unicast threshold.
 }
 type ResponseSwitchUpdateNetworkSwitchStormControl struct {
-	BroadcastThreshold      *int `json:"broadcastThreshold,omitempty"`      // Broadcast threshold.
-	MulticastThreshold      *int `json:"multicastThreshold,omitempty"`      // Multicast threshold.
-	UnknownUnicastThreshold *int `json:"unknownUnicastThreshold,omitempty"` // Unknown Unicast threshold.
+	BroadcastThreshold                   *int     `json:"broadcastThreshold,omitempty"`                   // Broadcast threshold.
+	MulticastThreshold                   *int     `json:"multicastThreshold,omitempty"`                   // Multicast threshold.
+	TreatTheseTrafficTypesAsOneThreshold []string `json:"treatTheseTrafficTypesAsOneThreshold,omitempty"` // Grouped traffic types
+	UnknownUnicastThreshold              *int     `json:"unknownUnicastThreshold,omitempty"`              // Unknown Unicast threshold.
 }
 type ResponseSwitchGetNetworkSwitchStp struct {
-	RstpEnabled       *bool                                                 `json:"rstpEnabled,omitempty"`       //
-	StpBridgePriority *[]ResponseSwitchGetNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` //
+	RstpEnabled       *bool                                                 `json:"rstpEnabled,omitempty"`       // The spanning tree protocol status in network
+	StpBridgePriority *[]ResponseSwitchGetNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` // STP bridge priority for switches/stacks or switch templates. An empty array will clear the STP bridge priority settings.
 }
 type ResponseSwitchGetNetworkSwitchStpStpBridgePriority struct {
-	StpPriority *int     `json:"stpPriority,omitempty"` //
-	Switches    []string `json:"switches,omitempty"`    //
+	Stacks         []string `json:"stacks,omitempty"`         // List of stack IDs
+	StpPriority    *int     `json:"stpPriority,omitempty"`    // STP priority for switch, stacks, or switch templates
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs
+	Switches       []string `json:"switches,omitempty"`       // List of switch serial numbers
 }
-type ResponseSwitchUpdateNetworkSwitchStp interface{}
+type ResponseSwitchUpdateNetworkSwitchStp struct {
+	RstpEnabled       *bool                                                    `json:"rstpEnabled,omitempty"`       // The spanning tree protocol status in network
+	StpBridgePriority *[]ResponseSwitchUpdateNetworkSwitchStpStpBridgePriority `json:"stpBridgePriority,omitempty"` // STP bridge priority for switches/stacks or switch templates. An empty array will clear the STP bridge priority settings.
+}
+type ResponseSwitchUpdateNetworkSwitchStpStpBridgePriority struct {
+	Stacks         []string `json:"stacks,omitempty"`         // List of stack IDs
+	StpPriority    *int     `json:"stpPriority,omitempty"`    // STP priority for switch, stacks, or switch templates
+	SwitchProfiles []string `json:"switchProfiles,omitempty"` // List of switch template IDs
+	Switches       []string `json:"switches,omitempty"`       // List of switch serial numbers
+}
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles []ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfiles // Array of ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles
 type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfiles struct {
 	Model           string `json:"model,omitempty"`           // Switch model
@@ -1517,33 +1790,39 @@ type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfiles struct {
 }
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePorts []ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePorts // Array of ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePorts
 type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePorts struct {
-	AccessPolicyNumber          *int                                                                      `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                                    `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                                    `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                                                     `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                     `json:"enabled,omitempty"`                     // The status of the switch template port.
-	FlexibleStackingEnabled     *bool                                                                     `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                     `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
-	LinkNegotiation             string                                                                    `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
-	LinkNegotiationCapabilities []string                                                                  `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
-	MacAllowList                []string                                                                  `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                                                    `json:"name,omitempty"`                        // The name of the switch template port.
-	PoeEnabled                  *bool                                                                     `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
-	PortID                      string                                                                    `json:"portId,omitempty"`                      // The identifier of the switch template port.
-	PortScheduleID              string                                                                    `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                                                     `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                                                  `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                                                      `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                     `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
-	StpGuard                    string                                                                    `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                                  `json:"tags,omitempty"`                        // The list of tags of the switch template port.
-	Type                        string                                                                    `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
-	Udld                        string                                                                    `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                      `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                      `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                                               `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                                             `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                                             `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                                              `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsDot3Az           `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                                              `json:"enabled,omitempty"`                     // The status of the switch template port.
+	FlexibleStackingEnabled     *bool                                                                              `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                                              `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                                             `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                                           `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
+	MacAllowList                []string                                                                           `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsMirror           `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsModule           `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                                             `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                              `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                                             `json:"portId,omitempty"`                      // The identifier of the switch template port.
+	PortScheduleID              string                                                                             `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile          `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                                              `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsSchedule         `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsStackwiseVirtual `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                                                           `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                                               `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                                              `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
+	StpGuard                    string                                                                             `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                                                           `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                                             `json:"type,omitempty"`                        // The type of the switch template port ('trunk', 'access' or 'stack').
+	Udld                        string                                                                             `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                                               `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                               `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch template port.
 }
 type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -1556,34 +1835,48 @@ type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsProfile st
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseItemSwitchGetOrganizationConfigTemplateSwitchProfilePortsStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
+}
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePort struct {
-	AccessPolicyNumber          *int                                                                 `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                               `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                               `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                                                `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                `json:"enabled,omitempty"`                     // The status of the switch template port.
-	FlexibleStackingEnabled     *bool                                                                `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
-	LinkNegotiation             string                                                               `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
-	LinkNegotiationCapabilities []string                                                             `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
-	MacAllowList                []string                                                             `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                                               `json:"name,omitempty"`                        // The name of the switch template port.
-	PoeEnabled                  *bool                                                                `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
-	PortID                      string                                                               `json:"portId,omitempty"`                      // The identifier of the switch template port.
-	PortScheduleID              string                                                               `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                                                `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                                             `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                                                 `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
-	StpGuard                    string                                                               `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                             `json:"tags,omitempty"`                        // The list of tags of the switch template port.
-	Type                        string                                                               `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
-	Udld                        string                                                               `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                 `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                 `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                                          `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                                        `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                                        `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                                         `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortDot3Az           `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                                         `json:"enabled,omitempty"`                     // The status of the switch template port.
+	FlexibleStackingEnabled     *bool                                                                         `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                                         `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                                        `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                                      `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
+	MacAllowList                []string                                                                      `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortMirror           `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortModule           `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                                        `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                         `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                                        `json:"portId,omitempty"`                      // The identifier of the switch template port.
+	PortScheduleID              string                                                                        `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile          `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                                         `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortSchedule         `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortStackwiseVirtual `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                                                      `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                                          `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                                         `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
+	StpGuard                    string                                                                        `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                                                      `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                                        `json:"type,omitempty"`                        // The type of the switch template port ('trunk', 'access' or 'stack').
+	Udld                        string                                                                        `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                                          `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                          `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch template port.
 }
 type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -1596,34 +1889,48 @@ type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortProfile struct 
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePortStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
+}
 type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePort struct {
-	AccessPolicyNumber          *int                                                                    `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
-	AccessPolicyType            string                                                                  `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
-	AllowedVLANs                string                                                                  `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
-	DaiTrusted                  *bool                                                                   `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
-	Enabled                     *bool                                                                   `json:"enabled,omitempty"`                     // The status of the switch template port.
-	FlexibleStackingEnabled     *bool                                                                   `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
-	IsolationEnabled            *bool                                                                   `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
-	LinkNegotiation             string                                                                  `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
-	LinkNegotiationCapabilities []string                                                                `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
-	MacAllowList                []string                                                                `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
-	Mirror                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortMirror  `json:"mirror,omitempty"`                      // Port mirror
-	Module                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortModule  `json:"module,omitempty"`                      // Expansion module
-	Name                        string                                                                  `json:"name,omitempty"`                        // The name of the switch template port.
-	PoeEnabled                  *bool                                                                   `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
-	PortID                      string                                                                  `json:"portId,omitempty"`                      // The identifier of the switch template port.
-	PortScheduleID              string                                                                  `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
-	Profile                     *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile `json:"profile,omitempty"`                     // Profile attributes
-	RstpEnabled                 *bool                                                                   `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
-	StickyMacAllowList          []string                                                                `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StickyMacAllowListLimit     *int                                                                    `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
-	StormControlEnabled         *bool                                                                   `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
-	StpGuard                    string                                                                  `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
-	Tags                        []string                                                                `json:"tags,omitempty"`                        // The list of tags of the switch template port.
-	Type                        string                                                                  `json:"type,omitempty"`                        // The type of the switch template port ('trunk' or 'access').
-	Udld                        string                                                                  `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
-	VLAN                        *int                                                                    `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	VoiceVLAN                   *int                                                                    `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+	AccessPolicyNumber          *int                                                                             `json:"accessPolicyNumber,omitempty"`          // The number of a custom access policy to configure on the switch template port. Only applicable when 'accessPolicyType' is 'Custom access policy'.
+	AccessPolicyType            string                                                                           `json:"accessPolicyType,omitempty"`            // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
+	AllowedVLANs                string                                                                           `json:"allowedVlans,omitempty"`                // The VLANs allowed on the switch template port. Only applicable to trunk ports.
+	DaiTrusted                  *bool                                                                            `json:"daiTrusted,omitempty"`                  // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortDot3Az           `json:"dot3az,omitempty"`                      // dot3az settings for the port
+	Enabled                     *bool                                                                            `json:"enabled,omitempty"`                     // The status of the switch template port.
+	FlexibleStackingEnabled     *bool                                                                            `json:"flexibleStackingEnabled,omitempty"`     // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
+	IsolationEnabled            *bool                                                                            `json:"isolationEnabled,omitempty"`            // The isolation status of the switch template port.
+	LinkNegotiation             string                                                                           `json:"linkNegotiation,omitempty"`             // The link speed for the switch template port.
+	LinkNegotiationCapabilities []string                                                                         `json:"linkNegotiationCapabilities,omitempty"` // Available link speeds for the switch template port.
+	MacAllowList                []string                                                                         `json:"macAllowList,omitempty"`                // Only devices with MAC addresses specified in this list will have access to this port. Up to 20 MAC addresses can be defined. Only applicable when 'accessPolicyType' is 'MAC allow list'.
+	Mirror                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortMirror           `json:"mirror,omitempty"`                      // Port mirror
+	Module                      *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortModule           `json:"module,omitempty"`                      // Expansion module
+	Name                        string                                                                           `json:"name,omitempty"`                        // The name of the switch template port.
+	PoeEnabled                  *bool                                                                            `json:"poeEnabled,omitempty"`                  // The PoE status of the switch template port.
+	PortID                      string                                                                           `json:"portId,omitempty"`                      // The identifier of the switch template port.
+	PortScheduleID              string                                                                           `json:"portScheduleId,omitempty"`              // The ID of the port schedule. A value of null will clear the port schedule.
+	Profile                     *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile          `json:"profile,omitempty"`                     // Profile attributes
+	RstpEnabled                 *bool                                                                            `json:"rstpEnabled,omitempty"`                 // The rapid spanning tree protocol status.
+	Schedule                    *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortSchedule         `json:"schedule,omitempty"`                    // The port schedule data.
+	StackwiseVirtual            *ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortStackwiseVirtual `json:"stackwiseVirtual,omitempty"`            // Stackwise Virtual settings for the port
+	StickyMacAllowList          []string                                                                         `json:"stickyMacAllowList,omitempty"`          // The initial list of MAC addresses for sticky Mac allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StickyMacAllowListLimit     *int                                                                             `json:"stickyMacAllowListLimit,omitempty"`     // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
+	StormControlEnabled         *bool                                                                            `json:"stormControlEnabled,omitempty"`         // The storm control status of the switch template port.
+	StpGuard                    string                                                                           `json:"stpGuard,omitempty"`                    // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
+	Tags                        []string                                                                         `json:"tags,omitempty"`                        // The list of tags of the switch template port.
+	Type                        string                                                                           `json:"type,omitempty"`                        // The type of the switch template port ('trunk', 'access' or 'stack').
+	Udld                        string                                                                           `json:"udld,omitempty"`                        // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
+	VLAN                        *int                                                                             `json:"vlan,omitempty"`                        // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	VoiceVLAN                   *int                                                                             `json:"voiceVlan,omitempty"`                   // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch template port.
 }
 type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortMirror struct {
 	Mode string `json:"mode,omitempty"` // The port mirror mode. Can be one of ('Destination port', 'Source port' or 'Not mirroring traffic').
@@ -1636,26 +1943,36 @@ type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile stru
 	ID      string `json:"id,omitempty"`      // When enabled, the ID of the port profile used to override the port's configuration.
 	Iname   string `json:"iname,omitempty"`   // When enabled, the IName of the profile.
 }
+type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortSchedule struct {
+	ID   string `json:"id,omitempty"`   // The ID of the port schedule.
+	Name string `json:"name,omitempty"` // The name of the port schedule.
+}
+type ResponseSwitchUpdateOrganizationConfigTemplateSwitchProfilePortStackwiseVirtual struct {
+	IsDualActiveDetector   *bool `json:"isDualActiveDetector,omitempty"`   // For SVL devices, whether or not the port is used for Dual Active Detection.
+	IsStackWiseVirtualLink *bool `json:"isStackWiseVirtualLink,omitempty"` // For SVL devices, whether or not the port is used for StackWise Virtual Link.
+}
 type ResponseSwitchGetOrganizationSummarySwitchPowerHistory []ResponseItemSwitchGetOrganizationSummarySwitchPowerHistory // Array of ResponseSwitchGetOrganizationSummarySwitchPowerHistory
 type ResponseItemSwitchGetOrganizationSummarySwitchPowerHistory struct {
 	Draw *float64 `json:"draw,omitempty"` // The PoE power draw in watts for all switch ports in the organization for the given interval.
 	Ts   string   `json:"ts,omitempty"`   // Timestamp of the start of the interval.
 }
-type ResponseSwitchCloneOrganizationSwitchDevices interface{}
-type ResponseSwitchGetOrganizationSwitchPortsBySwitch []ResponseItemSwitchGetOrganizationSwitchPortsBySwitch // Array of ResponseSwitchGetOrganizationSwitchPortsBySwitch
-type ResponseItemSwitchGetOrganizationSwitchPortsBySwitch struct {
-	Mac     string                                                       `json:"mac,omitempty"`     // The MAC address of the switch.
-	Model   string                                                       `json:"model,omitempty"`   // The model of the switch.
-	Name    string                                                       `json:"name,omitempty"`    // The name of the switch.
-	Network *ResponseItemSwitchGetOrganizationSwitchPortsBySwitchNetwork `json:"network,omitempty"` // Identifying information of the switch's network.
-	Ports   *[]ResponseItemSwitchGetOrganizationSwitchPortsBySwitchPorts `json:"ports,omitempty"`   // Ports belonging to the switch
-	Serial  string                                                       `json:"serial,omitempty"`  // The serial number of the switch.
+type ResponseSwitchCloneOrganizationSwitchDevices struct {
+	SourceSerial  string   `json:"sourceSerial,omitempty"`  // Serial number of the source switch (must be on a network not bound to a template)
+	TargetSerials []string `json:"targetSerials,omitempty"` // Array of serial numbers of one or more target switches (must be on a network not bound to a template)
 }
-type ResponseItemSwitchGetOrganizationSwitchPortsBySwitchNetwork struct {
+type ResponseSwitchGetOrganizationSwitchPortsBySwitch struct {
+	Mac     string                                                   `json:"mac,omitempty"`     // The MAC address of the switch.
+	Model   string                                                   `json:"model,omitempty"`   // The model of the switch.
+	Name    string                                                   `json:"name,omitempty"`    // The name of the switch.
+	Network *ResponseSwitchGetOrganizationSwitchPortsBySwitchNetwork `json:"network,omitempty"` // Identifying information of the switch's network.
+	Ports   *[]ResponseSwitchGetOrganizationSwitchPortsBySwitchPorts `json:"ports,omitempty"`   // Ports belonging to the switch
+	Serial  string                                                   `json:"serial,omitempty"`  // The serial number of the switch.
+}
+type ResponseSwitchGetOrganizationSwitchPortsBySwitchNetwork struct {
 	ID   string `json:"id,omitempty"`   // The ID of the network.
 	Name string `json:"name,omitempty"` // The name of the network.
 }
-type ResponseItemSwitchGetOrganizationSwitchPortsBySwitchPorts struct {
+type ResponseSwitchGetOrganizationSwitchPortsBySwitchPorts struct {
 	AccessPolicyType        string   `json:"accessPolicyType,omitempty"`        // The type of the access policy of the switch port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
 	AllowedVLANs            string   `json:"allowedVlans,omitempty"`            // The VLANs allowed on the switch port. Only applicable to trunk ports.
 	Enabled                 *bool    `json:"enabled,omitempty"`                 // The status of the switch port.
@@ -1668,9 +1985,187 @@ type ResponseItemSwitchGetOrganizationSwitchPortsBySwitchPorts struct {
 	StickyMacAllowListLimit *int     `json:"stickyMacAllowListLimit,omitempty"` // The maximum number of MAC addresses for sticky MAC allow list. Only applicable when 'accessPolicyType' is 'Sticky MAC allow list'.
 	StpGuard                string   `json:"stpGuard,omitempty"`                // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
 	Tags                    []string `json:"tags,omitempty"`                    // The list of tags of the switch port.
-	Type                    string   `json:"type,omitempty"`                    // The type of the switch port ('trunk' or 'access').
+	Type                    string   `json:"type,omitempty"`                    // The type of the switch port ('trunk', 'access' or 'stack').
 	VLAN                    *int     `json:"vlan,omitempty"`                    // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN               *int     `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice struct {
+	Items *[]ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItems `json:"items,omitempty"` // Switches
+	Meta  *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItems struct {
+	Mac     string                                                                       `json:"mac,omitempty"`     // The MAC address of the switch.
+	Model   string                                                                       `json:"model,omitempty"`   // The model of the switch.
+	Name    string                                                                       `json:"name,omitempty"`    // The name of the switch.
+	Network *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsNetwork `json:"network,omitempty"` // Identifying information of the switch's network.
+	Ports   *[]ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPorts `json:"ports,omitempty"`   // The number of online clients of the ports on the switch.
+	Serial  string                                                                       `json:"serial,omitempty"`  // The serial number of the switch.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // The ID of the network.
+	Name string `json:"name,omitempty"` // The name of the network.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPorts struct {
+	Counts *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPortsCounts `json:"counts,omitempty"` // Number of clients on the port in a given time.
+	PortID string                                                                           `json:"portId,omitempty"` // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPortsCounts struct {
+	ByStatus *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPortsCountsByStatus `json:"byStatus,omitempty"` // Associated client count on access point by status.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceItemsPortsCountsByStatus struct {
+	Online *int `json:"online,omitempty"` // Active client count.
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMeta struct {
+	Counts *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMetaCounts struct {
+	Items *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverview struct {
+	Counts *ResponseSwitchGetOrganizationSwitchPortsOverviewCounts `json:"counts,omitempty"` // The count data of all ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCounts struct {
+	ByStatus *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatus `json:"byStatus,omitempty"` // The count data, indexed by active or inactive status
+	Total    *int                                                            `json:"total,omitempty"`    // The total number of ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatus struct {
+	Active   *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActive   `json:"active,omitempty"`   // The count data for active ports
+	Inactive *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactive `json:"inactive,omitempty"` // The count data for inactive ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActive struct {
+	ByMediaAndLinkSpeed *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeed `json:"byMediaAndLinkSpeed,omitempty"` // The active count data, indexed by media type (RJ45 or SFP)
+	Total               *int                                                                                     `json:"total,omitempty"`               // The total number of active ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeed struct {
+	Rj45 *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeedRj45 `json:"rj45,omitempty"` // The count data for RJ45 ports, indexed by speed in Mb
+	Sfp  *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeedSfp  `json:"sfp,omitempty"`  // The count data for SFP ports, indexed by speed in Mb
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeedRj45 struct {
+	Status10    *int `json:"10,omitempty"`    // The number of active 10 Mbps RJ45 ports
+	Status100   *int `json:"100,omitempty"`   // The number of active 100 Mbps RJ45 ports
+	Status1000  *int `json:"1000,omitempty"`  // The number of active 1 Gbps RJ45 ports
+	Status10000 *int `json:"10000,omitempty"` // The number of active 10 Gbps RJ45 ports
+	Status2500  *int `json:"2500,omitempty"`  // The number of active 2 Gbps RJ45 ports
+	Status5000  *int `json:"5000,omitempty"`  // The number of active 5 Gbps RJ45 ports
+	Total       *int `json:"total,omitempty"` // The total number of active RJ45 ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusActiveByMediaAndLinkSpeedSfp struct {
+	Status100    *int `json:"100,omitempty"`    // The number of active 100 Mbps SFP ports
+	Status1000   *int `json:"1000,omitempty"`   // The number of active 1 Gbps SFP ports
+	Status10000  *int `json:"10000,omitempty"`  // The number of active 10 Gbps SFP ports
+	Status100000 *int `json:"100000,omitempty"` // The number of active 100 Gbps SFP ports
+	Status20000  *int `json:"20000,omitempty"`  // The number of active 20 Gbps SFP ports
+	Status25000  *int `json:"25000,omitempty"`  // The number of active 25 Gbps SFP ports
+	Status40000  *int `json:"40000,omitempty"`  // The number of active 40 Gbps SFP ports
+	Status50000  *int `json:"50000,omitempty"`  // The number of active 50 Gbps SFP ports
+	Total        *int `json:"total,omitempty"`  // The total number of active SFP ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactive struct {
+	ByMedia *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMedia `json:"byMedia,omitempty"` // The inactive count data, indexed by media type (RJ45 or SFP)
+	Total   *int                                                                           `json:"total,omitempty"`   // The total number of inactive ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMedia struct {
+	Rj45 *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMediaRj45 `json:"rj45,omitempty"` // The count data for inactive RJ45 ports
+	Sfp  *ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMediaSfp  `json:"sfp,omitempty"`  // The count data for inactive SFP ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMediaRj45 struct {
+	Total *int `json:"total,omitempty"` // The total number of inactive RJ45 ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsOverviewCountsByStatusInactiveByMediaSfp struct {
+	Total *int `json:"total,omitempty"` // The total number of inactive SFP ports
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch struct {
+	Items *[]ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItems `json:"items,omitempty"` // Switches
+	Meta  *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItems struct {
+	Mac     string                                                                `json:"mac,omitempty"`     // The MAC address of the switch.
+	Model   string                                                                `json:"model,omitempty"`   // The model of the switch.
+	Name    string                                                                `json:"name,omitempty"`    // The name of the switch.
+	Network *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsNetwork `json:"network,omitempty"` // Identifying information of the switch's network.
+	Ports   *[]ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPorts `json:"ports,omitempty"`   // The statuses of the ports on the switch.
+	Serial  string                                                                `json:"serial,omitempty"`  // The serial number of the switch.
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // The ID of the network.
+	Name string `json:"name,omitempty"` // The name of the network.
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPorts struct {
+	Duplex       string                                                                          `json:"duplex,omitempty"`       // The current duplex of a connected port.
+	Enabled      *bool                                                                           `json:"enabled,omitempty"`      // Whether the port is configured to be enabled.
+	Errors       []string                                                                        `json:"errors,omitempty"`       // All errors present on the port.
+	IsUplink     *bool                                                                           `json:"isUplink,omitempty"`     // Whether the port is the switch's uplink.
+	Poe          *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsPoe          `json:"poe,omitempty"`          // PoE status of the port.
+	PortID       string                                                                          `json:"portId,omitempty"`       // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
+	SecurePort   *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsSecurePort   `json:"securePort,omitempty"`   // The Secure Port status of the port.
+	SpanningTree *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsSpanningTree `json:"spanningTree,omitempty"` // The Spanning Tree Protocol (STP) information of the connected device.
+	Speed        string                                                                          `json:"speed,omitempty"`        // The current data transfer rate which the port is operating at.
+	Status       string                                                                          `json:"status,omitempty"`       // The current connection status of the port.
+	Warnings     []string                                                                        `json:"warnings,omitempty"`     // All warnings present on the port.
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsPoe struct {
+	IsAllocated *bool `json:"isAllocated,omitempty"` // Whether the port is drawing power
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsSecurePort struct {
+	Active               *bool  `json:"active,omitempty"`               // Whether Secure Port is currently active for this port.
+	AuthenticationStatus string `json:"authenticationStatus,omitempty"` // The current Secure Port status.
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchItemsPortsSpanningTree struct {
+	Statuses []string `json:"statuses,omitempty"` // The current Spanning Tree Protocol statuses of the port.
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMeta struct {
+	Counts *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMetaCounts struct {
+	Items *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitchMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice struct {
+	Items *[]ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItems `json:"items,omitempty"` // Switches
+	Meta  *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItems struct {
+	Mac     string                                                                         `json:"mac,omitempty"`     // The MAC address of the switch.
+	Model   string                                                                         `json:"model,omitempty"`   // The model of the switch.
+	Name    string                                                                         `json:"name,omitempty"`    // The name of the switch.
+	Network *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsNetwork `json:"network,omitempty"` // Identifying information of the switch's network.
+	Ports   *[]ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPorts `json:"ports,omitempty"`   // Ports belonging to the switch with LLDP/CDP discovery info.
+	Serial  string                                                                         `json:"serial,omitempty"`  // The serial number of the switch.
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // The ID of the network.
+	Name string `json:"name,omitempty"` // The name of the network.
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPorts struct {
+	Cdp           *[]ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPortsCdp  `json:"cdp,omitempty"`           // The Cisco Discovery Protocol (CDP) information of the connected device.
+	LastUpdatedAt string                                                                             `json:"lastUpdatedAt,omitempty"` // Timestamp for most recent discovery info on this port.
+	Lldp          *[]ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPortsLldp `json:"lldp,omitempty"`          // The Link Layer Discovery Protocol (LLDP) information of the connected device.
+	PortID        string                                                                             `json:"portId,omitempty"`        // The string identifier of this port on the switch. This is commonly just the port number but may contain additional identifying information such as the slot and module-type if the port is located on a port module.
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPortsCdp struct {
+	Name  string `json:"name,omitempty"`  // CDP RFC/official name of TLV
+	Value string `json:"value,omitempty"` // Value of the named TLV.
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceItemsPortsLldp struct {
+	Name  string `json:"name,omitempty"`  // LLDP RFC/official name of TLV
+	Value string `json:"value,omitempty"` // Value of the named TLV.
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMeta struct {
+	Counts *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMetaCounts struct {
+	Items *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
 type RequestSwitchCycleDeviceSwitchPorts struct {
 	Ports []string `json:"ports,omitempty"` // List of switch ports
@@ -1681,6 +2176,7 @@ type RequestSwitchUpdateDeviceSwitchPort struct {
 	AdaptivePolicyGroupID   string                                      `json:"adaptivePolicyGroupId,omitempty"`   // The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
 	AllowedVLANs            string                                      `json:"allowedVlans,omitempty"`            // The VLANs allowed on the switch port. Only applicable to trunk ports.
 	DaiTrusted              *bool                                       `json:"daiTrusted,omitempty"`              // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                  *RequestSwitchUpdateDeviceSwitchPortDot3Az  `json:"dot3az,omitempty"`                  // dot3az settings for the port
 	Enabled                 *bool                                       `json:"enabled,omitempty"`                 // The status of the switch port.
 	FlexibleStackingEnabled *bool                                       `json:"flexibleStackingEnabled,omitempty"` // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
 	IsolationEnabled        *bool                                       `json:"isolationEnabled,omitempty"`        // The isolation status of the switch port.
@@ -1697,10 +2193,13 @@ type RequestSwitchUpdateDeviceSwitchPort struct {
 	StormControlEnabled     *bool                                       `json:"stormControlEnabled,omitempty"`     // The storm control status of the switch port.
 	StpGuard                string                                      `json:"stpGuard,omitempty"`                // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
 	Tags                    []string                                    `json:"tags,omitempty"`                    // The list of tags of the switch port.
-	Type                    string                                      `json:"type,omitempty"`                    // The type of the switch port ('trunk' or 'access').
+	Type                    string                                      `json:"type,omitempty"`                    // The type of the switch port ('trunk', 'access' or 'stack').
 	Udld                    string                                      `json:"udld,omitempty"`                    // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
 	VLAN                    *int                                        `json:"vlan,omitempty"`                    // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN               *int                                        `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch port. Only applicable to access ports.
+}
+type RequestSwitchUpdateDeviceSwitchPortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch port.
 }
 type RequestSwitchUpdateDeviceSwitchPortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -1714,7 +2213,6 @@ type RequestSwitchCreateDeviceSwitchRoutingInterface struct {
 	MulticastRouting string                                                       `json:"multicastRouting,omitempty"` // Enable multicast support if, multicast routing between VLANs is required. Options are:         'disabled', 'enabled' or 'IGMP snooping querier'. Default is 'disabled'.
 	Name             string                                                       `json:"name,omitempty"`             // A friendly name or description for the interface or VLAN.
 	OspfSettings     *RequestSwitchCreateDeviceSwitchRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // The OSPF routing settings of the interface.
-	OspfV3           *RequestSwitchCreateDeviceSwitchRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // The OSPFv3 routing settings of the interface.
 	Subnet           string                                                       `json:"subnet,omitempty"`           // The network that this routed interface is on, in CIDR notation (ex. 10.1.1.0/24).
 	VLANID           *int                                                         `json:"vlanId,omitempty"`           // The VLAN this routed interface is on. VLAN must be between 1 and 4094.
 }
@@ -1729,11 +2227,6 @@ type RequestSwitchCreateDeviceSwitchRoutingInterfaceOspfSettings struct {
 	Cost             *int   `json:"cost,omitempty"`             // The path cost for this interface. Defaults to 1, but can be increased up to 65535           to give lower priority.
 	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // When enabled, OSPF will not run on the interface, but the subnet will still be advertised.
 }
-type RequestSwitchCreateDeviceSwitchRoutingInterfaceOspfV3 struct {
-	Area             string `json:"area,omitempty"`             // The OSPFv3 area to which this interface should belong. Can be either 'disabled' or the identifier of an           existing OSPFv3 area. Defaults to 'disabled'.
-	Cost             *int   `json:"cost,omitempty"`             // The path cost for this interface. Defaults to 1, but can be increased up to 65535           to give lower priority.
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // When enabled, OSPFv3 will not run on the interface, but the subnet will still be advertised.
-}
 type RequestSwitchUpdateDeviceSwitchRoutingInterface struct {
 	DefaultGateway   string                                                       `json:"defaultGateway,omitempty"`   // The next hop for any traffic that isn't going to a directly connected subnet or over a static route.         This IP address must exist in a subnet with a routed interface. Required if this is the first IPv4 interface.
 	InterfaceIP      string                                                       `json:"interfaceIp,omitempty"`      // The IP address this switch will use for layer 3 routing on this VLAN or subnet. This cannot be the same         as the switch's management IP.
@@ -1741,7 +2234,6 @@ type RequestSwitchUpdateDeviceSwitchRoutingInterface struct {
 	MulticastRouting string                                                       `json:"multicastRouting,omitempty"` // Enable multicast support if, multicast routing between VLANs is required. Options are:         'disabled', 'enabled' or 'IGMP snooping querier'. Default is 'disabled'.
 	Name             string                                                       `json:"name,omitempty"`             // A friendly name or description for the interface or VLAN.
 	OspfSettings     *RequestSwitchUpdateDeviceSwitchRoutingInterfaceOspfSettings `json:"ospfSettings,omitempty"`     // The OSPF routing settings of the interface.
-	OspfV3           *RequestSwitchUpdateDeviceSwitchRoutingInterfaceOspfV3       `json:"ospfV3,omitempty"`           // The OSPFv3 routing settings of the interface.
 	Subnet           string                                                       `json:"subnet,omitempty"`           // The network that this routed interface is on, in CIDR notation (ex. 10.1.1.0/24).
 	VLANID           *int                                                         `json:"vlanId,omitempty"`           // The VLAN this routed interface is on. VLAN must be between 1 and 4094.
 }
@@ -1755,11 +2247,6 @@ type RequestSwitchUpdateDeviceSwitchRoutingInterfaceOspfSettings struct {
 	Area             string `json:"area,omitempty"`             // The OSPF area to which this interface should belong. Can be either 'disabled' or the identifier of an           existing OSPF area. Defaults to 'disabled'.
 	Cost             *int   `json:"cost,omitempty"`             // The path cost for this interface. Defaults to 1, but can be increased up to 65535           to give lower priority.
 	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // When enabled, OSPF will not run on the interface, but the subnet will still be advertised.
-}
-type RequestSwitchUpdateDeviceSwitchRoutingInterfaceOspfV3 struct {
-	Area             string `json:"area,omitempty"`             // The OSPFv3 area to which this interface should belong. Can be either 'disabled' or the identifier of an           existing OSPFv3 area. Defaults to 'disabled'.
-	Cost             *int   `json:"cost,omitempty"`             // The path cost for this interface. Defaults to 1, but can be increased up to 65535           to give lower priority.
-	IsPassiveEnabled *bool  `json:"isPassiveEnabled,omitempty"` // When enabled, OSPFv3 will not run on the interface, but the subnet will still be advertised.
 }
 type RequestSwitchUpdateDeviceSwitchRoutingInterfaceDhcp struct {
 	BootFileName         string                                                                   `json:"bootFileName,omitempty"`         // The PXE boot server filename for the DHCP server running on the switch interface
@@ -1798,6 +2285,7 @@ type RequestSwitchCreateDeviceSwitchRoutingStaticRoute struct {
 }
 type RequestSwitchUpdateDeviceSwitchRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static route via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // Name or description for layer 3 static route
 	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // IP address of the next hop device to which the device sends its traffic for the subnet
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static route over OSPF routes
@@ -1844,9 +2332,14 @@ type RequestSwitchCreateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type RequestSwitchCreateNetworkSwitchAccessPolicyRadius struct {
+	Cache                    *RequestSwitchCreateNetworkSwitchAccessPolicyRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *RequestSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                            `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                            `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type RequestSwitchCreateNetworkSwitchAccessPolicyRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type RequestSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -1854,14 +2347,16 @@ type RequestSwitchCreateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type RequestSwitchCreateNetworkSwitchAccessPolicyRadiusAccountingServers struct {
-	Host   string `json:"host,omitempty"`   // Public IP address of the RADIUS accounting server
-	Port   *int   `json:"port,omitempty"`   // UDP port that the RADIUS Accounting server listens on for access requests
-	Secret string `json:"secret,omitempty"` // RADIUS client shared secret
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. If this field is provided, the host, port and secret field will be ignored
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	Secret                     string `json:"secret,omitempty"`                     // RADIUS client shared secret
 }
 type RequestSwitchCreateNetworkSwitchAccessPolicyRadiusServers struct {
-	Host   string `json:"host,omitempty"`   // Public IP address of the RADIUS server
-	Port   *int   `json:"port,omitempty"`   // UDP port that the RADIUS server listens on for access requests
-	Secret string `json:"secret,omitempty"` // RADIUS client shared secret
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. If this field is provided, the host, port and secret field will be ignored
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	Secret                     string `json:"secret,omitempty"`                     // RADIUS client shared secret
 }
 type RequestSwitchUpdateNetworkSwitchAccessPolicy struct {
 	AccessPolicyType               string                                                                 `json:"accessPolicyType,omitempty"`               // Access Type of the policy. Automatically 'Hybrid authentication' when hostMode is 'Multi-Domain'.
@@ -1886,9 +2381,14 @@ type RequestSwitchUpdateNetworkSwitchAccessPolicyDot1X struct {
 	ControlDirection string `json:"controlDirection,omitempty"` // Supports either 'both' or 'inbound'. Set to 'inbound' to allow unauthorized egress on the switchport. Set to 'both' to control both traffic directions with authorization. Defaults to 'both'
 }
 type RequestSwitchUpdateNetworkSwitchAccessPolicyRadius struct {
+	Cache                    *RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusCache        `json:"cache,omitempty"`                    // Object for RADIUS Cache Settings
 	CriticalAuth             *RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth `json:"criticalAuth,omitempty"`             // Critical auth settings for when authentication is rejected by the RADIUS server
 	FailedAuthVLANID         *int                                                            `json:"failedAuthVlanId,omitempty"`         // VLAN that clients will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 	ReAuthenticationInterval *int                                                            `json:"reAuthenticationInterval,omitempty"` // Re-authentication period in seconds. Will be null if hostMode is Multi-Auth
+}
+type RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusCache struct {
+	Enabled *bool `json:"enabled,omitempty"` // Enable to cache authorization and authentication responses on the RADIUS server
+	Timeout *int  `json:"timeout,omitempty"` // If RADIUS caching is enabled, this value dictates how long the cache will remain in the RADIUS server, in hours, to allow network access without authentication
 }
 type RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	DataVLANID        *int  `json:"dataVlanId,omitempty"`        // VLAN that clients who use data will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
@@ -1896,14 +2396,18 @@ type RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusCriticalAuth struct {
 	VoiceVLANID       *int  `json:"voiceVlanId,omitempty"`       // VLAN that clients who use voice will be placed on when RADIUS authentication fails. Will be null if hostMode is Multi-Auth
 }
 type RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusAccountingServers struct {
-	Host   string `json:"host,omitempty"`   // Public IP address of the RADIUS accounting server
-	Port   *int   `json:"port,omitempty"`   // UDP port that the RADIUS Accounting server listens on for access requests
-	Secret string `json:"secret,omitempty"` // RADIUS client shared secret
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS accounting server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. If this field is provided, the host, port and secret field will be ignored
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS Accounting server listens on for access requests
+	Secret                     string `json:"secret,omitempty"`                     // RADIUS client shared secret
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS accounting server. When provided, the existing RADIUS server will be updated instead of creating a new one
 }
 type RequestSwitchUpdateNetworkSwitchAccessPolicyRadiusServers struct {
-	Host   string `json:"host,omitempty"`   // Public IP address of the RADIUS server
-	Port   *int   `json:"port,omitempty"`   // UDP port that the RADIUS server listens on for access requests
-	Secret string `json:"secret,omitempty"` // RADIUS client shared secret
+	Host                       string `json:"host,omitempty"`                       // Public IP address of the RADIUS server
+	OrganizationRadiusServerID string `json:"organizationRadiusServerId,omitempty"` // Organization wide RADIUS server ID. If this field is provided, the host, port and secret field will be ignored
+	Port                       *int   `json:"port,omitempty"`                       // UDP port that the RADIUS server listens on for access requests
+	Secret                     string `json:"secret,omitempty"`                     // RADIUS client shared secret
+	ServerID                   string `json:"serverId,omitempty"`                   // Unique ID of the RADIUS server. When provided, the existing RADIUS server will be updated instead of creating a new one
 }
 type RequestSwitchUpdateNetworkSwitchAlternateManagementInterface struct {
 	Enabled   *bool                                                                   `json:"enabled,omitempty"`   // Boolean value to enable or disable AMI configuration. If enabled, VLAN and protocols must be set
@@ -2087,24 +2591,24 @@ type RequestSwitchUpdateNetworkSwitchPortSchedulePortScheduleWednesday struct {
 	To     string `json:"to,omitempty"`     // The time, from '00:00' to '24:00'. Must be greater than the time specified in 'from'. Defaults to '24:00'. Only 30 minute increments are allowed.
 }
 type RequestSwitchCreateNetworkSwitchQosRule struct {
-	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag. Set this to -1 to trust incoming DSCP. Default value is 0
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag for the incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
 	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
-	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
-	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY"
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP.
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Default value is "ANY"
 	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
-	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP.
 	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
 }
 type RequestSwitchUpdateNetworkSwitchQosRulesOrder struct {
 	RuleIDs []string `json:"ruleIds,omitempty"` // A list of quality of service rule IDs arranged in order in which they should be processed by the switch.
 }
 type RequestSwitchUpdateNetworkSwitchQosRule struct {
-	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag that should be assigned to incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0.
+	Dscp         *int   `json:"dscp,omitempty"`         // DSCP tag that should be assigned to incoming packet. Set this to -1 to trust incoming DSCP. Default value is 0
 	DstPort      *int   `json:"dstPort,omitempty"`      // The destination port of the incoming packet. Applicable only if protocol is TCP or UDP.
-	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
-	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Can be one of "ANY", "TCP" or "UDP". Default value is "ANY".
+	DstPortRange string `json:"dstPortRange,omitempty"` // The destination port range of the incoming packet. Applicable only if protocol is set to TCP or UDP.
+	Protocol     string `json:"protocol,omitempty"`     // The protocol of the incoming packet. Default value is "ANY"
 	SrcPort      *int   `json:"srcPort,omitempty"`      // The source port of the incoming packet. Applicable only if protocol is TCP or UDP.
-	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP. Example: 70-80
+	SrcPortRange string `json:"srcPortRange,omitempty"` // The source port range of the incoming packet. Applicable only if protocol is set to TCP or UDP.
 	VLAN         *int   `json:"vlan,omitempty"`         // The VLAN of the incoming packet. A null value will match any VLAN.
 }
 type RequestSwitchUpdateNetworkSwitchRoutingMulticast struct {
@@ -2265,15 +2769,17 @@ type RequestSwitchCreateNetworkSwitchStackRoutingStaticRoute struct {
 }
 type RequestSwitchUpdateNetworkSwitchStackRoutingStaticRoute struct {
 	AdvertiseViaOspfEnabled     *bool  `json:"advertiseViaOspfEnabled,omitempty"`     // Option to advertise static route via OSPF
+	ManagementNextHop           string `json:"managementNextHop,omitempty"`           // Optional fallback IP address for management traffic
 	Name                        string `json:"name,omitempty"`                        // Name or description for layer 3 static route
 	NextHopIP                   string `json:"nextHopIp,omitempty"`                   // IP address of the next hop device to which the device sends its traffic for the subnet
 	PreferOverOspfRoutesEnabled *bool  `json:"preferOverOspfRoutesEnabled,omitempty"` // Option to prefer static route over OSPF routes
 	Subnet                      string `json:"subnet,omitempty"`                      // The subnet which is routed via this static route and should be specified in CIDR notation (ex. 1.2.3.0/24)
 }
 type RequestSwitchUpdateNetworkSwitchStormControl struct {
-	BroadcastThreshold      *int `json:"broadcastThreshold,omitempty"`      // Percentage (1 to 99) of total available port bandwidth for broadcast traffic type. Default value 100 percent rate is to clear the configuration.
-	MulticastThreshold      *int `json:"multicastThreshold,omitempty"`      // Percentage (1 to 99) of total available port bandwidth for multicast traffic type. Default value 100 percent rate is to clear the configuration.
-	UnknownUnicastThreshold *int `json:"unknownUnicastThreshold,omitempty"` // Percentage (1 to 99) of total available port bandwidth for unknown unicast (dlf-destination lookup failure) traffic type. Default value 100 percent rate is to clear the configuration.
+	BroadcastThreshold                   *int     `json:"broadcastThreshold,omitempty"`                   // Percentage (1 to 99) of total available port bandwidth for broadcast traffic type. Default value 100 percent rate is to clear the configuration.
+	MulticastThreshold                   *int     `json:"multicastThreshold,omitempty"`                   // Percentage (1 to 99) of total available port bandwidth for multicast traffic type. Default value 100 percent rate is to clear the configuration.
+	TreatTheseTrafficTypesAsOneThreshold []string `json:"treatTheseTrafficTypesAsOneThreshold,omitempty"` // Grouped traffic types
+	UnknownUnicastThreshold              *int     `json:"unknownUnicastThreshold,omitempty"`              // Percentage (1 to 99) of total available port bandwidth for unknown unicast (dlf-destination lookup failure) traffic type. Default value 100 percent rate is to clear the configuration.
 }
 type RequestSwitchUpdateNetworkSwitchStp struct {
 	RstpEnabled       *bool                                                   `json:"rstpEnabled,omitempty"`       // The spanning tree protocol status in network
@@ -2290,6 +2796,7 @@ type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePort struct {
 	AccessPolicyType        string                                                                 `json:"accessPolicyType,omitempty"`        // The type of the access policy of the switch template port. Only applicable to access ports. Can be one of 'Open', 'Custom access policy', 'MAC allow list' or 'Sticky MAC allow list'.
 	AllowedVLANs            string                                                                 `json:"allowedVlans,omitempty"`            // The VLANs allowed on the switch template port. Only applicable to trunk ports.
 	DaiTrusted              *bool                                                                  `json:"daiTrusted,omitempty"`              // If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.
+	Dot3Az                  *RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePortDot3Az  `json:"dot3az,omitempty"`                  // dot3az settings for the port
 	Enabled                 *bool                                                                  `json:"enabled,omitempty"`                 // The status of the switch template port.
 	FlexibleStackingEnabled *bool                                                                  `json:"flexibleStackingEnabled,omitempty"` // For supported switches (e.g. MS420/MS425), whether or not the port has flexible stacking enabled.
 	IsolationEnabled        *bool                                                                  `json:"isolationEnabled,omitempty"`        // The isolation status of the switch template port.
@@ -2305,10 +2812,13 @@ type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePort struct {
 	StormControlEnabled     *bool                                                                  `json:"stormControlEnabled,omitempty"`     // The storm control status of the switch template port.
 	StpGuard                string                                                                 `json:"stpGuard,omitempty"`                // The state of the STP guard ('disabled', 'root guard', 'bpdu guard' or 'loop guard').
 	Tags                    []string                                                               `json:"tags,omitempty"`                    // The list of tags of the switch template port.
-	Type                    string                                                                 `json:"type,omitempty"`                    // The type of the switch template port ('trunk' or 'access').
+	Type                    string                                                                 `json:"type,omitempty"`                    // The type of the switch template port ('trunk', 'access' or 'stack').
 	Udld                    string                                                                 `json:"udld,omitempty"`                    // The action to take when Unidirectional Link is detected (Alert only, Enforce). Default configuration is Alert only.
 	VLAN                    *int                                                                   `json:"vlan,omitempty"`                    // The VLAN of the switch template port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 	VoiceVLAN               *int                                                                   `json:"voiceVlan,omitempty"`               // The voice VLAN of the switch template port. Only applicable to access ports.
+}
+type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePortDot3Az struct {
+	Enabled *bool `json:"enabled,omitempty"` // The Energy Efficient Ethernet status of the switch template port.
 }
 type RequestSwitchUpdateOrganizationConfigTemplateSwitchProfilePortProfile struct {
 	Enabled *bool  `json:"enabled,omitempty"` // When enabled, override this port's configuration with a port profile.
@@ -3837,6 +4347,150 @@ func (s *SwitchService) GetOrganizationSwitchPortsBySwitch(organizationID string
 
 }
 
+//GetOrganizationSwitchPortsClientsOverviewByDevice List the number of clients for all switchports with at least one online client in an organization.
+/* List the number of clients for all switchports with at least one online client in an organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *SwitchService) GetOrganizationSwitchPortsClientsOverviewByDevice(organizationID string, getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams *GetOrganizationSwitchPortsClientsOverviewByDeviceQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/switch/ports/clients/overview/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSwitchPortsClientsOverviewByDevice")
+	}
+
+	result := response.Result().(*ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationSwitchPortsOverview Returns the counts of all active ports for the requested timespan, grouped by speed
+/* Returns the counts of all active ports for the requested timespan, grouped by speed. An active port is a port that at any point during the timeframe is observed to be connected to a responsive device and isn't configured to be disabled. For a port that is observed at multiple speeds during the timeframe, it will be counted at the highest speed observed. The number of inactive ports, and the total number of ports are also provided. Only ports on switches online during the timeframe will be represented and a port is only guaranteed to be present if its switch was online for at least 6 hours of the timeframe.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSwitchPortsOverviewQueryParams Filtering parameter
+
+
+*/
+func (s *SwitchService) GetOrganizationSwitchPortsOverview(organizationID string, getOrganizationSwitchPortsOverviewQueryParams *GetOrganizationSwitchPortsOverviewQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsOverview, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/switch/ports/overview"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSwitchPortsOverviewQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSwitchGetOrganizationSwitchPortsOverview{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSwitchPortsOverview")
+	}
+
+	result := response.Result().(*ResponseSwitchGetOrganizationSwitchPortsOverview)
+	return result, response, err
+
+}
+
+//GetOrganizationSwitchPortsStatusesBySwitch List the switchports in an organization
+/* List the switchports in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSwitchPortsStatusesBySwitchQueryParams Filtering parameter
+
+
+*/
+func (s *SwitchService) GetOrganizationSwitchPortsStatusesBySwitch(organizationID string, getOrganizationSwitchPortsStatusesBySwitchQueryParams *GetOrganizationSwitchPortsStatusesBySwitchQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/switch/ports/statuses/bySwitch"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSwitchPortsStatusesBySwitchQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSwitchPortsStatusesBySwitch")
+	}
+
+	result := response.Result().(*ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch)
+	return result, response, err
+
+}
+
+//GetOrganizationSwitchPortsTopologyDiscoveryByDevice List most recently seen LLDP/CDP discovery and topology information per switch port in an organization.
+/* List most recently seen LLDP/CDP discovery and topology information per switch port in an organization.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *SwitchService) GetOrganizationSwitchPortsTopologyDiscoveryByDevice(organizationID string, getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams *GetOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/switch/ports/topology/discovery/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationSwitchPortsTopologyDiscoveryByDevice")
+	}
+
+	result := response.Result().(*ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice)
+	return result, response, err
+
+}
+
 //CycleDeviceSwitchPorts Cycle a set of switch ports
 /* Cycle a set of switch ports
 
@@ -4041,6 +4695,7 @@ func (s *SwitchService) CreateNetworkSwitchLinkAggregation(networkID string, req
 	if response.IsError() {
 		return nil, response, fmt.Errorf("error with operation CreateNetworkSwitchLinkAggregation")
 	}
+
 	result := response.Result().(*ResponseSwitchCreateNetworkSwitchLinkAggregation)
 	return result, response, err
 
@@ -4342,7 +4997,7 @@ func (s *SwitchService) CreateNetworkSwitchStackRoutingStaticRoute(networkID str
 
 */
 
-func (s *SwitchService) CloneOrganizationSwitchDevices(organizationID string, requestSwitchCloneOrganizationSwitchDevices *RequestSwitchCloneOrganizationSwitchDevices) (*resty.Response, error) {
+func (s *SwitchService) CloneOrganizationSwitchDevices(organizationID string, requestSwitchCloneOrganizationSwitchDevices *RequestSwitchCloneOrganizationSwitchDevices) (*ResponseSwitchCloneOrganizationSwitchDevices, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/devices/clone"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -4351,20 +5006,21 @@ func (s *SwitchService) CloneOrganizationSwitchDevices(organizationID string, re
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchCloneOrganizationSwitchDevices).
-		// SetResult(&ResponseSwitchCloneOrganizationSwitchDevices{}).
+		SetResult(&ResponseSwitchCloneOrganizationSwitchDevices{}).
 		SetError(&Error).
 		Post(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation CloneOrganizationSwitchDevices")
+		return nil, response, fmt.Errorf("error with operation CloneOrganizationSwitchDevices")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchCloneOrganizationSwitchDevices)
+	return result, response, err
 
 }
 
@@ -4607,7 +5263,7 @@ func (s *SwitchService) UpdateNetworkSwitchAccessPolicy(networkID string, access
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchAlternateManagementInterface(networkID string, requestSwitchUpdateNetworkSwitchAlternateManagementInterface *RequestSwitchUpdateNetworkSwitchAlternateManagementInterface) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchAlternateManagementInterface(networkID string, requestSwitchUpdateNetworkSwitchAlternateManagementInterface *RequestSwitchUpdateNetworkSwitchAlternateManagementInterface) (*ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/alternateManagementInterface"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4616,19 +5272,21 @@ func (s *SwitchService) UpdateNetworkSwitchAlternateManagementInterface(networkI
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchAlternateManagementInterface).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchAlternateManagementInterface")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchAlternateManagementInterface")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchAlternateManagementInterface)
+	return result, response, err
 
 }
 
@@ -4703,7 +5361,7 @@ func (s *SwitchService) UpdateNetworkSwitchDhcpServerPolicyArpInspectionTrustedS
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchDscpToCosMappings(networkID string, requestSwitchUpdateNetworkSwitchDscpToCosMappings *RequestSwitchUpdateNetworkSwitchDscpToCosMappings) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchDscpToCosMappings(networkID string, requestSwitchUpdateNetworkSwitchDscpToCosMappings *RequestSwitchUpdateNetworkSwitchDscpToCosMappings) (*ResponseSwitchUpdateNetworkSwitchDscpToCosMappings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dscpToCosMappings"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4712,19 +5370,21 @@ func (s *SwitchService) UpdateNetworkSwitchDscpToCosMappings(networkID string, r
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchDscpToCosMappings).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchDscpToCosMappings{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchDscpToCosMappings")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchDscpToCosMappings")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchDscpToCosMappings)
+	return result, response, err
 
 }
 
@@ -4734,7 +5394,7 @@ func (s *SwitchService) UpdateNetworkSwitchDscpToCosMappings(networkID string, r
 @param networkID networkId path parameter. Network ID
 @param linkAggregationID linkAggregationId path parameter. Link aggregation ID
 */
-func (s *SwitchService) UpdateNetworkSwitchLinkAggregation(networkID string, linkAggregationID string, requestSwitchUpdateNetworkSwitchLinkAggregation *RequestSwitchUpdateNetworkSwitchLinkAggregation) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchLinkAggregation(networkID string, linkAggregationID string, requestSwitchUpdateNetworkSwitchLinkAggregation *RequestSwitchUpdateNetworkSwitchLinkAggregation) (*ResponseSwitchUpdateNetworkSwitchLinkAggregation, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/linkAggregations/{linkAggregationId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4744,19 +5404,21 @@ func (s *SwitchService) UpdateNetworkSwitchLinkAggregation(networkID string, lin
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchLinkAggregation).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchLinkAggregation{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchLinkAggregation")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchLinkAggregation")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchLinkAggregation)
+	return result, response, err
 
 }
 
@@ -4765,7 +5427,7 @@ func (s *SwitchService) UpdateNetworkSwitchLinkAggregation(networkID string, lin
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchMtu(networkID string, requestSwitchUpdateNetworkSwitchMtu *RequestSwitchUpdateNetworkSwitchMtu) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchMtu(networkID string, requestSwitchUpdateNetworkSwitchMtu *RequestSwitchUpdateNetworkSwitchMtu) (*ResponseSwitchUpdateNetworkSwitchMtu, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/mtu"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4774,19 +5436,21 @@ func (s *SwitchService) UpdateNetworkSwitchMtu(networkID string, requestSwitchUp
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchMtu).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchMtu{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchMtu")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchMtu")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchMtu)
+	return result, response, err
 
 }
 
@@ -4829,7 +5493,7 @@ func (s *SwitchService) UpdateNetworkSwitchPortSchedule(networkID string, portSc
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchQosRulesOrder(networkID string, requestSwitchUpdateNetworkSwitchQosRulesOrder *RequestSwitchUpdateNetworkSwitchQosRulesOrder) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchQosRulesOrder(networkID string, requestSwitchUpdateNetworkSwitchQosRulesOrder *RequestSwitchUpdateNetworkSwitchQosRulesOrder) (*ResponseSwitchUpdateNetworkSwitchQosRulesOrder, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/qosRules/order"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4838,19 +5502,21 @@ func (s *SwitchService) UpdateNetworkSwitchQosRulesOrder(networkID string, reque
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchQosRulesOrder).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchQosRulesOrder{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchQosRulesOrder")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchQosRulesOrder")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchQosRulesOrder)
+	return result, response, err
 
 }
 
@@ -4860,7 +5526,7 @@ func (s *SwitchService) UpdateNetworkSwitchQosRulesOrder(networkID string, reque
 @param networkID networkId path parameter. Network ID
 @param qosRuleID qosRuleId path parameter. Qos rule ID
 */
-func (s *SwitchService) UpdateNetworkSwitchQosRule(networkID string, qosRuleID string, requestSwitchUpdateNetworkSwitchQosRule *RequestSwitchUpdateNetworkSwitchQosRule) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchQosRule(networkID string, qosRuleID string, requestSwitchUpdateNetworkSwitchQosRule *RequestSwitchUpdateNetworkSwitchQosRule) (*ResponseSwitchUpdateNetworkSwitchQosRule, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/qosRules/{qosRuleId}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4870,19 +5536,21 @@ func (s *SwitchService) UpdateNetworkSwitchQosRule(networkID string, qosRuleID s
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchQosRule).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchQosRule{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchQosRule")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchQosRule")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchQosRule)
+	return result, response, err
 
 }
 
@@ -4957,7 +5625,7 @@ func (s *SwitchService) UpdateNetworkSwitchRoutingMulticastRendezvousPoint(netwo
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchRoutingOspf(networkID string, requestSwitchUpdateNetworkSwitchRoutingOspf *RequestSwitchUpdateNetworkSwitchRoutingOspf) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchRoutingOspf(networkID string, requestSwitchUpdateNetworkSwitchRoutingOspf *RequestSwitchUpdateNetworkSwitchRoutingOspf) (*ResponseSwitchUpdateNetworkSwitchRoutingOspf, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/ospf"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -4966,19 +5634,21 @@ func (s *SwitchService) UpdateNetworkSwitchRoutingOspf(networkID string, request
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchRoutingOspf).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchRoutingOspf{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingOspf")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchRoutingOspf")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchRoutingOspf)
+	return result, response, err
 
 }
 
@@ -5159,7 +5829,7 @@ func (s *SwitchService) UpdateNetworkSwitchStormControl(networkID string, reques
 
 @param networkID networkId path parameter. Network ID
 */
-func (s *SwitchService) UpdateNetworkSwitchStp(networkID string, requestSwitchUpdateNetworkSwitchStp *RequestSwitchUpdateNetworkSwitchStp) (*resty.Response, error) {
+func (s *SwitchService) UpdateNetworkSwitchStp(networkID string, requestSwitchUpdateNetworkSwitchStp *RequestSwitchUpdateNetworkSwitchStp) (*ResponseSwitchUpdateNetworkSwitchStp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stp"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -5168,19 +5838,21 @@ func (s *SwitchService) UpdateNetworkSwitchStp(networkID string, requestSwitchUp
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestSwitchUpdateNetworkSwitchStp).
+		SetResult(&ResponseSwitchUpdateNetworkSwitchStp{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkSwitchStp")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkSwitchStp")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseSwitchUpdateNetworkSwitchStp)
+	return result, response, err
 
 }
 

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -89,13 +89,14 @@ type GetNetworkWirelessClientConnectivityEventsQueryParams struct {
 	PerPage            int      `url:"perPage,omitempty"`              //The number of entries per page returned. Acceptable range is 3 - 1000.
 	StartingAfter      string   `url:"startingAfter,omitempty"`        //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore       string   `url:"endingBefore,omitempty"`         //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	SortOrder          string   `url:"sortOrder,omitempty"`            //Sorted order of entries. Order options are 'ascending' and 'descending'. Default is 'ascending'.
 	T0                 string   `url:"t0,omitempty"`                   //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
 	T1                 string   `url:"t1,omitempty"`                   //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
 	Timespan           float64  `url:"timespan,omitempty"`             //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 1 day.
 	Types              []string `url:"types[],omitempty"`              //A list of event types to include. If not specified, events of all types will be returned. Valid types are 'assoc', 'disassoc', 'auth', 'deauth', 'dns', 'dhcp', 'roam', 'connection' and/or 'sticky'.
+	Band               string   `url:"band,omitempty"`                 //Filter results by band. Valid bands are '2.4', '5' or '6'.
+	SSIDNumber         int      `url:"ssidNumber,omitempty"`           //Filter results by SSID. If not specified, events for all SSIDs will be returned.
 	IncludedSeverities []string `url:"includedSeverities[],omitempty"` //A list of severities to include. If not specified, events of all severities will be returned. Valid severities are 'good', 'info', 'warn' and/or 'bad'.
-	Band               string   `url:"band,omitempty"`                 //Filter results by band (either '2.4', '5', '6').
-	SSIDNumber         int      `url:"ssidNumber,omitempty"`           //An SSID number to include. If not specified, events for all SSIDs will be returned.
 	DeviceSerial       string   `url:"deviceSerial,omitempty"`         //Filter results by an AP's serial number.
 }
 type GetNetworkWirelessClientLatencyHistoryQueryParams struct {
@@ -220,12 +221,62 @@ type GetNetworkWirelessUsageHistoryQueryParams struct {
 	Band           string  `url:"band,omitempty"`           //Filter results by band (either '2.4', '5' or '6').
 	SSID           int     `url:"ssid,omitempty"`           //Filter results by SSID number.
 }
-
+type GetOrganizationWirelessAirMarshalRulesQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //(optional) The set of network IDs to include.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessAirMarshalSettingsByNetworkQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //The network IDs to include in the result set.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessClientsOverviewByDeviceQueryParams struct {
+	NetworkIDs              []string `url:"networkIds[],omitempty"`              //Optional parameter to filter access points client counts by network ID. This filter uses multiple exact matches.
+	Serials                 []string `url:"serials[],omitempty"`                 //Optional parameter to filter access points client counts by its serial numbers. This filter uses multiple exact matches.
+	CampusGatewayClusterIDs []string `url:"campusGatewayClusterIds[],omitempty"` //Optional parameter to filter access points client counts by MCG cluster IDs. This filter uses multiple exact matches.
+	PerPage                 int      `url:"perPage,omitempty"`                   //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter           string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore            string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
 type GetOrganizationWirelessDevicesEthernetStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 100.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //A list of Meraki network IDs to filter results to contain only specified networks. E.g.: networkIds[]=N_12345678&networkIds[]=L_3456
+}
+type GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams struct {
+	NetworkIDs        []string `url:"networkIds[],omitempty"`        //Optional parameter to filter access points by network ID. This filter uses multiple exact matches.
+	Serials           []string `url:"serials[],omitempty"`           //Optional parameter to filter access points by its cloud ID. This filter uses multiple exact matches.
+	ControllerSerials []string `url:"controllerSerials[],omitempty"` //Optional parameter to filter access points by its wireless LAN controller cloud ID. This filter uses multiple exact matches.
+	PerPage           int      `url:"perPage,omitempty"`             //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 100.
+	StartingAfter     string   `url:"startingAfter,omitempty"`       //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore      string   `url:"endingBefore,omitempty"`        //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams struct {
+	PerPage       int      `url:"perPage,omitempty"`        //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"`  //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`   //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	NetworkIDs    []string `url:"networkIds[],omitempty"`   //Optional parameter to filter devices by network.
+	ProductTypes  []string `url:"productTypes[],omitempty"` //Optional parameter to filter devices by product type. Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor, wirelessController, and secureConnect.
+	Name          string   `url:"name,omitempty"`           //Optional parameter to filter RF profiles by device name. All returned devices will have a name that contains the search term or is an exact match.
+	Mac           string   `url:"mac,omitempty"`            //Optional parameter to filter RF profiles by device MAC address. All returned devices will have a MAC address that contains the search term or is an exact match.
+	Serial        string   `url:"serial,omitempty"`         //Optional parameter to filter RF profiles by device serial number. All returned devices will have a serial number that contains the search term or is an exact match.
+	Model         string   `url:"model,omitempty"`          //Optional parameter to filter RF profiles by device model. All returned devices will have a model that contains the search term or is an exact match.
+	Macs          []string `url:"macs[],omitempty"`         //Optional parameter to filter RF profiles by one or more device MAC addresses. All returned devices will have a MAC address that is an exact match.
+	Serials       []string `url:"serials[],omitempty"`      //Optional parameter to filter RF profiles by one or more device serial numbers. All returned devices will have a serial number that is an exact match.
+	Models        []string `url:"models[],omitempty"`       //Optional parameter to filter RF profiles by one or more device models. All returned devices will have a model that is an exact match.
+}
+type GetOrganizationWirelessSSIDsStatusesByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter the result set by the included set of network IDs
+	Serials       []string `url:"serials[],omitempty"`     //A list of serial numbers. The returned devices will be filtered to only include these serials.
+	Bssids        []string `url:"bssids[],omitempty"`      //A list of BSSIDs. The returned devices will be filtered to only include these BSSIDs.
+	HideDisabled  bool     `url:"hideDisabled,omitempty"`  //If true, the returned devices will not include disabled SSIDs. (default: true)
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 500. Default is 100.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
 
 type ResponseWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6 struct {
@@ -263,6 +314,24 @@ type ResponseWirelessGetDeviceWirelessConnectionStatsConnectionStats struct {
 	DNS     *int `json:"dns,omitempty"`     // The number of failed DNS attempts
 	Success *int `json:"success,omitempty"` // The number of successful connection attempts
 }
+type ResponseWirelessGetDeviceWirelessElectronicShelfLabel struct {
+	ApEslID   *int   `json:"apEslId,omitempty"`   // An identifier for the device used by the ESL system
+	Channel   string `json:"channel,omitempty"`   // Desired ESL channel for the device, or 'Auto' (case insensitive) to use the recommended channel
+	Enabled   *bool  `json:"enabled,omitempty"`   // Turn ESL features on and off for this device
+	Hostname  string `json:"hostname,omitempty"`  // Hostname of the ESL management service
+	NetworkID string `json:"networkId,omitempty"` // The identifier for the device's network
+	Provider  string `json:"provider,omitempty"`  // The service providing ESL functionality
+	Serial    string `json:"serial,omitempty"`    // The serial number of the device
+}
+type ResponseWirelessUpdateDeviceWirelessElectronicShelfLabel struct {
+	ApEslID   *int   `json:"apEslId,omitempty"`   // An identifier for the device used by the ESL system
+	Channel   string `json:"channel,omitempty"`   // Desired ESL channel for the device, or 'Auto' (case insensitive) to use the recommended channel
+	Enabled   *bool  `json:"enabled,omitempty"`   // Turn ESL features on and off for this device
+	Hostname  string `json:"hostname,omitempty"`  // Hostname of the ESL management service
+	NetworkID string `json:"networkId,omitempty"` // The identifier for the device's network
+	Provider  string `json:"provider,omitempty"`  // The service providing ESL functionality
+	Serial    string `json:"serial,omitempty"`    // The serial number of the device
+}
 type ResponseWirelessGetDeviceWirelessLatencyStats struct {
 	LatencyStats *ResponseWirelessGetDeviceWirelessLatencyStatsLatencyStats `json:"latencyStats,omitempty"` //
 	Serial       string                                                     `json:"serial,omitempty"`       //
@@ -299,9 +368,9 @@ type ResponseWirelessGetDeviceWirelessRadioSettings struct {
 	TwoFourGhzSettings *ResponseWirelessGetDeviceWirelessRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` //
 }
 type ResponseWirelessGetDeviceWirelessRadioSettingsFiveGhzSettings struct {
-	Channel      *int   `json:"channel,omitempty"`      //
-	ChannelWidth string `json:"channelWidth,omitempty"` //
-	TargetPower  *int   `json:"targetPower,omitempty"`  //
+	Channel      *int `json:"channel,omitempty"`      //
+	ChannelWidth *int `json:"channelWidth,omitempty"` //
+	TargetPower  *int `json:"targetPower,omitempty"`  //
 }
 type ResponseWirelessGetDeviceWirelessRadioSettingsTwoFourGhzSettings struct {
 	Channel     *int `json:"channel,omitempty"`     //
@@ -342,6 +411,42 @@ type ResponseItemWirelessGetNetworkWirelessAirMarshalBssids struct {
 type ResponseItemWirelessGetNetworkWirelessAirMarshalBssidsDetectedBy struct {
 	Device string `json:"device,omitempty"` //
 	Rssi   *int   `json:"rssi,omitempty"`   //
+}
+type ResponseWirelessCreateNetworkWirelessAirMarshalRule struct {
+	CreatedAt string                                                      `json:"createdAt,omitempty"` // Created at timestamp
+	Match     *ResponseWirelessCreateNetworkWirelessAirMarshalRuleMatch   `json:"match,omitempty"`     // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Network   *ResponseWirelessCreateNetworkWirelessAirMarshalRuleNetwork `json:"network,omitempty"`   // Network details
+	RuleID    string                                                      `json:"ruleId,omitempty"`    // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Type      string                                                      `json:"type,omitempty"`      // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	UpdatedAt string                                                      `json:"updatedAt,omitempty"` // Updated at timestamp
+}
+type ResponseWirelessCreateNetworkWirelessAirMarshalRuleMatch struct {
+	String string `json:"string,omitempty"` // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Type   string `json:"type,omitempty"`   // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+}
+type ResponseWirelessCreateNetworkWirelessAirMarshalRuleNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID
+	Name string `json:"name,omitempty"` // Network name
+}
+type ResponseWirelessUpdateNetworkWirelessAirMarshalRule struct {
+	CreatedAt string                                                      `json:"createdAt,omitempty"` // Created at timestamp
+	Match     *ResponseWirelessUpdateNetworkWirelessAirMarshalRuleMatch   `json:"match,omitempty"`     // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Network   *ResponseWirelessUpdateNetworkWirelessAirMarshalRuleNetwork `json:"network,omitempty"`   // Network details
+	RuleID    string                                                      `json:"ruleId,omitempty"`    // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Type      string                                                      `json:"type,omitempty"`      // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	UpdatedAt string                                                      `json:"updatedAt,omitempty"` // Updated at timestamp
+}
+type ResponseWirelessUpdateNetworkWirelessAirMarshalRuleMatch struct {
+	String string `json:"string,omitempty"` // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+	Type   string `json:"type,omitempty"`   // Indicates whether or not clients are allowed to       connect to rogue SSIDs by default. (blocked by default)
+}
+type ResponseWirelessUpdateNetworkWirelessAirMarshalRuleNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID
+	Name string `json:"name,omitempty"` // Network name
+}
+type ResponseWirelessUpdateNetworkWirelessAirMarshalSettings struct {
+	DefaultPolicy string `json:"defaultPolicy,omitempty"` // Indicates whether or not clients are allowed to       connect to rogue SSIDs. (blocked by default)
+	NetworkID     string `json:"networkId,omitempty"`     // The network ID
 }
 type ResponseWirelessGetNetworkWirelessAlternateManagementInterface struct {
 	AccessPoints *[]ResponseWirelessGetNetworkWirelessAlternateManagementInterfaceAccessPoints `json:"accessPoints,omitempty"` //
@@ -461,33 +566,31 @@ type ResponseItemWirelessGetNetworkWirelessClientsLatencyStatsLatencyStatsBackgr
 	Status8    *int `json:"8,omitempty"`    //
 }
 type ResponseWirelessGetNetworkWirelessClientConnectionStats struct {
-	ConnectionStats *ResponseWirelessGetNetworkWirelessClientConnectionStatsConnectionStats `json:"connectionStats,omitempty"` //
-	Mac             string                                                                  `json:"mac,omitempty"`             //
+	ConnectionStats *ResponseWirelessGetNetworkWirelessClientConnectionStatsConnectionStats `json:"connectionStats,omitempty"` // Connection stats
+	Mac             string                                                                  `json:"mac,omitempty"`             // MAC address of the client
 }
 type ResponseWirelessGetNetworkWirelessClientConnectionStatsConnectionStats struct {
-	Assoc   *int `json:"assoc,omitempty"`   //
-	Auth    *int `json:"auth,omitempty"`    //
-	Dhcp    *int `json:"dhcp,omitempty"`    //
-	DNS     *int `json:"dns,omitempty"`     //
-	Success *int `json:"success,omitempty"` //
+	Assoc   *int `json:"assoc,omitempty"`   // Association count
+	Auth    *int `json:"auth,omitempty"`    // Authorization count
+	Dhcp    *int `json:"dhcp,omitempty"`    // DHCP count
+	Success *int `json:"success,omitempty"` // successful count
 }
 type ResponseWirelessGetNetworkWirelessClientConnectivityEvents []ResponseItemWirelessGetNetworkWirelessClientConnectivityEvents // Array of ResponseWirelessGetNetworkWirelessClientConnectivityEvents
 type ResponseItemWirelessGetNetworkWirelessClientConnectivityEvents struct {
-	Band         *int                                                                     `json:"band,omitempty"`         //
-	Channel      *int                                                                     `json:"channel,omitempty"`      //
-	DeviceSerial string                                                                   `json:"deviceSerial,omitempty"` //
-	DurationMs   *float64                                                                 `json:"durationMs,omitempty"`   //
-	EventData    *ResponseItemWirelessGetNetworkWirelessClientConnectivityEventsEventData `json:"eventData,omitempty"`    //
-	OccurredAt   *int                                                                     `json:"occurredAt,omitempty"`   //
-	Rssi         *int                                                                     `json:"rssi,omitempty"`         //
-	Severity     string                                                                   `json:"severity,omitempty"`     //
-	SSIDNumber   *int                                                                     `json:"ssidNumber,omitempty"`   //
-	Subtype      string                                                                   `json:"subtype,omitempty"`      //
-	Type         string                                                                   `json:"type,omitempty"`         //
+	Band         string                                                                   `json:"band,omitempty"`         // Wireless band the event occurred on
+	CaptureID    string                                                                   `json:"captureId,omitempty"`    // Id of the packet capture triggered for the event, if any
+	Channel      *int                                                                     `json:"channel,omitempty"`      // Wireless channel the event occurred over
+	DeviceSerial string                                                                   `json:"deviceSerial,omitempty"` // Serial number of the device the event occurred for
+	DurationMs   *int                                                                     `json:"durationMs,omitempty"`   // Duration of the event in milliseconds
+	EventData    *ResponseItemWirelessGetNetworkWirelessClientConnectivityEventsEventData `json:"eventData,omitempty"`    // Additional information relevant to the given event. Properties vary based on event type.
+	OccurredAt   string                                                                   `json:"occurredAt,omitempty"`   // Timestamp at which the event occurred
+	Rssi         *int                                                                     `json:"rssi,omitempty"`         // RSSI recorded at the time of the event
+	Severity     string                                                                   `json:"severity,omitempty"`     // Event severity
+	SSIDNumber   *int                                                                     `json:"ssidNumber,omitempty"`   // Number of the SSID the event occurred in
+	Subtype      string                                                                   `json:"subtype,omitempty"`      // Event subtype
+	Type         string                                                                   `json:"type,omitempty"`         // Event type
 }
-type ResponseItemWirelessGetNetworkWirelessClientConnectivityEventsEventData struct {
-	ClientIP string `json:"clientIp,omitempty"` //
-}
+type ResponseItemWirelessGetNetworkWirelessClientConnectivityEventsEventData interface{}
 type ResponseWirelessGetNetworkWirelessClientLatencyHistory []ResponseItemWirelessGetNetworkWirelessClientLatencyHistory // Array of ResponseWirelessGetNetworkWirelessClientLatencyHistory
 type ResponseItemWirelessGetNetworkWirelessClientLatencyHistory struct {
 	LatencyBinsByCategory *ResponseItemWirelessGetNetworkWirelessClientLatencyHistoryLatencyBinsByCategory `json:"latencyBinsByCategory,omitempty"` // The latency buckets by category
@@ -646,6 +749,19 @@ type ResponseItemWirelessGetNetworkWirelessDevicesLatencyStatsLatencyStatsBackgr
 	Status64   *int `json:"64,omitempty"`   //
 	Status8    *int `json:"8,omitempty"`    //
 }
+type ResponseWirelessGetNetworkWirelessElectronicShelfLabel struct {
+	Enabled  *bool  `json:"enabled,omitempty"`  // Turn ESL features on and off for this network
+	Hostname string `json:"hostname,omitempty"` // Desired ESL hostname of the network
+}
+type ResponseWirelessUpdateNetworkWirelessElectronicShelfLabel struct {
+	Enabled  *bool  `json:"enabled,omitempty"`  // Turn ESL features on and off for this network
+	Hostname string `json:"hostname,omitempty"` // Desired ESL hostname of the network
+}
+type ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices []ResponseItemWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices // Array of ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices
+type ResponseItemWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices struct {
+	Enabled  *bool  `json:"enabled,omitempty"`  // Turn ESL features on and off for this network
+	Hostname string `json:"hostname,omitempty"` // Desired ESL hostname of the network
+}
 type ResponseWirelessGetNetworkWirelessEthernetPortsProfiles []ResponseItemWirelessGetNetworkWirelessEthernetPortsProfiles // Array of ResponseWirelessGetNetworkWirelessEthernetPortsProfiles
 type ResponseItemWirelessGetNetworkWirelessEthernetPortsProfiles struct {
 	IsDefault *bool                                                                  `json:"isDefault,omitempty"` // Is default profile
@@ -791,6 +907,8 @@ type ResponseItemWirelessGetNetworkWirelessRfProfiles struct {
 	ClientBalancingEnabled *bool                                                           `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
 	FiveGhzSettings        *ResponseWirelessGetNetworkWirelessRfProfilesFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
 	ID                     string                                                          `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	IsIndoorDefault        *bool                                                           `json:"isIndoorDefault,omitempty"`        // Set this profile as the default indoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
+	IsOutdoorDefault       *bool                                                           `json:"isOutdoorDefault,omitempty"`       // Set this profile as the default outdoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
 	MinBitrateType         string                                                          `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
 	Name                   string                                                          `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                          `json:"networkId,omitempty"`              // The network ID of the RF Profile
@@ -805,7 +923,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesApBandSettings struct {
 	Bands               *ResponseWirelessGetNetworkWirelessRfProfilesApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -840,7 +958,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -850,7 +968,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -860,7 +978,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10 struct {
 	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -870,7 +988,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11 struct {
 	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -880,7 +998,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12 struct {
 	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -890,7 +1008,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13 struct {
 	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -900,7 +1018,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14 struct {
 	Name                string                                                              `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -910,7 +1028,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -920,7 +1038,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -930,7 +1048,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -940,7 +1058,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -950,7 +1068,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -960,7 +1078,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -970,7 +1088,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -980,7 +1098,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesPerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilesSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
@@ -1007,6 +1125,8 @@ type ResponseWirelessCreateNetworkWirelessRfProfile struct {
 	ClientBalancingEnabled *bool                                                             `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
 	FiveGhzSettings        *ResponseWirelessCreateNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
 	ID                     string                                                            `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	IsIndoorDefault        *bool                                                             `json:"isIndoorDefault,omitempty"`        // Set this profile as the default indoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
+	IsOutdoorDefault       *bool                                                             `json:"isOutdoorDefault,omitempty"`       // Set this profile as the default outdoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
 	MinBitrateType         string                                                            `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
 	Name                   string                                                            `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                            `json:"networkId,omitempty"`              // The network ID of the RF Profile
@@ -1021,7 +1141,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfileApBandSettings struct {
 	Bands               *ResponseWirelessCreateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -1056,7 +1176,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1066,7 +1186,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1076,7 +1196,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1086,7 +1206,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1096,7 +1216,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1106,7 +1226,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1116,7 +1236,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1126,7 +1246,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1136,7 +1256,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1146,7 +1266,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1156,7 +1276,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1166,7 +1286,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1176,7 +1296,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1186,7 +1306,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1196,7 +1316,7 @@ type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessCreateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
@@ -1223,6 +1343,8 @@ type ResponseWirelessGetNetworkWirelessRfProfile struct {
 	ClientBalancingEnabled *bool                                                          `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
 	FiveGhzSettings        *ResponseWirelessGetNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
 	ID                     string                                                         `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	IsIndoorDefault        *bool                                                          `json:"isIndoorDefault,omitempty"`        // Set this profile as the default indoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
+	IsOutdoorDefault       *bool                                                          `json:"isOutdoorDefault,omitempty"`       // Set this profile as the default outdoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
 	MinBitrateType         string                                                         `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
 	Name                   string                                                         `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                         `json:"networkId,omitempty"`              // The network ID of the RF Profile
@@ -1237,7 +1359,7 @@ type ResponseWirelessGetNetworkWirelessRfProfileApBandSettings struct {
 	Bands               *ResponseWirelessGetNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type ResponseWirelessGetNetworkWirelessRfProfileApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -1272,7 +1394,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1282,7 +1404,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1292,7 +1414,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1302,7 +1424,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1312,7 +1434,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1322,7 +1444,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	BandOperationMode   string                                                             `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1332,7 +1454,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	Name                string                                                             `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1342,7 +1464,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1352,7 +1474,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1362,7 +1484,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1372,7 +1494,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1382,7 +1504,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1392,7 +1514,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1402,7 +1524,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	BandOperationMode   string                                                            `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1412,7 +1534,7 @@ type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	Name                string                                                            `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessGetNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessGetNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
@@ -1439,6 +1561,8 @@ type ResponseWirelessUpdateNetworkWirelessRfProfile struct {
 	ClientBalancingEnabled *bool                                                             `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
 	FiveGhzSettings        *ResponseWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
 	ID                     string                                                            `json:"id,omitempty"`                     // The name of the new profile. Must be unique.
+	IsIndoorDefault        *bool                                                             `json:"isIndoorDefault,omitempty"`        // Set this profile as the default indoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
+	IsOutdoorDefault       *bool                                                             `json:"isOutdoorDefault,omitempty"`       // Set this profile as the default outdoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
 	MinBitrateType         string                                                            `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'. Defaults to band.
 	Name                   string                                                            `json:"name,omitempty"`                   // The name of the new profile. Must be unique. This param is required on creation.
 	NetworkID              string                                                            `json:"networkId,omitempty"`              // The network ID of the RF Profile
@@ -1453,7 +1577,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettings struct {
 	Bands               *ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -1488,7 +1612,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1498,7 +1622,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1508,7 +1632,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1518,7 +1642,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1528,7 +1652,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1538,7 +1662,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	BandOperationMode   string                                                                `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1548,7 +1672,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	Name                string                                                                `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1558,7 +1682,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1568,7 +1692,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1578,7 +1702,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1588,7 +1712,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1598,7 +1722,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1608,7 +1732,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1618,7 +1742,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -1628,7 +1752,7 @@ type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	Name                string                                                               `json:"name,omitempty"`                // Name of SSID
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type ResponseWirelessUpdateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to auto.
@@ -1656,7 +1780,7 @@ type ResponseWirelessGetNetworkWirelessSettings struct {
 	MeshingEnabled           *bool                                                       `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
 	NamedVLANs               *ResponseWirelessGetNetworkWirelessSettingsNamedVLANs       `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
 	RegulatoryDomain         *ResponseWirelessGetNetworkWirelessSettingsRegulatoryDomain `json:"regulatoryDomain,omitempty"`         // Regulatory domain information for this network.
-	Upgradestrategy          string                                                      `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	Upgradestrategy          string                                                      `json:"upgradeStrategy,omitempty"`          // The default strategy that network devices will use to perform an upgrade. Requires firmware version MR 26.8 or higher.
 }
 type ResponseWirelessGetNetworkWirelessSettingsNamedVLANs struct {
 	PoolDhcpMonitoring *ResponseWirelessGetNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
@@ -1677,7 +1801,7 @@ type ResponseWirelessUpdateNetworkWirelessSettings struct {
 	MeshingEnabled           *bool                                                          `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
 	NamedVLANs               *ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs       `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
 	RegulatoryDomain         *ResponseWirelessUpdateNetworkWirelessSettingsRegulatoryDomain `json:"regulatoryDomain,omitempty"`         // Regulatory domain information for this network.
-	Upgradestrategy          string                                                         `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	Upgradestrategy          string                                                         `json:"upgradeStrategy,omitempty"`          // The default strategy that network devices will use to perform an upgrade. Requires firmware version MR 26.8 or higher.
 }
 type ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANs struct {
 	PoolDhcpMonitoring *ResponseWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
@@ -1844,7 +1968,7 @@ type ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingException struct {
 }
 type ResponseWirelessGetNetworkWirelessSSIDBonjourForwardingRules struct {
 	Description string   `json:"description,omitempty"` // Desctiption of the bonjour forwarding rule
-	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AFP', 'AirPlay', 'Apple screen share', 'BitTorrent', 'Chromecast', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners', 'Spotify' and 'SSH'
 	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwarding struct {
@@ -1857,7 +1981,7 @@ type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingException struct 
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules struct {
 	Description string   `json:"description,omitempty"` // Desctiption of the bonjour forwarding rule
-	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AFP', 'AirPlay', 'Apple screen share', 'BitTorrent', 'Chromecast', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners', 'Spotify' and 'SSH'
 	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required
 }
 type ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPolicies struct {
@@ -1898,7 +2022,8 @@ type ResponseWirelessUpdateNetworkWirelessSSIDEapOverrideIDentity struct {
 	Timeout *int `json:"timeout,omitempty"` // EAP timeout in seconds.
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRules struct {
-	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
+	AllowLanAccess *bool                                                                 `json:"allowLanAccess,omitempty"` // Allows wireless client access to local LAN (boolean value - true allows access and false denies access)
+	Rules          *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"`          // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
@@ -1909,7 +2034,8 @@ type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	IpVer    string `json:"ipVer,omitempty"`    //
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules struct {
-	Rules *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
+	AllowLanAccess *bool                                                                    `json:"allowLanAccess,omitempty"` // Allows wireless client access to local LAN (boolean value - true allows access and false denies access)
+	Rules          *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules `json:"rules,omitempty"`          // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	Comment  string `json:"comment,omitempty"`  // Description of the rule (optional)
@@ -2077,16 +2203,35 @@ type ResponseWirelessUpdateNetworkWirelessSSIDIDentityPsk struct {
 	WifiPersonalNetworkID string `json:"wifiPersonalNetworkId,omitempty"` // The WiFi Personal Network unique identifier
 }
 type ResponseWirelessGetNetworkWirelessSSIDSchedules struct {
-	Enabled *bool                                                    `json:"enabled,omitempty"` //
-	Ranges  *[]ResponseWirelessGetNetworkWirelessSSIDSchedulesRanges `json:"ranges,omitempty"`  //
+	Enabled         *bool                                                             `json:"enabled,omitempty"`         // If true, the SSID outage schedule is enabled.
+	Ranges          *[]ResponseWirelessGetNetworkWirelessSSIDSchedulesRanges          `json:"ranges,omitempty"`          // List of outage ranges. Has a start date and time, and end date and time. If this parameter is passed in along with rangesInSeconds parameter, this will take precedence.
+	RangesInSeconds *[]ResponseWirelessGetNetworkWirelessSSIDSchedulesRangesInSeconds `json:"rangesInSeconds,omitempty"` // List of outage ranges in seconds since Sunday at Midnight. Has a start and end. If this parameter is passed in along with the ranges parameter, ranges will take precedence.
 }
 type ResponseWirelessGetNetworkWirelessSSIDSchedulesRanges struct {
-	EndDay    string `json:"endDay,omitempty"`    //
-	EndTime   string `json:"endTime,omitempty"`   //
-	StartDay  string `json:"startDay,omitempty"`  //
-	StartTime string `json:"startTime,omitempty"` //
+	EndDay    string `json:"endDay,omitempty"`    // Day of when the outage ends. Can be either full day name, or three letter abbreviation
+	EndTime   string `json:"endTime,omitempty"`   // 24 hour time when the outage ends.
+	StartDay  string `json:"startDay,omitempty"`  // Day of when the outage starts. Can be either full day name, or three letter abbreviation.
+	StartTime string `json:"startTime,omitempty"` // 24 hour time when the outage starts.
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDSchedules interface{}
+type ResponseWirelessGetNetworkWirelessSSIDSchedulesRangesInSeconds struct {
+	End   *int `json:"end,omitempty"`   // Seconds since Sunday at midnight when that outage range ends.
+	Start *int `json:"start,omitempty"` // Seconds since Sunday at midnight when the outage range starts.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDSchedules struct {
+	Enabled         *bool                                                                `json:"enabled,omitempty"`         // If true, the SSID outage schedule is enabled.
+	Ranges          *[]ResponseWirelessUpdateNetworkWirelessSSIDSchedulesRanges          `json:"ranges,omitempty"`          // List of outage ranges. Has a start date and time, and end date and time. If this parameter is passed in along with rangesInSeconds parameter, this will take precedence.
+	RangesInSeconds *[]ResponseWirelessUpdateNetworkWirelessSSIDSchedulesRangesInSeconds `json:"rangesInSeconds,omitempty"` // List of outage ranges in seconds since Sunday at Midnight. Has a start and end. If this parameter is passed in along with the ranges parameter, ranges will take precedence.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDSchedulesRanges struct {
+	EndDay    string `json:"endDay,omitempty"`    // Day of when the outage ends. Can be either full day name, or three letter abbreviation
+	EndTime   string `json:"endTime,omitempty"`   // 24 hour time when the outage ends.
+	StartDay  string `json:"startDay,omitempty"`  // Day of when the outage starts. Can be either full day name, or three letter abbreviation.
+	StartTime string `json:"startTime,omitempty"` // 24 hour time when the outage starts.
+}
+type ResponseWirelessUpdateNetworkWirelessSSIDSchedulesRangesInSeconds struct {
+	End   *int `json:"end,omitempty"`   // Seconds since Sunday at midnight when that outage range ends.
+	Start *int `json:"start,omitempty"` // Seconds since Sunday at midnight when the outage range starts.
+}
 type ResponseWirelessGetNetworkWirelessSSIDSplashSettings struct {
 	AllowSimultaneousLogins         *bool                                                                   `json:"allowSimultaneousLogins,omitempty"`         // Whether or not to allow simultaneous logins from different devices.
 	Billing                         *ResponseWirelessGetNetworkWirelessSSIDSplashSettingsBilling            `json:"billing,omitempty"`                         // Details associated with billing splash
@@ -2284,6 +2429,81 @@ type ResponseItemWirelessGetNetworkWirelessUsageHistory struct {
 	StartTs      string `json:"startTs,omitempty"`      // The start time of the query range
 	TotalKbps    *int   `json:"totalKbps,omitempty"`    // Total usage in kilobytes-per-second
 }
+type ResponseWirelessGetOrganizationWirelessAirMarshalRules struct {
+	Items *[]ResponseWirelessGetOrganizationWirelessAirMarshalRulesItems `json:"items,omitempty"` // List of rules
+	Meta  *ResponseWirelessGetOrganizationWirelessAirMarshalRulesMeta    `json:"meta,omitempty"`  // Meta details about the result
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesItems struct {
+	CreatedAt string                                                              `json:"createdAt,omitempty"` // Created at timestamp
+	Match     *ResponseWirelessGetOrganizationWirelessAirMarshalRulesItemsMatch   `json:"match,omitempty"`     // Indicates whether or not clients are allowed to        connect to rogue SSIDs by default. (blocked by default)
+	Network   *ResponseWirelessGetOrganizationWirelessAirMarshalRulesItemsNetwork `json:"network,omitempty"`   // Network details
+	RuleID    string                                                              `json:"ruleId,omitempty"`    // Indicates whether or not clients are allowed to        connect to rogue SSIDs by default. (blocked by default)
+	Type      string                                                              `json:"type,omitempty"`      // Indicates whether or not clients are allowed to        connect to rogue SSIDs by default. (blocked by default)
+	UpdatedAt string                                                              `json:"updatedAt,omitempty"` // Updated at timestamp
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesItemsMatch struct {
+	String string `json:"string,omitempty"` // Indicates whether or not clients are allowed to        connect to rogue SSIDs by default. (blocked by default)
+	Type   string `json:"type,omitempty"`   // Indicates whether or not clients are allowed to        connect to rogue SSIDs by default. (blocked by default)
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // Network ID
+	Name string `json:"name,omitempty"` // Network name
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesMeta struct {
+	Counts *ResponseWirelessGetOrganizationWirelessAirMarshalRulesMetaCounts `json:"counts,omitempty"` // Counts
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesMetaCounts struct {
+	Items *ResponseWirelessGetOrganizationWirelessAirMarshalRulesMetaCountsItems `json:"items,omitempty"` // Items
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalRulesMetaCountsItems struct {
+	Total *int `json:"total,omitempty"` // Count of rules
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork struct {
+	Items *[]ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkItems `json:"items,omitempty"` // List of settings
+	Meta  *ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMeta    `json:"meta,omitempty"`  // Metadata
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkItems struct {
+	DefaultPolicy string `json:"defaultPolicy,omitempty"` // Indicates whether or not clients are allowed to       connect to rogue SSIDs. (blocked by default)
+	NetworkID     string `json:"networkId,omitempty"`     // The network ID
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMeta struct {
+	Counts *ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMetaCounts `json:"counts,omitempty"` // Counts
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMetaCounts struct {
+	Items *ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMetaCountsItems `json:"items,omitempty"` // Items
+}
+type ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetworkMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // Remaining number of items
+	Total     *int `json:"total,omitempty"`     // Total number of items
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice struct {
+	Items *[]ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItems `json:"items,omitempty"` // Access point client count
+	Meta  *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItems struct {
+	Counts  *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsCounts  `json:"counts,omitempty"`  // Associated client count on access point
+	Network *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsNetwork `json:"network,omitempty"` // Access point network
+	Serial  string                                                                      `json:"serial,omitempty"`  // Access point Serial number
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsCounts struct {
+	ByStatus *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsCountsByStatus `json:"byStatus,omitempty"` // Associated client count on access point by status
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsCountsByStatus struct {
+	Online *int `json:"online,omitempty"` // Active client count
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Access point network ID
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMeta struct {
+	Counts *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMetaCounts struct {
+	Items *ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessGetOrganizationWirelessClientsOverviewByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
 type ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice
 type ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
 	ByBand  *[]ResponseItemWirelessGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
@@ -2394,8 +2614,8 @@ type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatuses struct {
 	Serial      string                                                                         `json:"serial,omitempty"`      // The serial number of the AP
 }
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesAggregation struct {
-	Enabled *bool `json:"enabled,omitempty"` // Link Aggregation enabled flag
-	Speed   *int  `json:"speed,omitempty"`   // Link Aggregation speed
+	Enabled *bool `json:"enabled,omitempty"` // Link Aggregation enabled flag will return null on Catalyst devices
+	Speed   *int  `json:"speed,omitempty"`   // Link Aggregation speed will return null on Catalyst devices
 }
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesNetwork struct {
 	ID string `json:"id,omitempty"` // The network ID the AP is associated to
@@ -2406,8 +2626,8 @@ type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPorts str
 	Poe             *ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPortsPoe             `json:"poe,omitempty"`             // PoE details object for the port
 }
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPortsLinkNegotiation struct {
-	Duplex string `json:"duplex,omitempty"` // The duplex mode of the port. Can be 'full' or 'half'
-	Speed  *int   `json:"speed,omitempty"`  // The speed of the port
+	Duplex string `json:"duplex,omitempty"` // The duplex mode of the port. Can be 'full' or 'half' will return null on Catalyst devices
+	Speed  *int   `json:"speed,omitempty"`  // Show the speed of the port. The port speed will return null on Catalyst devices
 }
 type ResponseItemWirelessGetOrganizationWirelessDevicesEthernetStatusesPortsPoe struct {
 	Standard string `json:"standard,omitempty"` // The PoE Standard for the port. Can be '802.3at', '802.3af', '802.3bt', or null
@@ -2494,6 +2714,123 @@ type ResponseItemWirelessGetOrganizationWirelessDevicesPacketLossByNetworkUpstre
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
 	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
 }
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice struct {
+	Items *[]ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItems `json:"items,omitempty"` // List of Catalyst access points information
+	Meta  *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItems struct {
+	Controller  *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController `json:"controller,omitempty"`  // Associated wireless controller
+	CountryCode string                                                                                    `json:"countryCode,omitempty"` // Country code (2 characters)
+	Details     *[]ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails  `json:"details,omitempty"`     // Catalyst access point details
+	JoinedAt    string                                                                                    `json:"joinedAt,omitempty"`    // The time when AP joins wireless controller
+	Mode        string                                                                                    `json:"mode,omitempty"`        // AP mode (local, flex, etc.)
+	Model       string                                                                                    `json:"model,omitempty"`       // AP model
+	Network     *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork    `json:"network,omitempty"`     // Catalyst access point network
+	Serial      string                                                                                    `json:"serial,omitempty"`      // AP cloud ID
+	Tags        *[]ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags     `json:"tags,omitempty"`        // The tags of the catalyst access point
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController struct {
+	Serial string `json:"serial,omitempty"` // Associated wireless controller cloud ID
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails struct {
+	Name  string `json:"name,omitempty"`  // Item name
+	Value string `json:"value,omitempty"` // Item value
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Catalyst access point network ID
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags struct {
+	Policy string `json:"policy,omitempty"` // Policy tag
+	Rf     string `json:"rf,omitempty"`     // RF tag
+	Site   string `json:"site,omitempty"`   // Site tag
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta struct {
+	Counts *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts struct {
+	Items *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessRecalculateOrganizationWirelessRadioAutoRfChannels struct {
+	EstimatedCompletedAt string `json:"estimatedCompletedAt,omitempty"` // Estimated time of completion.
+}
+type ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice []ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice // Array of ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice struct {
+	Items *[]ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItems `json:"items,omitempty"` // The top-level propery containing all status data.
+	Meta  *ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMeta    `json:"meta,omitempty"`  // Other metadata related to this result set.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItems struct {
+	Model     string                                                                                  `json:"model,omitempty"`     // Model number of the device.
+	Name      string                                                                                  `json:"name,omitempty"`      // Name of the device.
+	Network   *ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItemsNetwork   `json:"network,omitempty"`   // Information regarding the network the device belongs to.
+	RfProfile *ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItemsRfProfile `json:"rfProfile,omitempty"` // Information regarding the RF Profile of the device.
+	Serial    string                                                                                  `json:"serial,omitempty"`    // Unique serial number for device.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItemsNetwork struct {
+	ID string `json:"id,omitempty"` // The network ID.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceItemsRfProfile struct {
+	ID               string `json:"id,omitempty"`               // The ID of the RF Profile the device belongs to.
+	IsIndoorDefault  *bool  `json:"isIndoorDefault,omitempty"`  // Status to show if this profile is default indoor profile.
+	IsOutdoorDefault *bool  `json:"isOutdoorDefault,omitempty"` // Status to show if this profile is default outdoor profile.
+	Name             string `json:"name,omitempty"`             // The name of the RF Profile the device belongs to.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMeta struct {
+	Counts *ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMetaCounts `json:"counts,omitempty"` // Count metadata related to this result set.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMetaCounts struct {
+	Items *ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMetaCountsItems `json:"items,omitempty"` // The count metadata.
+}
+type ResponseItemWirelessGetOrganizationWirelessRfProfilesAssignmentsByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of serials remaining based on current pagination location within the dataset.
+	Total     *int `json:"total,omitempty"`     // The total number of serials.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice struct {
+	Items *[]ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItems `json:"items,omitempty"` // The top-level propery containing all status data.
+	Meta  *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMeta    `json:"meta,omitempty"`  // Other metadata related to this result set.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItems struct {
+	BasicServiceSets *[]ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSets `json:"basicServiceSets,omitempty"` // Status information for wireless access points.
+	Name             string                                                                               `json:"name,omitempty"`             // Name of device.
+	Network          *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsNetwork            `json:"network,omitempty"`          // Group of devices and settings.
+	Serial           string                                                                               `json:"serial,omitempty"`           // Unique serial number for device.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSets struct {
+	Bssid string                                                                                  `json:"bssid,omitempty"` // Unique identifier for wireless access point.
+	Radio *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSetsRadio `json:"radio,omitempty"` // Wireless access point radio identifier.
+	SSID  *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSetsSSID  `json:"ssid,omitempty"`  // Wireless access point and network identifier.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSetsRadio struct {
+	Band           string `json:"band,omitempty"`           // Frequency range used for wireless communication.
+	Channel        *int   `json:"channel,omitempty"`        // Frequency channel used for wireless communication.
+	ChannelWidth   *int   `json:"channelWidth,omitempty"`   // Width of frequency channel used for wireless communication.
+	Index          string `json:"index,omitempty"`          // The radio index.
+	IsBroadcasting *bool  `json:"isBroadcasting,omitempty"` // Indicates whether or not this radio is currently broadcasting.
+	Power          *int   `json:"power,omitempty"`          // Strength of wireless signal.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsBasicServiceSetsSSID struct {
+	Advertised *bool  `json:"advertised,omitempty"` // Availability of wireless network for devices to connect to.
+	Enabled    *bool  `json:"enabled,omitempty"`    // Status of wireless network.
+	Name       string `json:"name,omitempty"`       // Name of wireless network.
+	Number     *int   `json:"number,omitempty"`     // Unique identifier for wireless network.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // Unique identifier for network.
+	Name string `json:"name,omitempty"` // Name of network.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMeta struct {
+	Counts *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMetaCounts `json:"counts,omitempty"` // Count metadata related to this result set.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMetaCounts struct {
+	Items *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMetaCountsItems `json:"items,omitempty"` // The count metadata.
+}
+type ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items remaining based on current pagination location within the dataset.
+	Total     *int `json:"total,omitempty"`     // The total number of items.
+}
 type RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6 struct {
 	Addresses *[]RequestWirelessUpdateDeviceWirelessAlternateManagementInterfaceIPv6Addresses `json:"addresses,omitempty"` // configured alternate management interface addresses
 }
@@ -2513,19 +2850,42 @@ type RequestWirelessUpdateDeviceWirelessBluetoothSettings struct {
 	Minor *int   `json:"minor,omitempty"` // Desired minor value of the beacon. If the value is set to null it will reset to Dashboard's automatically generated value.
 	UUID  string `json:"uuid,omitempty"`  // Desired UUID of the beacon. If the value is set to null it will reset to Dashboard's automatically generated value.
 }
+type RequestWirelessUpdateDeviceWirelessElectronicShelfLabel struct {
+	Channel string `json:"channel,omitempty"` // Desired ESL channel for the device, or 'Auto' (case insensitive) to use the recommended channel
+	Enabled *bool  `json:"enabled,omitempty"` // Turn ESL features on and off for this device
+}
 type RequestWirelessUpdateDeviceWirelessRadioSettings struct {
 	FiveGhzSettings    *RequestWirelessUpdateDeviceWirelessRadioSettingsFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`    // Manual radio settings for 5 GHz.
 	RfProfileID        string                                                              `json:"rfProfileId,omitempty"`        // The ID of an RF profile to assign to the device. If the value of this parameter is null, the appropriate basic RF profile (indoor or outdoor) will be assigned to the device. Assigning an RF profile will clear ALL manually configured overrides on the device (channel width, channel, power).
 	TwoFourGhzSettings *RequestWirelessUpdateDeviceWirelessRadioSettingsTwoFourGhzSettings `json:"twoFourGhzSettings,omitempty"` // Manual radio settings for 2.4 GHz.
 }
 type RequestWirelessUpdateDeviceWirelessRadioSettingsFiveGhzSettings struct {
-	Channel      *int   `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
-	ChannelWidth string `json:"channelWidth,omitempty"` // Sets a manual channel for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
-	TargetPower  *int   `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz. Can be between '8' or '30' or null for using auto power range.
+	Channel      *int `json:"channel,omitempty"`      // Sets a manual channel for 5 GHz. Can be '36', '40', '44', '48', '52', '56', '60', '64', '100', '104', '108', '112', '116', '120', '124', '128', '132', '136', '140', '144', '149', '153', '157', '161', '165', '169', '173' or '177' or null for using auto channel.
+	ChannelWidth *int `json:"channelWidth,omitempty"` // Sets a manual channel for 5 GHz. Can be '0', '20', '40', '80' or '160' or null for using auto channel width.
+	TargetPower  *int `json:"targetPower,omitempty"`  // Set a manual target power for 5 GHz (dBm). Enter null for using auto power range.
 }
 type RequestWirelessUpdateDeviceWirelessRadioSettingsTwoFourGhzSettings struct {
 	Channel     *int `json:"channel,omitempty"`     // Sets a manual channel for 2.4 GHz. Can be '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13' or '14' or null for using auto channel.
-	TargetPower *int `json:"targetPower,omitempty"` // Set a manual target power for 2.4 GHz. Can be between '5' or '30' or null for using auto power range.
+	TargetPower *int `json:"targetPower,omitempty"` // Set a manual target power for 2.4 GHz (dBm). Enter null for using auto power range.
+}
+type RequestWirelessCreateNetworkWirelessAirMarshalRule struct {
+	Match *RequestWirelessCreateNetworkWirelessAirMarshalRuleMatch `json:"match,omitempty"` // Object describing the rule specification.
+	Type  string                                                   `json:"type,omitempty"`  // Indicates if this rule will allow, block, or alert.
+}
+type RequestWirelessCreateNetworkWirelessAirMarshalRuleMatch struct {
+	String string `json:"string,omitempty"` // The string used to match.
+	Type   string `json:"type,omitempty"`   // The type of match.
+}
+type RequestWirelessUpdateNetworkWirelessAirMarshalRule struct {
+	Match *RequestWirelessUpdateNetworkWirelessAirMarshalRuleMatch `json:"match,omitempty"` // Object describing the rule specification.
+	Type  string                                                   `json:"type,omitempty"`  // Indicates if this rule will allow, block, or alert.
+}
+type RequestWirelessUpdateNetworkWirelessAirMarshalRuleMatch struct {
+	String string `json:"string,omitempty"` // The string used to match.
+	Type   string `json:"type,omitempty"`   // The type of match.
+}
+type RequestWirelessUpdateNetworkWirelessAirMarshalSettings struct {
+	DefaultPolicy string `json:"defaultPolicy,omitempty"` // Allows clients to access rogue networks. Blocked by default.
 }
 type RequestWirelessUpdateNetworkWirelessAlternateManagementInterface struct {
 	AccessPoints *[]RequestWirelessUpdateNetworkWirelessAlternateManagementInterfaceAccessPoints `json:"accessPoints,omitempty"` // Array of access point serial number and IP assignment. Note: accessPoints IP assignment is not applicable for template networks, in other words, do not put 'accessPoints' in the body when updating template networks. Also, an empty 'accessPoints' array will remove all previous static IP assignments
@@ -2562,6 +2922,10 @@ type RequestWirelessUpdateNetworkWirelessBluetoothSettings struct {
 	Minor                    *int   `json:"minor,omitempty"`                    // The minor number to be used in the beacon identifier. Only valid in 'Non-unique' mode.
 	ScanningEnabled          *bool  `json:"scanningEnabled,omitempty"`          // Whether APs will scan for Bluetooth enabled clients.
 	UUID                     string `json:"uuid,omitempty"`                     // The UUID to be used in the beacon identifier.
+}
+type RequestWirelessUpdateNetworkWirelessElectronicShelfLabel struct {
+	Enabled  *bool  `json:"enabled,omitempty"`  // Turn ESL features on and off for this network
+	Hostname string `json:"hostname,omitempty"` // Desired ESL hostname of the network
 }
 type RequestWirelessCreateNetworkWirelessEthernetPortsProfile struct {
 	Name     string                                                              `json:"name,omitempty"`     // AP port profile name
@@ -2621,7 +2985,7 @@ type RequestWirelessCreateNetworkWirelessRfProfileApBandSettings struct {
 	Bands               *RequestWirelessCreateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type RequestWirelessCreateNetworkWirelessRfProfileApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'. Defaults to auto.
@@ -2662,7 +3026,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2671,7 +3035,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2680,7 +3044,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2689,7 +3053,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2698,7 +3062,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2707,7 +3071,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2716,7 +3080,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2725,7 +3089,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2734,7 +3098,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2743,7 +3107,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2752,7 +3116,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2761,7 +3125,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2770,7 +3134,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2779,7 +3143,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2788,7 +3152,7 @@ type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessCreateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4","5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessCreateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'. Defaults to 0.
@@ -2815,6 +3179,8 @@ type RequestWirelessUpdateNetworkWirelessRfProfile struct {
 	ClientBalancingEnabled *bool                                                            `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false.
 	FiveGhzSettings        *RequestWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings    `json:"fiveGhzSettings,omitempty"`        // Settings related to 5Ghz band
 	FlexRadios             *RequestWirelessUpdateNetworkWirelessRfProfileFlexRadios         `json:"flexRadios,omitempty"`             // Flex radio settings.
+	IsIndoorDefault        *bool                                                            `json:"isIndoorDefault,omitempty"`        // Set this profile as the default indoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
+	IsOutdoorDefault       *bool                                                            `json:"isOutdoorDefault,omitempty"`       // Set this profile as the default outdoor rf profile. If the profile ID is one of 'indoor' or 'outdoor',   then a new profile will be created from the respective ID and set as the default
 	MinBitrateType         string                                                           `json:"minBitrateType,omitempty"`         // Minimum bitrate can be set to either 'band' or 'ssid'.
 	Name                   string                                                           `json:"name,omitempty"`                   // The name of the new profile. Must be unique.
 	PerSSIDSettings        *RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings    `json:"perSsidSettings,omitempty"`        // Per-SSID radio settings by number.
@@ -2828,7 +3194,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfileApBandSettings struct {
 	Bands               *RequestWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands `json:"bands,omitempty"`               // Settings related to all bands
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileApBandSettingsBands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileFiveGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 5Ghz band. Can be one of 'auto', '20', '40' or '80'.
@@ -2869,7 +3235,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings0Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2878,7 +3244,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings1Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2887,7 +3253,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings10Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2896,7 +3262,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings11Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2905,7 +3271,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings12Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2914,7 +3280,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings13Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	BandOperationMode   string                                                               `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2923,7 +3289,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14 struct {
 	MinBitrate          *float64                                                             `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings14Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2932,7 +3298,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings2Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2941,7 +3307,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings3Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2950,7 +3316,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings4Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2959,7 +3325,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings5Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2968,7 +3334,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings6Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2977,7 +3343,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings7Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2986,7 +3352,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings8Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	BandOperationMode   string                                                              `json:"bandOperationMode,omitempty"`   // Choice between 'dual', '2.4ghz', '5ghz', '6ghz' or 'multi'.
@@ -2995,7 +3361,7 @@ type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9 struct {
 	MinBitrate          *float64                                                            `json:"minBitrate,omitempty"`          // Sets min bitrate (Mbps) of this SSID. Can be one of '1', '2', '5.5', '6', '9', '11', '12', '18', '24', '36', '48' or '54'.
 }
 type RequestWirelessUpdateNetworkWirelessRfProfilePerSSIDSettings9Bands struct {
-	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"
+	Enabled []string `json:"enabled,omitempty"` // List of enabled bands. Can include ["2.4", "5", "6", "disabled"]
 }
 type RequestWirelessUpdateNetworkWirelessRfProfileSixGhzSettings struct {
 	ChannelWidth      string `json:"channelWidth,omitempty"`      // Sets channel width (MHz) for 6Ghz band. Can be one of '0', '20', '40', '80' or '160'.
@@ -3022,7 +3388,7 @@ type RequestWirelessUpdateNetworkWirelessSettings struct {
 	LocationAnalyticsEnabled *bool                                                   `json:"locationAnalyticsEnabled,omitempty"` // Toggle for enabling or disabling location analytics for your network
 	MeshingEnabled           *bool                                                   `json:"meshingEnabled,omitempty"`           // Toggle for enabling or disabling meshing in a network
 	NamedVLANs               *RequestWirelessUpdateNetworkWirelessSettingsNamedVLANs `json:"namedVlans,omitempty"`               // Named VLAN settings for wireless networks.
-	Upgradestrategy          string                                                  `json:"upgradeStrategy,omitempty"`          // The upgrade strategy to apply to the network. Must be one of 'minimizeUpgradeTime' or 'minimizeClientDowntime'. Requires firmware version MR 26.8 or higher'
+	Upgradestrategy          string                                                  `json:"upgradeStrategy,omitempty"`          // The default strategy that network devices will use to perform an upgrade. Requires firmware version MR 26.8 or higher.
 }
 type RequestWirelessUpdateNetworkWirelessSettingsNamedVLANs struct {
 	PoolDhcpMonitoring *RequestWirelessUpdateNetworkWirelessSettingsNamedVLANsPoolDhcpMonitoring `json:"poolDhcpMonitoring,omitempty"` // Named VLAN Pool DHCP Monitoring settings.
@@ -3035,7 +3401,7 @@ type RequestWirelessUpdateNetworkWirelessSSID struct {
 	ActiveDirectory                  *RequestWirelessUpdateNetworkWirelessSSIDActiveDirectory           `json:"activeDirectory,omitempty"`                  // The current setting for Active Directory. Only valid if splashPage is 'Password-protected with Active Directory'
 	AdultContentFilteringEnabled     *bool                                                              `json:"adultContentFilteringEnabled,omitempty"`     // Boolean indicating whether or not adult content will be blocked
 	ApTagsAndVLANIDs                 *[]RequestWirelessUpdateNetworkWirelessSSIDApTagsAndVLANIDs        `json:"apTagsAndVlanIds,omitempty"`                 // The list of tags and VLAN IDs used for VLAN tagging. This param is only valid when the ipAssignmentMode is 'Bridge mode' or 'Layer 3 roaming'
-	AuthMode                         string                                                             `json:"authMode,omitempty"`                         // The association control method for the SSID ('open', 'open-enhanced', 'psk', 'open-with-radius', 'open-with-nac', '8021x-meraki', '8021x-nac', '8021x-radius', '8021x-google', '8021x-localradius', 'ipsk-with-radius', 'ipsk-without-radius' or 'ipsk-with-nac')
+	AuthMode                         string                                                             `json:"authMode,omitempty"`                         // The association control method for the SSID ('open', 'open-enhanced', 'psk', 'open-with-radius', 'open-with-nac', '8021x-meraki', '8021x-nac', '8021x-radius', '8021x-google', '8021x-entra', '8021x-localradius', 'ipsk-with-radius', 'ipsk-without-radius' or 'ipsk-with-nac')
 	AvailabilityTags                 []string                                                           `json:"availabilityTags,omitempty"`                 // Accepts a list of tags for this SSID. If availableOnAllAps is false, then the SSID will only be broadcast by APs with tags matching any of the tags in this list.
 	AvailableOnAllAps                *bool                                                              `json:"availableOnAllAps,omitempty"`                // Boolean indicating whether all APs should broadcast the SSID or if it should be restricted to APs matching any availability tags. Can only be false if the SSID has availability tags.
 	BandSelection                    string                                                             `json:"bandSelection,omitempty"`                    // The client-serving radio frequencies of this SSID in the default indoor RF profile. ('Dual band operation', '5 GHz band only' or 'Dual band operation with Band Steering')
@@ -3084,7 +3450,7 @@ type RequestWirelessUpdateNetworkWirelessSSID struct {
 	SecondaryConcentratorNetworkID   string                                                             `json:"secondaryConcentratorNetworkId,omitempty"`   // The secondary concentrator to use when the ipAssignmentMode is 'VPN'. If configured, the APs will switch to using this concentrator if the primary concentrator is unreachable. This param is optional. ('disabled' represents no secondary concentrator.)
 	SpeedBurst                       *RequestWirelessUpdateNetworkWirelessSSIDSpeedBurst                `json:"speedBurst,omitempty"`                       // The SpeedBurst setting for this SSID'
 	SplashGuestSponsorDomains        []string                                                           `json:"splashGuestSponsorDomains,omitempty"`        // Array of valid sponsor email domains for sponsored guest splash type.
-	SplashPage                       string                                                             `json:"splashPage,omitempty"`                       // The type of splash page for the SSID ('', 'Click-through splash page', 'Billing', 'Password-protected with Meraki RADIUS', 'Password-protected with custom RADIUS', 'Password-protected with Active Directory', 'Password-protected with LDAP', 'SMS authentication', 'Systems Manager Sentry', 'Facebook Wi-Fi', 'Google OAuth', 'Sponsored guest', 'Cisco ISE' or 'Google Apps domain'). This attribute is not supported for template children.
+	SplashPage                       string                                                             `json:"splashPage,omitempty"`                       // The type of splash page for the SSID ('', 'Click-through splash page', 'Billing', 'Password-protected with Meraki RADIUS', 'Password-protected with custom RADIUS', 'Password-protected with Active Directory', 'Password-protected with LDAP', 'SMS authentication', 'Systems Manager Sentry', 'Facebook Wi-Fi', 'Google OAuth', 'Microsoft Entra ID', 'Sponsored guest', 'Cisco ISE' or 'Google Apps domain'). This attribute is not supported for template children.
 	UseVLANTagging                   *bool                                                              `json:"useVlanTagging,omitempty"`                   // Whether or not traffic should be directed to use specific VLANs. This param is only valid if the ipAssignmentMode is 'Bridge mode' or 'Layer 3 roaming'
 	Visible                          *bool                                                              `json:"visible,omitempty"`                          // Boolean indicating whether APs should advertise or hide this SSID. APs will only broadcast this SSID if set to true
 	VLANID                           *int                                                               `json:"vlanId,omitempty"`                           // The VLAN ID used for VLAN tagging. This param is only valid when the ipAssignmentMode is 'Layer 3 roaming with a concentrator' or 'VPN'
@@ -3213,7 +3579,7 @@ type RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingException struct {
 }
 type RequestWirelessUpdateNetworkWirelessSSIDBonjourForwardingRules struct {
 	Description string   `json:"description,omitempty"` // A description for your Bonjour forwarding rule. Optional.
-	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AirPlay', 'AFP', 'BitTorrent', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners' and 'SSH'
+	Services    []string `json:"services,omitempty"`    // A list of Bonjour services. At least one service must be specified. Available services are 'All Services', 'AFP', 'AirPlay', 'Apple screen share', 'BitTorrent', 'Chromecast', 'FTP', 'iChat', 'iTunes', 'Printers', 'Samba', 'Scanners', 'Spotify' and 'SSH'
 	VLANID      string   `json:"vlanId,omitempty"`      // The ID of the service VLAN. Required.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDDeviceTypeGroupPolicies struct {
@@ -3264,7 +3630,6 @@ type RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRulesValue s
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 }
-
 type RequestWirelessUpdateNetworkWirelessSSIDHotspot20 struct {
 	Domains           []string                                                      `json:"domains,omitempty"`           // An array of domain names
 	Enabled           *bool                                                         `json:"enabled,omitempty"`           // Whether or not Hotspot 2.0 for this SSID is enabled
@@ -3437,13 +3802,16 @@ type RequestWirelessUpdateNetworkWirelessSSIDVpnSplitTunnelRules struct {
 	Policy   string `json:"policy,omitempty"`   // Traffic policy specified for this split tunnel rule, 'allow' or 'deny'.
 	Protocol string `json:"protocol,omitempty"` // Protocol for this split tunnel rule.
 }
+type RequestWirelessRecalculateOrganizationWirelessRadioAutoRfChannels struct {
+	NetworkIDs []string `json:"networkIds,omitempty"` // A list of network ids (limit: 15).
+}
 
 //GetDeviceWirelessBluetoothSettings Return the bluetooth settings for a wireless device
 /* Return the bluetooth settings for a wireless device
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-bluetooth-settings
+
 */
 func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*ResponseWirelessGetDeviceWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/bluetooth/settings"
@@ -3477,7 +3845,7 @@ func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*Re
 @param serial serial path parameter.
 @param getDeviceWirelessConnectionStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-connection-stats
+
 */
 func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDeviceWirelessConnectionStatsQueryParams *GetDeviceWirelessConnectionStatsQueryParams) (*ResponseWirelessGetDeviceWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/connectionStats"
@@ -3507,13 +3875,46 @@ func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDev
 
 }
 
+//GetDeviceWirelessElectronicShelfLabel Return the ESL settings of a device
+/* Return the ESL settings of a device
+
+@param serial serial path parameter.
+
+
+*/
+func (s *WirelessService) GetDeviceWirelessElectronicShelfLabel(serial string) (*ResponseWirelessGetDeviceWirelessElectronicShelfLabel, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/wireless/electronicShelfLabel"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseWirelessGetDeviceWirelessElectronicShelfLabel{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetDeviceWirelessElectronicShelfLabel")
+	}
+
+	result := response.Result().(*ResponseWirelessGetDeviceWirelessElectronicShelfLabel)
+	return result, response, err
+
+}
+
 //GetDeviceWirelessLatencyStats Aggregated latency info for a given AP on this network
 /* Aggregated latency info for a given AP on this network
 
 @param serial serial path parameter.
 @param getDeviceWirelessLatencyStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-latency-stats
+
 */
 func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDeviceWirelessLatencyStatsQueryParams *GetDeviceWirelessLatencyStatsQueryParams) (*ResponseWirelessGetDeviceWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/latencyStats"
@@ -3548,7 +3949,7 @@ func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDevice
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-radio-settings
+
 */
 func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*ResponseWirelessGetDeviceWirelessRadioSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/radio/settings"
@@ -3581,7 +3982,7 @@ func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*Respon
 
 @param serial serial path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-device-wireless-status
+
 */
 func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirelessGetDeviceWirelessStatus, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/status"
@@ -3615,7 +4016,7 @@ func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirel
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessAirMarshalQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-air-marshal
+
 */
 func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetworkWirelessAirMarshalQueryParams *GetNetworkWirelessAirMarshalQueryParams) (*ResponseWirelessGetNetworkWirelessAirMarshal, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/airMarshal"
@@ -3650,7 +4051,7 @@ func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetw
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-alternate-management-interface
+
 */
 func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(networkID string) (*ResponseWirelessGetNetworkWirelessAlternateManagementInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/alternateManagementInterface"
@@ -3683,7 +4084,7 @@ func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(network
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-billing
+
 */
 func (s *WirelessService) GetNetworkWirelessBilling(networkID string) (*ResponseWirelessGetNetworkWirelessBilling, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/billing"
@@ -3718,7 +4119,7 @@ Bluetooth settings
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-bluetooth-settings
+
 */
 func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) (*ResponseWirelessGetNetworkWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/bluetooth/settings"
@@ -3752,7 +4153,7 @@ func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessChannelUtilizationHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-channel-utilization-history
+
 */
 func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID string, getNetworkWirelessChannelUtilizationHistoryQueryParams *GetNetworkWirelessChannelUtilizationHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessChannelUtilizationHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/channelUtilizationHistory"
@@ -3788,7 +4189,7 @@ func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientCountHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-count-history
+
 */
 func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string, getNetworkWirelessClientCountHistoryQueryParams *GetNetworkWirelessClientCountHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientCountHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clientCountHistory"
@@ -3824,7 +4225,7 @@ func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string,
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientsConnectionStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-clients-connection-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID string, getNetworkWirelessClientsConnectionStatsQueryParams *GetNetworkWirelessClientsConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/connectionStats"
@@ -3860,7 +4261,7 @@ func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessClientsLatencyStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-clients-latency-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string, getNetworkWirelessClientsLatencyStatsQueryParams *GetNetworkWirelessClientsLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/latencyStats"
@@ -3897,7 +4298,7 @@ func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientConnectionStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-connection-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID string, clientID string, getNetworkWirelessClientConnectionStatsQueryParams *GetNetworkWirelessClientConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectionStats"
@@ -3935,7 +4336,7 @@ func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID stri
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientConnectivityEventsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-connectivity-events
+
 */
 func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID string, clientID string, getNetworkWirelessClientConnectivityEventsQueryParams *GetNetworkWirelessClientConnectivityEventsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectivityEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectivityEvents"
@@ -3973,7 +4374,7 @@ func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID s
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientLatencyHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-latency-history
+
 */
 func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID string, clientID string, getNetworkWirelessClientLatencyHistoryQueryParams *GetNetworkWirelessClientLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyHistory"
@@ -4011,7 +4412,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID strin
 @param clientID clientId path parameter. Client ID
 @param getNetworkWirelessClientLatencyStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-client-latency-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string, clientID string, getNetworkWirelessClientLatencyStatsQueryParams *GetNetworkWirelessClientLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyStats"
@@ -4048,7 +4449,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string,
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessConnectionStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-connection-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, getNetworkWirelessConnectionStatsQueryParams *GetNetworkWirelessConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/connectionStats"
@@ -4084,7 +4485,7 @@ func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, ge
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDataRateHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-data-rate-history
+
 */
 func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, getNetworkWirelessDataRateHistoryQueryParams *GetNetworkWirelessDataRateHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessDataRateHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/dataRateHistory"
@@ -4120,7 +4521,7 @@ func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, ge
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDevicesConnectionStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-devices-connection-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID string, getNetworkWirelessDevicesConnectionStatsQueryParams *GetNetworkWirelessDevicesConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/connectionStats"
@@ -4156,7 +4557,7 @@ func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessDevicesLatencyStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-devices-latency-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string, getNetworkWirelessDevicesLatencyStatsQueryParams *GetNetworkWirelessDevicesLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/latencyStats"
@@ -4186,12 +4587,78 @@ func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string
 
 }
 
+//GetNetworkWirelessElectronicShelfLabel Return the ESL settings of a wireless network
+/* Return the ESL settings of a wireless network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+func (s *WirelessService) GetNetworkWirelessElectronicShelfLabel(networkID string) (*ResponseWirelessGetNetworkWirelessElectronicShelfLabel, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/electronicShelfLabel"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseWirelessGetNetworkWirelessElectronicShelfLabel{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkWirelessElectronicShelfLabel")
+	}
+
+	result := response.Result().(*ResponseWirelessGetNetworkWirelessElectronicShelfLabel)
+	return result, response, err
+
+}
+
+//GetNetworkWirelessElectronicShelfLabelConfiguredDevices Get a list of all ESL eligible devices of a network
+/* Get a list of all ESL eligible devices of a network
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+func (s *WirelessService) GetNetworkWirelessElectronicShelfLabelConfiguredDevices(networkID string) (*ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/electronicShelfLabel/configuredDevices"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetResult(&ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetNetworkWirelessElectronicShelfLabelConfiguredDevices")
+	}
+
+	result := response.Result().(*ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices)
+	return result, response, err
+
+}
+
 //GetNetworkWirelessEthernetPortsProfiles List the AP port profiles for this network
 /* List the AP port profiles for this network
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ethernet-ports-profiles
+
 */
 func (s *WirelessService) GetNetworkWirelessEthernetPortsProfiles(networkID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles"
@@ -4225,7 +4692,7 @@ func (s *WirelessService) GetNetworkWirelessEthernetPortsProfiles(networkID stri
 @param networkID networkId path parameter. Network ID
 @param profileID profileId path parameter. Profile ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ethernet-ports-profile
+
 */
 func (s *WirelessService) GetNetworkWirelessEthernetPortsProfile(networkID string, profileID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}"
@@ -4260,7 +4727,7 @@ func (s *WirelessService) GetNetworkWirelessEthernetPortsProfile(networkID strin
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessFailedConnectionsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-failed-connections
+
 */
 func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, getNetworkWirelessFailedConnectionsQueryParams *GetNetworkWirelessFailedConnectionsQueryParams) (*ResponseWirelessGetNetworkWirelessFailedConnections, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/failedConnections"
@@ -4296,7 +4763,7 @@ func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, 
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessLatencyHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-latency-history
+
 */
 func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, getNetworkWirelessLatencyHistoryQueryParams *GetNetworkWirelessLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyHistory"
@@ -4332,7 +4799,7 @@ func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, get
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessLatencyStatsQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-latency-stats
+
 */
 func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNetworkWirelessLatencyStatsQueryParams *GetNetworkWirelessLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyStats"
@@ -4368,7 +4835,7 @@ func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNe
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessMeshStatusesQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-mesh-statuses
+
 */
 func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNetworkWirelessMeshStatusesQueryParams *GetNetworkWirelessMeshStatusesQueryParams) (*ResponseWirelessGetNetworkWirelessMeshStatuses, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/meshStatuses"
@@ -4404,7 +4871,7 @@ func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNe
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessRfProfilesQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-rf-profiles
+
 */
 func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetworkWirelessRfProfilesQueryParams *GetNetworkWirelessRfProfilesQueryParams) (*ResponseWirelessGetNetworkWirelessRfProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles"
@@ -4440,7 +4907,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetw
 @param networkID networkId path parameter. Network ID
 @param rfProfileID rfProfileId path parameter. Rf profile ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-rf-profile
+
 */
 func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfileID string) (*ResponseWirelessGetNetworkWirelessRfProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles/{rfProfileId}"
@@ -4474,7 +4941,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfil
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-settings
+
 */
 func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*ResponseWirelessGetNetworkWirelessSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/settings"
@@ -4508,7 +4975,7 @@ func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*Respons
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessSignalQualityHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-signal-quality-history
+
 */
 func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID string, getNetworkWirelessSignalQualityHistoryQueryParams *GetNetworkWirelessSignalQualityHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessSignalQualityHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/signalQualityHistory"
@@ -4543,7 +5010,7 @@ func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID strin
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssids
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWirelessGetNetworkWirelessSSIDs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids"
@@ -4577,7 +5044,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWi
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid
+
 */
 func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSID, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}"
@@ -4612,7 +5079,7 @@ func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-bonjour-forwarding
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDBonjourForwarding, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding"
@@ -4647,7 +5114,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID stri
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-device-type-group-policies
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPolicies, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/deviceTypeGroupPolicies"
@@ -4682,7 +5149,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-eap-override
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDEapOverride, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/eapOverride"
@@ -4717,7 +5184,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, nu
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-firewall-l3-firewall-rules
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules"
@@ -4752,7 +5219,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-firewall-l7-firewall-rules
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules"
@@ -4787,7 +5254,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkI
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-hotspot20
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDHotspot20, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/hotspot20"
@@ -4822,7 +5289,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, numb
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-identity-psks
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsks, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks"
@@ -4858,7 +5325,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, n
 @param number number path parameter.
 @param identityPskID identityPskId path parameter. Identity psk ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-identity-psk
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}"
@@ -4894,7 +5361,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, nu
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-schedules
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/schedules"
@@ -4929,7 +5396,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, numb
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-splash-settings
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSplashSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/splash/settings"
@@ -4964,7 +5431,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string,
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-traffic-shaping-rules
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules"
@@ -4999,7 +5466,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID st
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-ssid-vpn
+
 */
 func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDVpn, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/vpn"
@@ -5034,7 +5501,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number str
 @param networkID networkId path parameter. Network ID
 @param getNetworkWirelessUsageHistoryQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-network-wireless-usage-history
+
 */
 func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNetworkWirelessUsageHistoryQueryParams *GetNetworkWirelessUsageHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/usageHistory"
@@ -5064,13 +5531,121 @@ func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNe
 
 }
 
+//GetOrganizationWirelessAirMarshalRules Returns the current Air Marshal rules for this organization
+/* Returns the current Air Marshal rules for this organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessAirMarshalRulesQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessAirMarshalRules(organizationID string, getOrganizationWirelessAirMarshalRulesQueryParams *GetOrganizationWirelessAirMarshalRulesQueryParams) (*ResponseWirelessGetOrganizationWirelessAirMarshalRules, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/airMarshal/rules"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessAirMarshalRulesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessAirMarshalRules{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessAirMarshalRules")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessAirMarshalRules)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessAirMarshalSettingsByNetwork Returns the current Air Marshal settings for this network
+/* Returns the current Air Marshal settings for this network
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessAirMarshalSettingsByNetwork(organizationID string, getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams *GetOrganizationWirelessAirMarshalSettingsByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/airMarshal/settings/byNetwork"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessAirMarshalSettingsByNetwork")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessClientsOverviewByDevice List access point client count at the moment in an organization
+/* List access point client count at the moment in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessClientsOverviewByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessClientsOverviewByDevice(organizationID string, getOrganizationWirelessClientsOverviewByDeviceQueryParams *GetOrganizationWirelessClientsOverviewByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/clients/overview/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessClientsOverviewByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessClientsOverviewByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice)
+	return result, response, err
+
+}
+
 //GetOrganizationWirelessDevicesChannelUtilizationByDevice Get average channel utilization for all bands in a network, split by AP
 /* Get average channel utilization for all bands in a network, split by AP
 
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-device
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
@@ -5106,7 +5681,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevi
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-by-network
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
@@ -5142,7 +5717,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetw
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-device-by-interval
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
@@ -5178,7 +5753,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-channel-utilization-history-by-network-by-interval
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
@@ -5214,7 +5789,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesEthernetStatusesQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-ethernet-statuses
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organizationID string, getOrganizationWirelessDevicesEthernetStatusesQueryParams *GetOrganizationWirelessDevicesEthernetStatusesQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/ethernet/statuses"
@@ -5250,7 +5825,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organiz
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByClientQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-client
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
@@ -5286,7 +5861,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organ
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByDeviceQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-device
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
@@ -5322,7 +5897,7 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organ
 @param organizationID organizationId path parameter. Organization ID
 @param getOrganizationWirelessDevicesPacketLossByNetworkQueryParams Filtering parameter
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!get-organization-wireless-devices-packet-loss-by-network
+
 */
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
@@ -5352,12 +5927,155 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(orga
 
 }
 
+//GetOrganizationWirelessDevicesWirelessControllersByDevice List of Catalyst access points information
+/* List of Catalyst access points information
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams *GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/devices/wirelessControllers/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesWirelessControllersByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessRfProfilesAssignmentsByDevice List the RF profiles of an organization by device
+/* List the RF profiles of an organization by device
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessRfProfilesAssignmentsByDevice(organizationID string, getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams *GetOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/rfProfiles/assignments/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessRfProfilesAssignmentsByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessSSIDsStatusesByDevice List status information of all BSSIDs in your organization
+/* List status information of all BSSIDs in your organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessSsidsStatusesByDeviceQueryParams Filtering parameter
+
+
+*/
+func (s *WirelessService) GetOrganizationWirelessSSIDsStatusesByDevice(organizationID string, getOrganizationWirelessSsidsStatusesByDeviceQueryParams *GetOrganizationWirelessSSIDsStatusesByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/ssids/statuses/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessSsidsStatusesByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessSsidsStatusesByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice)
+	return result, response, err
+
+}
+
+//CreateNetworkWirelessAirMarshalRule Creates a new rule
+/* Creates a new rule
+
+@param networkID networkId path parameter. Network ID
+
+
+*/
+
+func (s *WirelessService) CreateNetworkWirelessAirMarshalRule(networkID string, requestWirelessCreateNetworkWirelessAirMarshalRule *RequestWirelessCreateNetworkWirelessAirMarshalRule) (*ResponseWirelessCreateNetworkWirelessAirMarshalRule, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/airMarshal/rules"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessCreateNetworkWirelessAirMarshalRule).
+		SetResult(&ResponseWirelessCreateNetworkWirelessAirMarshalRule{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation CreateNetworkWirelessAirMarshalRule")
+	}
+
+	result := response.Result().(*ResponseWirelessCreateNetworkWirelessAirMarshalRule)
+	return result, response, err
+
+}
+
 //CreateNetworkWirelessEthernetPortsProfile Create an AP port profile
 /* Create an AP port profile
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-ethernet-ports-profile
+
 */
 
 func (s *WirelessService) CreateNetworkWirelessEthernetPortsProfile(networkID string, requestWirelessCreateNetworkWirelessEthernetPortsProfile *RequestWirelessCreateNetworkWirelessEthernetPortsProfile) (*ResponseWirelessCreateNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
@@ -5392,7 +6110,7 @@ func (s *WirelessService) CreateNetworkWirelessEthernetPortsProfile(networkID st
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!assign-network-wireless-ethernet-ports-profiles
+
 */
 
 func (s *WirelessService) AssignNetworkWirelessEthernetPortsProfiles(networkID string, requestWirelessAssignNetworkWirelessEthernetPortsProfiles *RequestWirelessAssignNetworkWirelessEthernetPortsProfiles) (*ResponseWirelessAssignNetworkWirelessEthernetPortsProfiles, *resty.Response, error) {
@@ -5427,7 +6145,7 @@ func (s *WirelessService) AssignNetworkWirelessEthernetPortsProfiles(networkID s
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!set-network-wireless-ethernet-ports-profiles-default
+
 */
 
 func (s *WirelessService) SetNetworkWirelessEthernetPortsProfilesDefault(networkID string, requestWirelessSetNetworkWirelessEthernetPortsProfilesDefault *RequestWirelessSetNetworkWirelessEthernetPortsProfilesDefault) (*ResponseWirelessSetNetworkWirelessEthernetPortsProfilesDefault, *resty.Response, error) {
@@ -5462,7 +6180,7 @@ func (s *WirelessService) SetNetworkWirelessEthernetPortsProfilesDefault(network
 
 @param networkID networkId path parameter. Network ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-rf-profile
+
 */
 
 func (s *WirelessService) CreateNetworkWirelessRfProfile(networkID string, requestWirelessCreateNetworkWirelessRfProfile *RequestWirelessCreateNetworkWirelessRfProfile) (*ResponseWirelessCreateNetworkWirelessRfProfile, *resty.Response, error) {
@@ -5498,7 +6216,7 @@ func (s *WirelessService) CreateNetworkWirelessRfProfile(networkID string, reque
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!create-network-wireless-ssid-identity-psk
+
 */
 
 func (s *WirelessService) CreateNetworkWirelessSSIDIDentityPsk(networkID string, number string, requestWirelessCreateNetworkWirelessSsidIdentityPsk *RequestWirelessCreateNetworkWirelessSSIDIDentityPsk) (*ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
@@ -5525,6 +6243,41 @@ func (s *WirelessService) CreateNetworkWirelessSSIDIDentityPsk(networkID string,
 	}
 
 	result := response.Result().(*ResponseWirelessCreateNetworkWirelessSSIDIDentityPsk)
+	return result, response, err
+
+}
+
+//RecalculateOrganizationWirelessRadioAutoRfChannels Recalculates automatically assigned channels for every AP within specified the specified network(s)
+/* Recalculates automatically assigned channels for every AP within specified the specified network(s). Note: This could cause a brief loss in connectivity for wireless clients.
+
+@param organizationID organizationId path parameter. Organization ID
+
+
+*/
+
+func (s *WirelessService) RecalculateOrganizationWirelessRadioAutoRfChannels(organizationID string, requestWirelessRecalculateOrganizationWirelessRadioAutoRfChannels *RequestWirelessRecalculateOrganizationWirelessRadioAutoRfChannels) (*ResponseWirelessRecalculateOrganizationWirelessRadioAutoRfChannels, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wireless/radio/autoRf/channels/recalculate"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessRecalculateOrganizationWirelessRadioAutoRfChannels).
+		SetResult(&ResponseWirelessRecalculateOrganizationWirelessRadioAutoRfChannels{}).
+		SetError(&Error).
+		Post(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation RecalculateOrganizationWirelessRadioAutoRfChannels")
+	}
+
+	result := response.Result().(*ResponseWirelessRecalculateOrganizationWirelessRadioAutoRfChannels)
 	return result, response, err
 
 }
@@ -5593,6 +6346,38 @@ func (s *WirelessService) UpdateDeviceWirelessBluetoothSettings(serial string, r
 
 }
 
+//UpdateDeviceWirelessElectronicShelfLabel Update the ESL settings of a device
+/* Update the ESL settings of a device
+
+@param serial serial path parameter.
+*/
+func (s *WirelessService) UpdateDeviceWirelessElectronicShelfLabel(serial string, requestWirelessUpdateDeviceWirelessElectronicShelfLabel *RequestWirelessUpdateDeviceWirelessElectronicShelfLabel) (*ResponseWirelessUpdateDeviceWirelessElectronicShelfLabel, *resty.Response, error) {
+	path := "/api/v1/devices/{serial}/wireless/electronicShelfLabel"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateDeviceWirelessElectronicShelfLabel).
+		SetResult(&ResponseWirelessUpdateDeviceWirelessElectronicShelfLabel{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateDeviceWirelessElectronicShelfLabel")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateDeviceWirelessElectronicShelfLabel)
+	return result, response, err
+
+}
+
 //UpdateDeviceWirelessRadioSettings Update the radio settings of a device
 /* Update the radio settings of a device
 
@@ -5620,6 +6405,72 @@ func (s *WirelessService) UpdateDeviceWirelessRadioSettings(serial string, reque
 	}
 
 	return response, err
+
+}
+
+//UpdateNetworkWirelessAirMarshalRule Update a rule
+/* Update a rule
+
+@param networkID networkId path parameter. Network ID
+@param ruleID ruleId path parameter. Rule ID
+*/
+func (s *WirelessService) UpdateNetworkWirelessAirMarshalRule(networkID string, ruleID string, requestWirelessUpdateNetworkWirelessAirMarshalRule *RequestWirelessUpdateNetworkWirelessAirMarshalRule) (*ResponseWirelessUpdateNetworkWirelessAirMarshalRule, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/airMarshal/rules/{ruleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{ruleId}", fmt.Sprintf("%v", ruleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateNetworkWirelessAirMarshalRule).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessAirMarshalRule{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessAirMarshalRule")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessAirMarshalRule)
+	return result, response, err
+
+}
+
+//UpdateNetworkWirelessAirMarshalSettings Updates Air Marshal settings.
+/* Updates Air Marshal settings.
+
+@param networkID networkId path parameter. Network ID
+*/
+func (s *WirelessService) UpdateNetworkWirelessAirMarshalSettings(networkID string, requestWirelessUpdateNetworkWirelessAirMarshalSettings *RequestWirelessUpdateNetworkWirelessAirMarshalSettings) (*ResponseWirelessUpdateNetworkWirelessAirMarshalSettings, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/airMarshal/settings"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateNetworkWirelessAirMarshalSettings).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessAirMarshalSettings{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessAirMarshalSettings")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessAirMarshalSettings)
+	return result, response, err
 
 }
 
@@ -5719,6 +6570,38 @@ func (s *WirelessService) UpdateNetworkWirelessBluetoothSettings(networkID strin
 
 }
 
+//UpdateNetworkWirelessElectronicShelfLabel Update the ESL settings of a wireless network
+/* Update the ESL settings of a wireless network
+
+@param networkID networkId path parameter. Network ID
+*/
+func (s *WirelessService) UpdateNetworkWirelessElectronicShelfLabel(networkID string, requestWirelessUpdateNetworkWirelessElectronicShelfLabel *RequestWirelessUpdateNetworkWirelessElectronicShelfLabel) (*ResponseWirelessUpdateNetworkWirelessElectronicShelfLabel, *resty.Response, error) {
+	path := "/api/v1/networks/{networkId}/wireless/electronicShelfLabel"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetBody(requestWirelessUpdateNetworkWirelessElectronicShelfLabel).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessElectronicShelfLabel{}).
+		SetError(&Error).
+		Put(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessElectronicShelfLabel")
+	}
+
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessElectronicShelfLabel)
+	return result, response, err
+
+}
+
 //UpdateNetworkWirelessEthernetPortsProfile Update the AP port profile by ID for this network
 /* Update the AP port profile by ID for this network
 
@@ -5754,7 +6637,7 @@ func (s *WirelessService) UpdateNetworkWirelessEthernetPortsProfile(networkID st
 }
 
 //UpdateNetworkWirelessRfProfile Updates specified RF profile for this network
-/* Updates specified RF profile for this network
+/* Updates specified RF profile for this network. Note: built-in RF profiles can only be assigned as a default, and its attributes are immutable
 
 @param networkID networkId path parameter. Network ID
 @param rfProfileID rfProfileId path parameter. Rf profile ID
@@ -6095,7 +6978,7 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDIDentityPsk(networkID string,
 @param networkID networkId path parameter. Network ID
 @param number number path parameter.
 */
-func (s *WirelessService) UpdateNetworkWirelessSSIDSchedules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidSchedules *RequestWirelessUpdateNetworkWirelessSSIDSchedules) (*resty.Response, error) {
+func (s *WirelessService) UpdateNetworkWirelessSSIDSchedules(networkID string, number string, requestWirelessUpdateNetworkWirelessSsidSchedules *RequestWirelessUpdateNetworkWirelessSSIDSchedules) (*ResponseWirelessUpdateNetworkWirelessSSIDSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/schedules"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
@@ -6105,19 +6988,21 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDSchedules(networkID string, n
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetBody(requestWirelessUpdateNetworkWirelessSsidSchedules).
+		SetResult(&ResponseWirelessUpdateNetworkWirelessSSIDSchedules{}).
 		SetError(&Error).
 		Put(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidSchedules")
+		return nil, response, fmt.Errorf("error with operation UpdateNetworkWirelessSsidSchedules")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseWirelessUpdateNetworkWirelessSSIDSchedules)
+	return result, response, err
 
 }
 
@@ -6221,13 +7106,47 @@ func (s *WirelessService) UpdateNetworkWirelessSSIDVpn(networkID string, number 
 
 }
 
+//DeleteNetworkWirelessAirMarshalRule Delete an Air Marshal rule.
+/* Delete an Air Marshal rule.
+
+@param networkID networkId path parameter. Network ID
+@param ruleID ruleId path parameter. Rule ID
+
+
+*/
+func (s *WirelessService) DeleteNetworkWirelessAirMarshalRule(networkID string, ruleID string) (*resty.Response, error) {
+	//networkID string,ruleID string
+	path := "/api/v1/networks/{networkId}/wireless/airMarshal/rules/{ruleId}"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
+	path = strings.Replace(path, "{ruleId}", fmt.Sprintf("%v", ruleID), -1)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetError(&Error).
+		Delete(path)
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	if response.IsError() {
+		return response, fmt.Errorf("error with operation DeleteNetworkWirelessAirMarshalRule")
+	}
+
+	return response, err
+
+}
+
 //DeleteNetworkWirelessEthernetPortsProfile Delete an AP port profile
 /* Delete an AP port profile
 
 @param networkID networkId path parameter. Network ID
 @param profileID profileId path parameter. Profile ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-ethernet-ports-profile
+
 */
 func (s *WirelessService) DeleteNetworkWirelessEthernetPortsProfile(networkID string, profileID string) (*resty.Response, error) {
 	//networkID string,profileID string
@@ -6261,7 +7180,7 @@ func (s *WirelessService) DeleteNetworkWirelessEthernetPortsProfile(networkID st
 @param networkID networkId path parameter. Network ID
 @param rfProfileID rfProfileId path parameter. Rf profile ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-rf-profile
+
 */
 func (s *WirelessService) DeleteNetworkWirelessRfProfile(networkID string, rfProfileID string) (*resty.Response, error) {
 	//networkID string,rfProfileID string
@@ -6296,7 +7215,7 @@ func (s *WirelessService) DeleteNetworkWirelessRfProfile(networkID string, rfPro
 @param number number path parameter.
 @param identityPskID identityPskId path parameter. Identity psk ID
 
-Documentation Link: https://developer.cisco.com/docs/dna-center/#!delete-network-wireless-ssid-identity-psk
+
 */
 func (s *WirelessService) DeleteNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string) (*resty.Response, error) {
 	//networkID string,number string,identityPskID string

--- a/sdk/wireless_controller.go
+++ b/sdk/wireless_controller.go
@@ -1,0 +1,1216 @@
+package meraki
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/google/go-querystring/query"
+)
+
+type WirelessControllerService service
+
+type GetOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter wireless LAN controllers by network ID. This filter uses multiple exact matches.
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	Resolution    int      `url:"resolution,omitempty"`    //The time resolution in seconds for returned data. The valid resolutions are: 300, 600, 1200, 3600, 14400, 86400. The default is 86400.
+}
+type GetOrganizationWirelessControllerConnectionsQueryParams struct {
+	NetworkIDs        []string `url:"networkIds[],omitempty"`        //Optional parameter to filter access points by network ID. This filter uses multiple exact matches.
+	ControllerSerials []string `url:"controllerSerials[],omitempty"` //Optional parameter to filter access points by its controller cloud ID. This filter uses multiple exact matches.
+	PerPage           int      `url:"perPage,omitempty"`             //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter     string   `url:"startingAfter,omitempty"`       //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore      string   `url:"endingBefore,omitempty"`        //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams struct {
+	Serials                         []string `url:"serials[],omitempty"`                       //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	IncludeInterfacesWithoutChanges bool     `url:"includeInterfacesWithoutChanges,omitempty"` //By default, interfaces without changes are omitted from the response for brevity. If you want to include the interfaces even if they have no changes, set to true. (default: false)
+	T0                              string   `url:"t0,omitempty"`                              //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1                              string   `url:"t1,omitempty"`                              //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan                        float64  `url:"timespan,omitempty"`                        //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage                         int      `url:"perPage,omitempty"`                         //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter                   string   `url:"startingAfter,omitempty"`                   //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore                    string   `url:"endingBefore,omitempty"`                    //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams struct {
+	Serials                         []string `url:"serials[],omitempty"`                       //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	IncludeInterfacesWithoutChanges bool     `url:"includeInterfacesWithoutChanges,omitempty"` //By default, interfaces without changes are omitted from the response for brevity. If you want to include the interfaces even if they have no changes, set to true. (default: false)
+	T0                              string   `url:"t0,omitempty"`                              //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1                              string   `url:"t1,omitempty"`                              //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan                        float64  `url:"timespan,omitempty"`                        //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage                         int      `url:"perPage,omitempty"`                         //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter                   string   `url:"startingAfter,omitempty"`                   //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore                    string   `url:"endingBefore,omitempty"`                    //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	Names         []string `url:"names[],omitempty"`       //Optional parameter to filter wireless LAN controller by its interface name. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 1 day from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 1 day after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 1 day. The default is 1 hour.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	Names         []string `url:"names[],omitempty"`       //Optional parameter to filter wireless LAN controller by its interface name. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud IDs. This filter uses multiple exact matches.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams struct {
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+type GetOrganizationWirelessControllerOverviewByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Optional parameter to filter wireless LAN controllers by network ID. This filter uses multiple exact matches.
+	Serials       []string `url:"serials[],omitempty"`     //Optional parameter to filter wireless LAN controller by its cloud ID. This filter uses multiple exact matches.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+}
+
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryItems `json:"items,omitempty"` // Wireless LAN controller connectivity information
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryItems struct {
+	Changes *[]ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryItemsChanges `json:"changes,omitempty"` // Connectivity information of a wireless LAN controller
+	Serial  string                                                                                                `json:"serial,omitempty"`  // Wireless LAN controller cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryItemsChanges struct {
+	EndTs   string `json:"endTs,omitempty"`   // The end time(UTC seconds) of the wireless LAN controller connectivity status change. This attribute is set to be null by default if there's no need to assign.
+	StartTs string `json:"startTs,omitempty"` // The start time(UTC seconds) of the wireless LAN controller connectivity status change
+	Status  string `json:"status,omitempty"`  // The wireless LAN controller connectivity status
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistoryMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItems `json:"items,omitempty"` // Overview history of wireless LAN controllers
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItems struct {
+	Network  *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsNetwork    `json:"network,omitempty"`  // Wireless LAN controller network
+	Readings *[]ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadings `json:"readings,omitempty"` // Overview history of a wireless LAN controller
+	Serial   string                                                                                                              `json:"serial,omitempty"`   // Wireless LAN controller cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Wireless LAN controller network ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadings struct {
+	Counts  *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadingsCounts `json:"counts,omitempty"`  // Client counts
+	EndTs   string                                                                                                                  `json:"endTs,omitempty"`   // The end time of the query range
+	StartTs string                                                                                                                  `json:"startTs,omitempty"` // The start time of the query range
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadingsCounts struct {
+	ByStatus *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadingsCountsByStatus `json:"byStatus,omitempty"` // Client counts by its status
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalItemsReadingsCountsByStatus struct {
+	Online *int `json:"online,omitempty"` // Number of connected clients
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnections struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItems `json:"items,omitempty"` // Access points associated with Wireless LAN controllers
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItems struct {
+	Controller *ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItemsController `json:"controller,omitempty"` // Associated wireless LAN controller
+	Network    *ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItemsNetwork    `json:"network,omitempty"`    // Access points network
+	Serial     string                                                                                 `json:"serial,omitempty"`     // Access points cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItemsController struct {
+	Serial string `json:"serial,omitempty"` // Associated wireless LAN controller cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsItemsNetwork struct {
+	ID   string `json:"id,omitempty"`   // Access points network ID
+	Name string `json:"name,omitempty"` // Access points network name
+	URL  string `json:"url,omitempty"`  // Access points network URL
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerConnectionsMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L2 interfaces
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems struct {
+	Interfaces *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces struct {
+	ChannelGroup     *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`     // The channel group of this wireless LAN controller interface
+	Description      string                                                                                                             `json:"description,omitempty"`      // The description of the wireless LAN controller interface
+	Enabled          *bool                                                                                                              `json:"enabled,omitempty"`          // The status of the wireless LAN controller interface
+	IsRedundancyPort *bool                                                                                                              `json:"isRedundancyPort,omitempty"` // Indicate whether the interface is a redundancy port used to perform HA role negotiation
+	IsUplink         *bool                                                                                                              `json:"isUplink,omitempty"`         // Indicate whether the interface is uplink
+	LinkNegotiation  string                                                                                                             `json:"linkNegotiation,omitempty"`  // The interface negotiation mode
+	Mac              string                                                                                                             `json:"mac,omitempty"`              // The MAC address of the wireless LAN controller interface
+	Module           *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule       `json:"module,omitempty"`           // The module of this wireless LAN controller interface
+	Name             string                                                                                                             `json:"name,omitempty"`             // The name of the wireless LAN controller interface
+	Speed            string                                                                                                             `json:"speed,omitempty"`            // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status           string                                                                                                             `json:"status,omitempty"`           // The status of the wireless LAN controller interface
+	VLAN             *int                                                                                                               `json:"vlan,omitempty"`             // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup struct {
+	Number *int `json:"number,omitempty"` // The interface channel group number
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule struct {
+	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces historical status
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                                        `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 2 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                               `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                               `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
+	Status   string   `json:"status,omitempty"`   // The status of the interface
+	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
+	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces usage
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 2 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                               `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings struct {
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
+	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
+	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
+	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L3 interfaces
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems struct {
+	Interfaces *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces struct {
+	Addresses       *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses  `json:"addresses,omitempty"`       // Available addresses for the interface.
+	ChannelGroup    *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`    // The channel group of this wireless LAN controller interface
+	Description     string                                                                                                             `json:"description,omitempty"`     // The description of the wireless LAN controller interface
+	IsUplink        *bool                                                                                                              `json:"isUplink,omitempty"`        // Indicate whether the interface is uplink
+	LinkNegotiation string                                                                                                             `json:"linkNegotiation,omitempty"` // The interface negotiation mode
+	Mac             string                                                                                                             `json:"mac,omitempty"`             // The MAC address of the wireless LAN controller interface
+	Module          *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule       `json:"module,omitempty"`          // The module of this wireless LAN controller interface
+	Name            string                                                                                                             `json:"name,omitempty"`            // The name of the wireless LAN controller interface
+	Speed           string                                                                                                             `json:"speed,omitempty"`           // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status          string                                                                                                             `json:"status,omitempty"`          // The status of the wireless LAN controller interface
+	VLAN            *int                                                                                                               `json:"vlan,omitempty"`            // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	Vrf             *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf          `json:"vrf,omitempty"`             // The virtual routing and forwarding (VRF) for the wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses struct {
+	Address  string `json:"address,omitempty"`  // The address of the wireless LAN controller interface
+	Protocol string `json:"protocol,omitempty"` // Type of address for the device uplink. Available options are: ipv4, ipv6. enum = [ipv4, ipv6]
+	Subnet   string `json:"subnet,omitempty"`   // The address of the wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup struct {
+	Number *int `json:"number,omitempty"` // The interface channel group number
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule struct {
+	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf struct {
+	Name string `json:"name,omitempty"` // The virtual routing and forwarding (VRF) name
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces historical status
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                                        `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 3 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                               `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                               `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
+	Status   string   `json:"status,omitempty"`   // The status of the interface
+	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
+	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces usage
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 3 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                               `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings struct {
+	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
+	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
+	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
+	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems `json:"items,omitempty"` // Wireless LAN controller interfaces packets statuses
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems struct {
+	Interfaces *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                                `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces struct {
+	Name     string                                                                                                                        `json:"name,omitempty"`     // The name of the wireless LAN controller interface
+	Readings *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings `json:"readings,omitempty"` // The status of packets counter on the interfaces of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings struct {
+	Name  string                                                                                                                          `json:"name,omitempty"`  // The type of packets being counted
+	Rate  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate `json:"rate,omitempty"`  // The interface packet rates measured in packets per second
+	Recv  *int                                                                                                                            `json:"recv,omitempty"`  // The total count of packets received by the interface during the timespan
+	Send  *int                                                                                                                            `json:"send,omitempty"`  // The total count of packets sent by the interface during the timespan
+	Total *int                                                                                                                            `json:"total,omitempty"` // The total count of sent and received packets during the timespan
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate struct {
+	Recv  *int `json:"recv,omitempty"`  // The rate of packets received during the timespan
+	Send  *int `json:"send,omitempty"`  // The rate of packets sent during the timespan
+	Total *int `json:"total,omitempty"` // The rate of all packets sent and received during the timespan
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller interfaces usage data
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems struct {
+	Intervals *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of interfaces usage data of the wireless LAN controller
+	Serial    string                                                                                                              `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals struct {
+	ByInterface *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface `json:"byInterface,omitempty"` // The usage data on the interfaces of the wireless LAN controller
+	EndTs       string                                                                                                                         `json:"endTs,omitempty"`       // The end time interval snapshots of the query range with iso8601 format
+	Overall     *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall       `json:"overall,omitempty"`     // The overall usage of all queried interfaces of the wireless LAN controller
+	StartTs     string                                                                                                                         `json:"startTs,omitempty"`     // The start time interval snapshots of the query range with iso8601 format
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface struct {
+	Name  string                                                                                                                            `json:"name,omitempty"`  // The name of the wireless LAN controller interface
+	Usage *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage `json:"usage,omitempty"` // The usage on the interfaces of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage struct {
+	Recv  *int `json:"recv,omitempty"`  // The received usage on the interface during the interval, unit is bit/sec
+	Send  *int `json:"send,omitempty"`  // The sent usage on the interface during the interval, unit is bit/sec
+	Total *int `json:"total,omitempty"` // The total usage on the interface during the interval, unit is bit/sec
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall struct {
+	Recv  *int `json:"recv,omitempty"`  // The received usage of all queried interfaces during the interval, unit is bit/sec
+	Send  *int `json:"send,omitempty"`  // The sent usage of all queried interfaces during the interval, unit is bit/sec
+	Total *int `json:"total,omitempty"` // The total usage of all queried interfaces during the interval, unit is bit/sec
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory []ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory // Array of ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory struct {
+	Items *[]ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems `json:"items,omitempty"` // Wireless LAN controller HA failover events
+	Meta  *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems struct {
+	Active *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive `json:"active,omitempty"` // Details about the active unit
+	Failed *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed `json:"failed,omitempty"` // Details about the failed unit
+	Reason string                                                                                                      `json:"reason,omitempty"` // Failover reason
+	Serial string                                                                                                      `json:"serial,omitempty"` // Wireless LAN controller cloud ID
+	Ts     string                                                                                                      `json:"ts,omitempty"`     // Failover time
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive struct {
+	Chassis *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis `json:"chassis,omitempty"` // Details about the active unit chassis
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis struct {
+	Name string `json:"name,omitempty"` // The name of the active chassis unit
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed struct {
+	Chassis *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis `json:"chassis,omitempty"` // Details about the failed unit chassis
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis struct {
+	Name string `json:"name,omitempty"` // The name of the failed chassis unit
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta struct {
+	Counts *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts struct {
+	Items *ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItems `json:"items,omitempty"` // Wireless LAN controller redundancy statuses
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItems struct {
+	Enabled     *bool                                                                                              `json:"enabled,omitempty"`     // Wireless LAN controller redundancy enablement
+	Failover    *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover `json:"failover,omitempty"`    // Wireless LAN controller failover information
+	MobilityMac string                                                                                             `json:"mobilityMac,omitempty"` // Wireless LAN controller redundancy mobility mac
+	Mode        string                                                                                             `json:"mode,omitempty"`        // Wireless LAN controller redundancy SSO (stateful switchover)
+	Serial      string                                                                                             `json:"serial,omitempty"`      // Wireless LAN controller cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts `json:"counts,omitempty"` // Wireless LAN controller switchover counts
+	Last   *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast   `json:"last,omitempty"`   // Wireless LAN controller last failover information
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts struct {
+	Total *int `json:"total,omitempty"` // Total number of failovers
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast struct {
+	Reason string `json:"reason,omitempty"` // Wireless LAN controller last redundancy switchover reason
+	Ts     string `json:"ts,omitempty"`     // Wireless LAN controller last redundancy switchover time
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller CPU usage data
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems struct {
+	Intervals *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of CPU usage data of the wireless LAN controller
+	Serial    string                                                                                                                `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals struct {
+	ByCore  *[]ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore `json:"byCore,omitempty"`  // The CPU usage per core of the wireless LAN controller
+	EndTs   string                                                                                                                      `json:"endTs,omitempty"`   // The end time of the query range  with iso8601 format
+	Overall *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall  `json:"overall,omitempty"` // The overall CPU usage of the wireless LAN controller
+	StartTs string                                                                                                                      `json:"startTs,omitempty"` // The start time of the query range with iso8601 format
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore struct {
+	Name  string                                                                                                                         `json:"name,omitempty"`  // The CPU core name
+	Usage *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage `json:"usage,omitempty"` // The specific core CPU usage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage struct {
+	Average *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage `json:"average,omitempty"` // The specific core average CPU usage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage struct {
+	Percentage *float64 `json:"percentage,omitempty"` // The specific core CPU usage percentage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall struct {
+	Usage *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage `json:"usage,omitempty"` // The CPU usage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage struct {
+	Average *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage `json:"average,omitempty"` // The average CPU usage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage struct {
+	Percentage *float64 `json:"percentage,omitempty"` // The CPU usage percentage of the wireless LAN controller
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice struct {
+	Items *[]ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItems `json:"items,omitempty"` // Wireless LAN controller overview
+	Meta  *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItems struct {
+	Counts     *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCounts     `json:"counts,omitempty"`     // Wireless LAN controller client and access point counts
+	Firmware   *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsFirmware   `json:"firmware,omitempty"`   // Wireless LAN controller device firmware information
+	Network    *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsNetwork    `json:"network,omitempty"`    // Wireless LAN controller network
+	Redundancy *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancy `json:"redundancy,omitempty"` // Wireless LAN controller redundancy information
+	Serial     string                                                                                      `json:"serial,omitempty"`     // Wireless LAN controller cloud ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCounts struct {
+	Clients     *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsClients     `json:"clients,omitempty"`     // Wireless LAN controller client counts
+	Connections *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsConnections `json:"connections,omitempty"` // Wireless LAN controller associated access point counts
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsClients struct {
+	ByStatus *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsClientsByStatus `json:"byStatus,omitempty"` // Client counts by their status
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsClientsByStatus struct {
+	Online *int `json:"online,omitempty"` // Wireless LAN controller active client count
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsConnections struct {
+	ByStatus *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsConnectionsByStatus `json:"byStatus,omitempty"` // Access point counts by their status
+	Total    *int                                                                                                       `json:"total,omitempty"`    // Wireless LAN controller associated total access point count
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsCountsConnectionsByStatus struct {
+	Offline *int `json:"offline,omitempty"` // Wireless LAN controller associated offline access point count
+	Online  *int `json:"online,omitempty"`  // Wireless LAN controller associated online access point count
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsFirmware struct {
+	Version *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsFirmwareVersion `json:"version,omitempty"` // Wireless LAN controller firmware version
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsFirmwareVersion struct {
+	ShortName string `json:"shortName,omitempty"` // Wireless LAN controller firmware version short name
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsNetwork struct {
+	ID string `json:"id,omitempty"` // Wireless LAN controller network ID
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancy struct {
+	ChassisName string                                                                                                `json:"chassisName,omitempty"` // Wireless LAN controller chassis name
+	ID          string                                                                                                `json:"id,omitempty"`          // Wireless LAN controller redundancy ID
+	Management  *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancyManagement `json:"management,omitempty"`  // Wireless LAN controller redundancy management interface information
+	Role        string                                                                                                `json:"role,omitempty"`        // Wireless LAN controller role(Active, Active recovery, Standby hot, Standby recovery and Offline)
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancyManagement struct {
+	Addresses *[]ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancyManagementAddresses `json:"addresses,omitempty"` // Wireless LAN controller redundancy management interface addresses
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceItemsRedundancyManagementAddresses struct {
+	Address string `json:"address,omitempty"` // Wireless LAN controller redundancy management interface ip address
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMeta struct {
+	Counts *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMetaCounts struct {
+	Items *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDeviceMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+
+//GetOrganizationWirelessControllerAvailabilitiesChangeHistory List connectivity data of wireless LAN controllers in an organization
+/* List connectivity data of wireless LAN controllers in an organization. If it is HA setup, then only returns active WLC data start from switchover
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerAvailabilitiesChangeHistory(organizationID string, getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams *GetOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/availabilities/changeHistory"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerAvailabilitiesChangeHistory")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval List wireless client counts of wireless LAN controllers over time in an organization
+/* List wireless client counts of wireless LAN controllers over time in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/clients/overview/history/byDevice/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerConnections List all access points associated with wireless LAN controllers in an organization
+/* List all access points associated with wireless LAN controllers in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerConnectionsQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerConnections(organizationID string, getOrganizationWirelessControllerConnectionsQueryParams *GetOrganizationWirelessControllerConnectionsQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerConnections, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/connections"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerConnectionsQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerConnections{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerConnections")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerConnections)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice List wireless LAN controller layer 2 interfaces in an organization
+/* List wireless LAN controller layer 2 interfaces in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice List wireless LAN controller layer 2 interfaces history status in an organization
+/* List wireless LAN controller layer 2 interfaces history status in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/statuses/changeHistory/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval List wireless LAN controller layer 2 interfaces history usage in an organization
+/* List wireless LAN controller layer 2 interfaces history usage in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice List wireless LAN controller layer 3 interfaces in an organization
+/* List wireless LAN controller layer 3 interfaces in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice List wireless LAN controller layer 3 interfaces history status in an organization
+/* List wireless LAN controller layer 3 interfaces history status in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/statuses/changeHistory/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval List wireless LAN controller layer 3 interfaces history usage in an organization
+/* List wireless LAN controller layer 3 interfaces history usage in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice Retrieve the packet counters for the interfaces of a Wireless LAN controller
+/* Retrieve the packet counters for the interfaces of a Wireless LAN controller
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/packets/overview/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval Retrieve the traffic for the interfaces of a Wireless LAN controller
+/* Retrieve the traffic for the interfaces of a Wireless LAN controller
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/usage/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory List the failover events of wireless LAN controllers in an organization
+/* List the failover events of wireless LAN controllers in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams *GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/failover/history"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesRedundancyStatuses List redundancy details of wireless LAN controllers in an organization
+/* List redundancy details of wireless LAN controllers in an organization. The failover count refers to the total failovers system happens from the moment of this device onboarding to Dashboard
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams *GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/statuses"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyStatuses")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval List cpu utilization data of wireless LAN controllers in an organization
+/* List cpu utilization data of wireless LAN controllers in an organization
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/system/utilization/history/byInterval"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval)
+	return result, response, err
+
+}
+
+//GetOrganizationWirelessControllerOverviewByDevice List the overview information of wireless LAN controllers in an organization and it is updated every minute.
+/* List the overview information of wireless LAN controllers in an organization and it is updated every minute.
+
+@param organizationID organizationId path parameter. Organization ID
+@param getOrganizationWirelessControllerOverviewByDeviceQueryParams Filtering parameter
+
+
+*/
+
+func (s *WirelessControllerService) GetOrganizationWirelessControllerOverviewByDevice(organizationID string, getOrganizationWirelessControllerOverviewByDeviceQueryParams *GetOrganizationWirelessControllerOverviewByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice, *resty.Response, error) {
+	path := "/api/v1/organizations/{organizationId}/wirelessController/overview/byDevice"
+	s.rateLimiterBucket.Wait(1)
+	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
+
+	queryString, _ := query.Values(getOrganizationWirelessControllerOverviewByDeviceQueryParams)
+
+	response, err := s.client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetQueryString(queryString.Encode()).SetResult(&ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice{}).
+		SetError(&Error).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+
+	}
+
+	if response.IsError() {
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerOverviewByDevice")
+	}
+
+	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice)
+	return result, response, err
+
+}


### PR DESCRIPTION
### Changed
- dashboard-api-go supports now v1.53.0 of Meraki Dashboard API.
- update appliance.go, added new query parameters for GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork.
- update appliance.go, added new query parameters for GetOrganizationApplianceUplinkStatuses.