### PR TITLE
## [4.0.1] - 2025-01-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2025-01-20
+### Added
+- **Support for fetching all items with `perpage=-1`**  
+  A new feature has been added to the endpoint where if the `perpage` parameter is set to `-1`, it will return all available items for that endpoint. This eliminates the need for multiple paginated requests when retrieving the full set of data.
+
+**Behavior:**
+- When `perpage` is set to `-1`, all items will be returned.
+- For positive values of `perpage`, the traditional pagination logic will be applied.
+
+**Benefits:**
+- Simplifies fetching all data in a single request.
+- Reduces the need for multiple API calls to retrieve the full dataset.
+
+
 ## [4.0.0] - 2025-01-20
 ### Changed
 - dashboard-api-go supports now v1.53.0 of Meraki Dashboard API.
@@ -1413,4 +1427,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.0.8]: https://github.com/meraki/dashboard-api-go/compare/v3.0.7...3.0.8
 [3.0.9]: https://github.com/meraki/dashboard-api-go/compare/v3.0.8...3.0.9
 [4.0.0]: https://github.com/meraki/dashboard-api-go/compare/v3.0.10...4.0.0
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v4.0.0...main
+[4.0.1]: https://github.com/meraki/dashboard-api-go/compare/v4.0.0...4.0.1
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v4.0.1...main

--- a/README.md
+++ b/README.md
@@ -45,6 +45,48 @@ nResponse, _, err := client.Administered.GetAdministeredIDentitiesMe()
 	}
 ```
 
+### Fetch All Items of an Endpoint with Pagination
+
+- **Support for fetching all items with `perpage=-1`**  
+  A new feature has been introduced to the API endpoints, enabling clients to fetch all available items in a single request by setting the `perpage` parameter to `-1`. This enhancement allows you to retrieve the full dataset without needing to make multiple paginated requests.
+
+### Behavior
+
+- When `perpage` is set to `-1`, the server will return **all available items** for that endpoint, bypassing the pagination logic.
+- If a positive integer is passed for `perpage`, the endpoint will continue using traditional pagination and return only the number of items specified by `perpage`.
+
+### Example Usage
+```go
+func main() {
+	var err error
+	fmt.Println("Authenticating")
+	client, err = meraki.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	nResponse, _, err := client.Organizations.GetOrganizationDevices("828099381482762270", &meraki.GetOrganizationDevicesQueryParams{
+		PerPage:        -1,
+		TagsFilterType: "withAnyTags",
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if nResponse != nil {
+		fmt.Println("\n <Count>: ", len(*nResponse))
+		fmt.Printf("%v", *nResponse)
+		return
+	}
+
+	fmt.Println("There's no data on response")
+```
+
+#### Fetch All Items
+To retrieve all items from the endpoint, set the `perpage` parameter to `-1`:
+
+
 ### Using environment variables
 
 The client can be configured with the following environment variables:

--- a/examples/429_Test/test.go
+++ b/examples/429_Test/test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
+)
+
+var client *meraki.Client
+
+func main() {
+	var err error
+	fmt.Println("Authenticating")
+	client, err = meraki.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	nResponse, _, err := client.Organizations.GetOrganizations(nil)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if nResponse != nil {
+		fmt.Println(nResponse)
+		return
+	}
+	fmt.Println("There's no data on response")
+}

--- a/examples/GetAllTests/main.go
+++ b/examples/GetAllTests/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
+)
+
+var client *meraki.Client
+
+func main() {
+	var err error
+	fmt.Println("Authenticating")
+	client, err = meraki.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	nResponse, _, err := client.Organizations.GetOrganizationDevices("828099381482762270", &meraki.GetOrganizationDevicesQueryParams{
+		PerPage:        -1,
+		TagsFilterType: "withAnyTags",
+	})
+	// nResponse, _, err := client.Organizations.GetOrganizationAssuranceAlertsOverviewByNetwork("828099381482762270", &meraki.GetOrganizationAssuranceAlertsOverviewByNetworkQueryParams{
+	// 	PerPage: -1,
+	// })
+	// nResponse, _, err := client.Devices.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice("828099381482762270", &meraki.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams{
+	// 	PerPage: -1,
+	// })
+
+	// nResponse, _, err := client.Switch.GetOrganizationSwitchPortsClientsOverviewByDevice("828099381482762270", &meraki.GetOrganizationSwitchPortsClientsOverviewByDeviceQueryParams{
+	// 	PerPage: -1,
+	// })
+	// nResponse, _, err := client.Switch.GetOrganizationSwitchPortsTopologyDiscoveryByDevice("828099381482762270", &meraki.GetOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams{
+	// 	PerPage: -1,
+	// })
+
+	// nResponse, _, err := client.WirelessController.GetOrganizationWirelessControllerAvailabilitiesChangeHistory("828099381482762270", &meraki.GetOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams{
+	// 	PerPage: -1,
+	// })
+	// nResponse, _, err := client.WirelessController.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice("828099381482762270", &meraki.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams{
+	// 	PerPage: -1,
+	// })
+
+	// nResponse, _, err := client.Wireless.GetOrganizationWirelessAirMarshalRules("828099381482762270", &meraki.GetOrganizationWirelessAirMarshalRulesQueryParams{
+	// 	PerPage: -1,
+	// })
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if nResponse != nil {
+		fmt.Println("\n Cantidad: ", len(*nResponse))
+		fmt.Printf("%v", *nResponse)
+		return
+	}
+
+	fmt.Println("There's no data on response")
+}

--- a/examples/GetAllTests2/main.go
+++ b/examples/GetAllTests2/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	meraki "github.com/meraki/dashboard-api-go/v4/sdk"
+)
+
+var client *meraki.Client
+
+func main() {
+	var err error
+	fmt.Println("Authenticating")
+	client, err = meraki.NewClient()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	nResponse, _, err := client.Networks.GetNetworkClientsApplicationUsage("L_828099381482771185", &meraki.GetNetworkClientsApplicationUsageQueryParams{
+		PerPage: -1,
+		Clients: "4c:c8:a1:0b:01:58",
+	})
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if nResponse != nil {
+		fmt.Println("\n Cantidad: ", len(*nResponse))
+		fmt.Printf("%v", *nResponse)
+		return
+	}
+
+	fmt.Println("There's no data on response")
+}

--- a/sdk/administered.go
+++ b/sdk/administered.go
@@ -48,6 +48,7 @@ type ResponseAdministeredGenerateAdministeredIDentitiesMeAPIKeys struct {
 
 
  */
+
 func (s *AdministeredService) GetAdministeredIDentitiesMe() (*ResponseAdministeredGetAdministeredIDentitiesMe, *resty.Response, error) {
 	path := "/api/v1/administered/identities/me"
 	s.rateLimiterBucket.Wait(1)
@@ -79,6 +80,7 @@ func (s *AdministeredService) GetAdministeredIDentitiesMe() (*ResponseAdminister
 
 
  */
+
 func (s *AdministeredService) GetAdministeredIDentitiesMeAPIKeys() (*ResponseAdministeredGetAdministeredIDentitiesMeAPIKeys, *resty.Response, error) {
 	path := "/api/v1/administered/identities/me/api/keys"
 	s.rateLimiterBucket.Wait(1)

--- a/sdk/appliance.go
+++ b/sdk/appliance.go
@@ -2824,6 +2824,7 @@ type RequestApplianceUpdateOrganizationApplianceVpnVpnFirewallRulesRules struct 
 
 
 */
+
 func (s *ApplianceService) GetDeviceApplianceDhcpSubnets(serial string) (*ResponseApplianceGetDeviceApplianceDhcpSubnets, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/dhcp/subnets"
 	s.rateLimiterBucket.Wait(1)
@@ -2858,6 +2859,7 @@ func (s *ApplianceService) GetDeviceApplianceDhcpSubnets(serial string) (*Respon
 
 
 */
+
 func (s *ApplianceService) GetDeviceAppliancePerformance(serial string, getDeviceAppliancePerformanceQueryParams *GetDeviceAppliancePerformanceQueryParams) (*ResponseApplianceGetDeviceAppliancePerformance, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/performance"
 	s.rateLimiterBucket.Wait(1)
@@ -2893,6 +2895,7 @@ func (s *ApplianceService) GetDeviceAppliancePerformance(serial string, getDevic
 
 
 */
+
 func (s *ApplianceService) GetDeviceAppliancePrefixesDelegated(serial string) (*ResponseApplianceGetDeviceAppliancePrefixesDelegated, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/prefixes/delegated"
 	s.rateLimiterBucket.Wait(1)
@@ -2926,6 +2929,7 @@ func (s *ApplianceService) GetDeviceAppliancePrefixesDelegated(serial string) (*
 
 
 */
+
 func (s *ApplianceService) GetDeviceAppliancePrefixesDelegatedVLANAssignments(serial string) (*ResponseApplianceGetDeviceAppliancePrefixesDelegatedVLANAssignments, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/prefixes/delegated/vlanAssignments"
 	s.rateLimiterBucket.Wait(1)
@@ -2959,6 +2963,7 @@ func (s *ApplianceService) GetDeviceAppliancePrefixesDelegatedVLANAssignments(se
 
 
 */
+
 func (s *ApplianceService) GetDeviceApplianceRadioSettings(serial string) (*ResponseApplianceGetDeviceApplianceRadioSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/radio/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -2992,6 +2997,7 @@ func (s *ApplianceService) GetDeviceApplianceRadioSettings(serial string) (*Resp
 
 
 */
+
 func (s *ApplianceService) GetDeviceApplianceUplinksSettings(serial string) (*ResponseApplianceGetDeviceApplianceUplinksSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/appliance/uplinks/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3027,9 +3033,40 @@ func (s *ApplianceService) GetDeviceApplianceUplinksSettings(serial string) (*Re
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceClientSecurityEvents(networkID string, clientID string, getNetworkApplianceClientSecurityEventsQueryParams *GetNetworkApplianceClientSecurityEventsQueryParams) (*ResponseApplianceGetNetworkApplianceClientSecurityEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/clients/{clientId}/security/events"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkApplianceClientSecurityEventsQueryParams != nil && getNetworkApplianceClientSecurityEventsQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetNetworkApplianceClientSecurityEvents
+		println("Paginate")
+		getNetworkApplianceClientSecurityEventsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkApplianceClientSecurityEventsPaginate, networkID, clientID, getNetworkApplianceClientSecurityEventsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetNetworkApplianceClientSecurityEvents
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{clientId}", fmt.Sprintf("%v", clientID), -1)
 
@@ -3055,6 +3092,11 @@ func (s *ApplianceService) GetNetworkApplianceClientSecurityEvents(networkID str
 	return result, response, err
 
 }
+func (s *ApplianceService) GetNetworkApplianceClientSecurityEventsPaginate(networkID string, clientID string, getNetworkApplianceClientSecurityEventsQueryParams any) (any, *resty.Response, error) {
+	getNetworkApplianceClientSecurityEventsQueryParamsConverted := getNetworkApplianceClientSecurityEventsQueryParams.(*GetNetworkApplianceClientSecurityEventsQueryParams)
+
+	return s.GetNetworkApplianceClientSecurityEvents(networkID, clientID, getNetworkApplianceClientSecurityEventsQueryParamsConverted)
+}
 
 //GetNetworkApplianceConnectivityMonitoringDestinations Return the connectivity testing destinations for an MX network
 /* Return the connectivity testing destinations for an MX network
@@ -3063,6 +3105,7 @@ func (s *ApplianceService) GetNetworkApplianceClientSecurityEvents(networkID str
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceConnectivityMonitoringDestinations(networkID string) (*ResponseApplianceGetNetworkApplianceConnectivityMonitoringDestinations, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/connectivityMonitoringDestinations"
 	s.rateLimiterBucket.Wait(1)
@@ -3096,6 +3139,7 @@ func (s *ApplianceService) GetNetworkApplianceConnectivityMonitoringDestinations
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceContentFiltering(networkID string) (*ResponseApplianceGetNetworkApplianceContentFiltering, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/contentFiltering"
 	s.rateLimiterBucket.Wait(1)
@@ -3129,6 +3173,7 @@ func (s *ApplianceService) GetNetworkApplianceContentFiltering(networkID string)
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceContentFilteringCategories(networkID string) (*ResponseApplianceGetNetworkApplianceContentFilteringCategories, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/contentFiltering/categories"
 	s.rateLimiterBucket.Wait(1)
@@ -3162,6 +3207,7 @@ func (s *ApplianceService) GetNetworkApplianceContentFilteringCategories(network
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallCellularFirewallRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallCellularFirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/cellularFirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3195,6 +3241,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallCellularFirewallRules(netw
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallFirewalledServices(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallFirewalledServices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/firewalledServices"
 	s.rateLimiterBucket.Wait(1)
@@ -3229,6 +3276,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallFirewalledServices(network
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallFirewalledService(networkID string, service string) (*ResponseApplianceGetNetworkApplianceFirewallFirewalledService, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/firewalledServices/{service}"
 	s.rateLimiterBucket.Wait(1)
@@ -3263,6 +3311,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallFirewalledService(networkI
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallInboundCellularFirewallRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallInboundCellularFirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/inboundCellularFirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3296,6 +3345,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallInboundCellularFirewallRul
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallInboundFirewallRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallInboundFirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/inboundFirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3329,6 +3379,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallInboundFirewallRules(netwo
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallL3FirewallRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallL3FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/l3FirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3362,6 +3413,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallL3FirewallRules(networkID 
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallL7FirewallRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallL7FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/l7FirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3395,6 +3447,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallL7FirewallRules(networkID 
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallL7FirewallRulesApplicationCategories(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesApplicationCategories, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/l7FirewallRules/applicationCategories"
 	s.rateLimiterBucket.Wait(1)
@@ -3428,6 +3481,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallL7FirewallRulesApplication
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallOneToManyNatRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallOneToManyNatRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/oneToManyNatRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3461,6 +3515,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallOneToManyNatRules(networkI
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallOneToOneNatRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallOneToOneNatRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/oneToOneNatRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3494,6 +3549,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallOneToOneNatRules(networkID
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallPortForwardingRules(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallPortForwardingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/portForwardingRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3527,6 +3583,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallPortForwardingRules(networ
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceFirewallSettings(networkID string) (*ResponseApplianceGetNetworkApplianceFirewallSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/firewall/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3560,6 +3617,7 @@ func (s *ApplianceService) GetNetworkApplianceFirewallSettings(networkID string)
 
 
 */
+
 func (s *ApplianceService) GetNetworkAppliancePorts(networkID string) (*ResponseApplianceGetNetworkAppliancePorts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/ports"
 	s.rateLimiterBucket.Wait(1)
@@ -3594,6 +3652,7 @@ func (s *ApplianceService) GetNetworkAppliancePorts(networkID string) (*Response
 
 
 */
+
 func (s *ApplianceService) GetNetworkAppliancePort(networkID string, portID string) (*ResponseApplianceGetNetworkAppliancePort, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/ports/{portId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3628,6 +3687,7 @@ func (s *ApplianceService) GetNetworkAppliancePort(networkID string, portID stri
 
 
 */
+
 func (s *ApplianceService) GetNetworkAppliancePrefixesDelegatedStatics(networkID string) (*ResponseApplianceGetNetworkAppliancePrefixesDelegatedStatics, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/prefixes/delegated/statics"
 	s.rateLimiterBucket.Wait(1)
@@ -3662,6 +3722,7 @@ func (s *ApplianceService) GetNetworkAppliancePrefixesDelegatedStatics(networkID
 
 
 */
+
 func (s *ApplianceService) GetNetworkAppliancePrefixesDelegatedStatic(networkID string, staticDelegatedPrefixID string) (*ResponseApplianceGetNetworkAppliancePrefixesDelegatedStatic, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/prefixes/delegated/statics/{staticDelegatedPrefixId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3696,6 +3757,7 @@ func (s *ApplianceService) GetNetworkAppliancePrefixesDelegatedStatic(networkID 
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceRfProfiles(networkID string) (*ResponseApplianceGetNetworkApplianceRfProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/rfProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -3730,6 +3792,7 @@ func (s *ApplianceService) GetNetworkApplianceRfProfiles(networkID string) (*Res
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceRfProfile(networkID string, rfProfileID string) (*ResponseApplianceGetNetworkApplianceRfProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/rfProfiles/{rfProfileId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3765,9 +3828,40 @@ func (s *ApplianceService) GetNetworkApplianceRfProfile(networkID string, rfProf
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSecurityEvents(networkID string, getNetworkApplianceSecurityEventsQueryParams *GetNetworkApplianceSecurityEventsQueryParams) (*ResponseApplianceGetNetworkApplianceSecurityEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/security/events"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkApplianceSecurityEventsQueryParams != nil && getNetworkApplianceSecurityEventsQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetNetworkApplianceSecurityEvents
+		println("Paginate")
+		getNetworkApplianceSecurityEventsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkApplianceSecurityEventsPaginate, networkID, "", getNetworkApplianceSecurityEventsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetNetworkApplianceSecurityEvents
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkApplianceSecurityEventsQueryParams)
@@ -3792,6 +3886,11 @@ func (s *ApplianceService) GetNetworkApplianceSecurityEvents(networkID string, g
 	return result, response, err
 
 }
+func (s *ApplianceService) GetNetworkApplianceSecurityEventsPaginate(networkID string, getNetworkApplianceSecurityEventsQueryParams any) (any, *resty.Response, error) {
+	getNetworkApplianceSecurityEventsQueryParamsConverted := getNetworkApplianceSecurityEventsQueryParams.(*GetNetworkApplianceSecurityEventsQueryParams)
+
+	return s.GetNetworkApplianceSecurityEvents(networkID, getNetworkApplianceSecurityEventsQueryParamsConverted)
+}
 
 //GetNetworkApplianceSecurityIntrusion Returns all supported intrusion settings for an MX network
 /* Returns all supported intrusion settings for an MX network
@@ -3800,6 +3899,7 @@ func (s *ApplianceService) GetNetworkApplianceSecurityEvents(networkID string, g
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSecurityIntrusion(networkID string) (*ResponseApplianceGetNetworkApplianceSecurityIntrusion, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/security/intrusion"
 	s.rateLimiterBucket.Wait(1)
@@ -3833,6 +3933,7 @@ func (s *ApplianceService) GetNetworkApplianceSecurityIntrusion(networkID string
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSecurityMalware(networkID string) (*ResponseApplianceGetNetworkApplianceSecurityMalware, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/security/malware"
 	s.rateLimiterBucket.Wait(1)
@@ -3866,6 +3967,7 @@ func (s *ApplianceService) GetNetworkApplianceSecurityMalware(networkID string) 
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSettings(networkID string) (*ResponseApplianceGetNetworkApplianceSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3899,6 +4001,7 @@ func (s *ApplianceService) GetNetworkApplianceSettings(networkID string) (*Respo
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSingleLan(networkID string) (*ResponseApplianceGetNetworkApplianceSingleLan, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/singleLan"
 	s.rateLimiterBucket.Wait(1)
@@ -3932,6 +4035,7 @@ func (s *ApplianceService) GetNetworkApplianceSingleLan(networkID string) (*Resp
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSSIDs(networkID string) (*ResponseApplianceGetNetworkApplianceSSIDs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/ssids"
 	s.rateLimiterBucket.Wait(1)
@@ -3966,6 +4070,7 @@ func (s *ApplianceService) GetNetworkApplianceSSIDs(networkID string) (*Response
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceSSID(networkID string, number string) (*ResponseApplianceGetNetworkApplianceSSID, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/ssids/{number}"
 	s.rateLimiterBucket.Wait(1)
@@ -4000,6 +4105,7 @@ func (s *ApplianceService) GetNetworkApplianceSSID(networkID string, number stri
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceStaticRoutes(networkID string) (*ResponseApplianceGetNetworkApplianceStaticRoutes, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
@@ -4034,6 +4140,7 @@ func (s *ApplianceService) GetNetworkApplianceStaticRoutes(networkID string) (*R
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceStaticRoute(networkID string, staticRouteID string) (*ResponseApplianceGetNetworkApplianceStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4068,6 +4175,7 @@ func (s *ApplianceService) GetNetworkApplianceStaticRoute(networkID string, stat
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShaping(networkID string) (*ResponseApplianceGetNetworkApplianceTrafficShaping, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping"
 	s.rateLimiterBucket.Wait(1)
@@ -4101,6 +4209,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShaping(networkID string) (
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShapingCustomPerformanceClasses(networkID string) (*ResponseApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClasses, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses"
 	s.rateLimiterBucket.Wait(1)
@@ -4135,6 +4244,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShapingCustomPerformanceCla
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShapingCustomPerformanceClass(networkID string, customPerformanceClassID string) (*ResponseApplianceGetNetworkApplianceTrafficShapingCustomPerformanceClass, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/customPerformanceClasses/{customPerformanceClassId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4169,6 +4279,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShapingCustomPerformanceCla
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShapingRules(networkID string) (*ResponseApplianceGetNetworkApplianceTrafficShapingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/rules"
 	s.rateLimiterBucket.Wait(1)
@@ -4202,6 +4313,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShapingRules(networkID stri
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShapingUplinkBandwidth(networkID string) (*ResponseApplianceGetNetworkApplianceTrafficShapingUplinkBandwidth, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/uplinkBandwidth"
 	s.rateLimiterBucket.Wait(1)
@@ -4235,6 +4347,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShapingUplinkBandwidth(netw
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceTrafficShapingUplinkSelection(networkID string) (*ResponseApplianceGetNetworkApplianceTrafficShapingUplinkSelection, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/trafficShaping/uplinkSelection"
 	s.rateLimiterBucket.Wait(1)
@@ -4269,6 +4382,7 @@ func (s *ApplianceService) GetNetworkApplianceTrafficShapingUplinkSelection(netw
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceUplinksUsageHistory(networkID string, getNetworkApplianceUplinksUsageHistoryQueryParams *GetNetworkApplianceUplinksUsageHistoryQueryParams) (*ResponseApplianceGetNetworkApplianceUplinksUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/uplinks/usageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4304,6 +4418,7 @@ func (s *ApplianceService) GetNetworkApplianceUplinksUsageHistory(networkID stri
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceVLANs(networkID string) (*ResponseApplianceGetNetworkApplianceVLANs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vlans"
 	s.rateLimiterBucket.Wait(1)
@@ -4337,6 +4452,7 @@ func (s *ApplianceService) GetNetworkApplianceVLANs(networkID string) (*Response
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceVLANsSettings(networkID string) (*ResponseApplianceGetNetworkApplianceVLANsSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vlans/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -4371,6 +4487,7 @@ func (s *ApplianceService) GetNetworkApplianceVLANsSettings(networkID string) (*
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceVLAN(networkID string, vlanID string) (*ResponseApplianceGetNetworkApplianceVLAN, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vlans/{vlanId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4405,6 +4522,7 @@ func (s *ApplianceService) GetNetworkApplianceVLAN(networkID string, vlanID stri
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceVpnBgp(networkID string) (*ResponseApplianceGetNetworkApplianceVpnBgp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vpn/bgp"
 	s.rateLimiterBucket.Wait(1)
@@ -4438,6 +4556,7 @@ func (s *ApplianceService) GetNetworkApplianceVpnBgp(networkID string) (*Respons
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceVpnSiteToSiteVpn(networkID string) (*ResponseApplianceGetNetworkApplianceVpnSiteToSiteVpn, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/vpn/siteToSiteVpn"
 	s.rateLimiterBucket.Wait(1)
@@ -4471,6 +4590,7 @@ func (s *ApplianceService) GetNetworkApplianceVpnSiteToSiteVpn(networkID string)
 
 
 */
+
 func (s *ApplianceService) GetNetworkApplianceWarmSpare(networkID string) (*ResponseApplianceGetNetworkApplianceWarmSpare, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/appliance/warmSpare"
 	s.rateLimiterBucket.Wait(1)
@@ -4505,9 +4625,40 @@ func (s *ApplianceService) GetNetworkApplianceWarmSpare(networkID string) (*Resp
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceSecurityEvents(organizationID string, getOrganizationApplianceSecurityEventsQueryParams *GetOrganizationApplianceSecurityEventsQueryParams) (*ResponseApplianceGetOrganizationApplianceSecurityEvents, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/security/events"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApplianceSecurityEventsQueryParams != nil && getOrganizationApplianceSecurityEventsQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetOrganizationApplianceSecurityEvents
+		println("Paginate")
+		getOrganizationApplianceSecurityEventsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationApplianceSecurityEventsPaginate, organizationID, "", getOrganizationApplianceSecurityEventsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetOrganizationApplianceSecurityEvents
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApplianceSecurityEventsQueryParams)
@@ -4532,6 +4683,11 @@ func (s *ApplianceService) GetOrganizationApplianceSecurityEvents(organizationID
 	return result, response, err
 
 }
+func (s *ApplianceService) GetOrganizationApplianceSecurityEventsPaginate(organizationID string, getOrganizationApplianceSecurityEventsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApplianceSecurityEventsQueryParamsConverted := getOrganizationApplianceSecurityEventsQueryParams.(*GetOrganizationApplianceSecurityEventsQueryParams)
+
+	return s.GetOrganizationApplianceSecurityEvents(organizationID, getOrganizationApplianceSecurityEventsQueryParamsConverted)
+}
 
 //GetOrganizationApplianceSecurityIntrusion Returns all supported intrusion settings for an organization
 /* Returns all supported intrusion settings for an organization
@@ -4540,6 +4696,7 @@ func (s *ApplianceService) GetOrganizationApplianceSecurityEvents(organizationID
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceSecurityIntrusion(organizationID string) (*ResponseApplianceGetOrganizationApplianceSecurityIntrusion, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/security/intrusion"
 	s.rateLimiterBucket.Wait(1)
@@ -4574,9 +4731,40 @@ func (s *ApplianceService) GetOrganizationApplianceSecurityIntrusion(organizatio
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork(organizationID string, getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams *GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams) (*ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/trafficShaping/vpnExclusions/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams != nil && getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork
+		println("Paginate")
+		getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkPaginate, organizationID, "", getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams)
@@ -4601,6 +4789,11 @@ func (s *ApplianceService) GetOrganizationApplianceTrafficShapingVpnExclusionsBy
 	return result, response, err
 
 }
+func (s *ApplianceService) GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkPaginate(organizationID string, getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParamsConverted := getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams.(*GetOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParams)
+
+	return s.GetOrganizationApplianceTrafficShapingVpnExclusionsByNetwork(organizationID, getOrganizationApplianceTrafficShapingVpnExclusionsByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationApplianceUplinkStatuses List the uplink status of every Meraki MX and Z series appliances in the organization
 /* List the uplink status of every Meraki MX and Z series appliances in the organization
@@ -4610,9 +4803,40 @@ func (s *ApplianceService) GetOrganizationApplianceTrafficShapingVpnExclusionsBy
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceUplinkStatuses(organizationID string, getOrganizationApplianceUplinkStatusesQueryParams *GetOrganizationApplianceUplinkStatusesQueryParams) (*ResponseApplianceGetOrganizationApplianceUplinkStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/uplink/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApplianceUplinkStatusesQueryParams != nil && getOrganizationApplianceUplinkStatusesQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetOrganizationApplianceUplinkStatuses
+		println("Paginate")
+		getOrganizationApplianceUplinkStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationApplianceUplinkStatusesPaginate, organizationID, "", getOrganizationApplianceUplinkStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetOrganizationApplianceUplinkStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApplianceUplinkStatusesQueryParams)
@@ -4637,6 +4861,11 @@ func (s *ApplianceService) GetOrganizationApplianceUplinkStatuses(organizationID
 	return result, response, err
 
 }
+func (s *ApplianceService) GetOrganizationApplianceUplinkStatusesPaginate(organizationID string, getOrganizationApplianceUplinkStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApplianceUplinkStatusesQueryParamsConverted := getOrganizationApplianceUplinkStatusesQueryParams.(*GetOrganizationApplianceUplinkStatusesQueryParams)
+
+	return s.GetOrganizationApplianceUplinkStatuses(organizationID, getOrganizationApplianceUplinkStatusesQueryParamsConverted)
+}
 
 //GetOrganizationApplianceUplinksStatusesOverview Returns an overview of uplink statuses
 /* Returns an overview of uplink statuses
@@ -4645,6 +4874,7 @@ func (s *ApplianceService) GetOrganizationApplianceUplinkStatuses(organizationID
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceUplinksStatusesOverview(organizationID string) (*ResponseApplianceGetOrganizationApplianceUplinksStatusesOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/uplinks/statuses/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4679,6 +4909,7 @@ func (s *ApplianceService) GetOrganizationApplianceUplinksStatusesOverview(organ
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceUplinksUsageByNetwork(organizationID string, getOrganizationApplianceUplinksUsageByNetworkQueryParams *GetOrganizationApplianceUplinksUsageByNetworkQueryParams) (*ResponseApplianceGetOrganizationApplianceUplinksUsageByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/uplinks/usage/byNetwork"
 	s.rateLimiterBucket.Wait(1)
@@ -4715,9 +4946,40 @@ func (s *ApplianceService) GetOrganizationApplianceUplinksUsageByNetwork(organiz
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceVpnStats(organizationID string, getOrganizationApplianceVpnStatsQueryParams *GetOrganizationApplianceVpnStatsQueryParams) (*ResponseApplianceGetOrganizationApplianceVpnStats, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/stats"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApplianceVpnStatsQueryParams != nil && getOrganizationApplianceVpnStatsQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetOrganizationApplianceVpnStats
+		println("Paginate")
+		getOrganizationApplianceVpnStatsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationApplianceVpnStatsPaginate, organizationID, "", getOrganizationApplianceVpnStatsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetOrganizationApplianceVpnStats
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApplianceVpnStatsQueryParams)
@@ -4742,6 +5004,11 @@ func (s *ApplianceService) GetOrganizationApplianceVpnStats(organizationID strin
 	return result, response, err
 
 }
+func (s *ApplianceService) GetOrganizationApplianceVpnStatsPaginate(organizationID string, getOrganizationApplianceVpnStatsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApplianceVpnStatsQueryParamsConverted := getOrganizationApplianceVpnStatsQueryParams.(*GetOrganizationApplianceVpnStatsQueryParams)
+
+	return s.GetOrganizationApplianceVpnStats(organizationID, getOrganizationApplianceVpnStatsQueryParamsConverted)
+}
 
 //GetOrganizationApplianceVpnStatuses Show VPN status for networks in an organization
 /* Show VPN status for networks in an organization
@@ -4751,9 +5018,40 @@ func (s *ApplianceService) GetOrganizationApplianceVpnStats(organizationID strin
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceVpnStatuses(organizationID string, getOrganizationApplianceVpnStatusesQueryParams *GetOrganizationApplianceVpnStatusesQueryParams) (*ResponseApplianceGetOrganizationApplianceVpnStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApplianceVpnStatusesQueryParams != nil && getOrganizationApplianceVpnStatusesQueryParams.PerPage == -1 {
+		var result *ResponseApplianceGetOrganizationApplianceVpnStatuses
+		println("Paginate")
+		getOrganizationApplianceVpnStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationApplianceVpnStatusesPaginate, organizationID, "", getOrganizationApplianceVpnStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseApplianceGetOrganizationApplianceVpnStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Vpnstatusentities = append(*result.Vpnstatusentities, *resultTmp.Vpnstatusentities...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApplianceVpnStatusesQueryParams)
@@ -4778,6 +5076,11 @@ func (s *ApplianceService) GetOrganizationApplianceVpnStatuses(organizationID st
 	return result, response, err
 
 }
+func (s *ApplianceService) GetOrganizationApplianceVpnStatusesPaginate(organizationID string, getOrganizationApplianceVpnStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApplianceVpnStatusesQueryParamsConverted := getOrganizationApplianceVpnStatusesQueryParams.(*GetOrganizationApplianceVpnStatusesQueryParams)
+
+	return s.GetOrganizationApplianceVpnStatuses(organizationID, getOrganizationApplianceVpnStatusesQueryParamsConverted)
+}
 
 //GetOrganizationApplianceVpnThirdPartyVpnpeers Return the third party VPN peers for an organization
 /* Return the third party VPN peers for an organization
@@ -4786,7 +5089,8 @@ func (s *ApplianceService) GetOrganizationApplianceVpnStatuses(organizationID st
 
 
 */
-func (s *ApplianceService) GetOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string) (*ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeers, *resty.Response, error) {
+
+func (s *ApplianceService) GetOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/thirdPartyVPNPeers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -4794,21 +5098,19 @@ func (s *ApplianceService) GetOrganizationApplianceVpnThirdPartyVpnpeers(organiz
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetResult(&ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeers{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 
 	}
 
 	if response.IsError() {
-		return nil, response, fmt.Errorf("error with operation GetOrganizationApplianceVpnThirdPartyVpnpeers")
+		return response, fmt.Errorf("error with operation GetOrganizationApplianceVpnThirdPartyVpnpeers")
 	}
 
-	result := response.Result().(*ResponseApplianceGetOrganizationApplianceVpnThirdPartyVpnpeers)
-	return result, response, err
+	return response, err
 
 }
 
@@ -4819,6 +5121,7 @@ func (s *ApplianceService) GetOrganizationApplianceVpnThirdPartyVpnpeers(organiz
 
 
 */
+
 func (s *ApplianceService) GetOrganizationApplianceVpnVpnFirewallRules(organizationID string) (*ResponseApplianceGetOrganizationApplianceVpnVpnFirewallRules, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/vpnFirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -6236,7 +6539,7 @@ func (s *ApplianceService) UpdateOrganizationApplianceSecurityIntrusion(organiza
 
 @param organizationID organizationId path parameter. Organization ID
 */
-func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string, requestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers *RequestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers) (*resty.Response, error) {
+func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(organizationID string) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/appliance/vpn/thirdPartyVPNPeers"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -6244,7 +6547,6 @@ func (s *ApplianceService) UpdateOrganizationApplianceVpnThirdPartyVpnpeers(orga
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBody(requestApplianceUpdateOrganizationApplianceVpnThirdPartyVpnpeers).
 		SetError(&Error).
 		Put(path)
 

--- a/sdk/camera.go
+++ b/sdk/camera.go
@@ -857,6 +857,7 @@ type RequestCameraUpdateOrganizationCameraRoleAppliedOrgWide struct {
 
 
 */
+
 func (s *CameraService) GetDeviceCameraAnalyticsLive(serial string) (*ResponseCameraGetDeviceCameraAnalyticsLive, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/analytics/live"
 	s.rateLimiterBucket.Wait(1)
@@ -891,6 +892,7 @@ func (s *CameraService) GetDeviceCameraAnalyticsLive(serial string) (*ResponseCa
 
 
 */
+
 func (s *CameraService) GetDeviceCameraAnalyticsOverview(serial string, getDeviceCameraAnalyticsOverviewQueryParams *GetDeviceCameraAnalyticsOverviewQueryParams) (*ResponseCameraGetDeviceCameraAnalyticsOverview, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/analytics/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -927,6 +929,7 @@ func (s *CameraService) GetDeviceCameraAnalyticsOverview(serial string, getDevic
 
 
 */
+
 func (s *CameraService) GetDeviceCameraAnalyticsRecent(serial string, getDeviceCameraAnalyticsRecentQueryParams *GetDeviceCameraAnalyticsRecentQueryParams) (*ResponseCameraGetDeviceCameraAnalyticsRecent, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/analytics/recent"
 	s.rateLimiterBucket.Wait(1)
@@ -962,6 +965,7 @@ func (s *CameraService) GetDeviceCameraAnalyticsRecent(serial string, getDeviceC
 
 
 */
+
 func (s *CameraService) GetDeviceCameraAnalyticsZones(serial string) (*ResponseCameraGetDeviceCameraAnalyticsZones, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/analytics/zones"
 	s.rateLimiterBucket.Wait(1)
@@ -997,6 +1001,7 @@ func (s *CameraService) GetDeviceCameraAnalyticsZones(serial string) (*ResponseC
 
 
 */
+
 func (s *CameraService) GetDeviceCameraAnalyticsZoneHistory(serial string, zoneID string, getDeviceCameraAnalyticsZoneHistoryQueryParams *GetDeviceCameraAnalyticsZoneHistoryQueryParams) (*ResponseCameraGetDeviceCameraAnalyticsZoneHistory, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/analytics/zones/{zoneId}/history"
 	s.rateLimiterBucket.Wait(1)
@@ -1033,6 +1038,7 @@ func (s *CameraService) GetDeviceCameraAnalyticsZoneHistory(serial string, zoneI
 
 
 */
+
 func (s *CameraService) GetDeviceCameraCustomAnalytics(serial string) (*ResponseCameraGetDeviceCameraCustomAnalytics, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/customAnalytics"
 	s.rateLimiterBucket.Wait(1)
@@ -1066,6 +1072,7 @@ func (s *CameraService) GetDeviceCameraCustomAnalytics(serial string) (*Response
 
 
 */
+
 func (s *CameraService) GetDeviceCameraQualityAndRetention(serial string) (*ResponseCameraGetDeviceCameraQualityAndRetention, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/qualityAndRetention"
 	s.rateLimiterBucket.Wait(1)
@@ -1099,6 +1106,7 @@ func (s *CameraService) GetDeviceCameraQualityAndRetention(serial string) (*Resp
 
 
 */
+
 func (s *CameraService) GetDeviceCameraSense(serial string) (*ResponseCameraGetDeviceCameraSense, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/sense"
 	s.rateLimiterBucket.Wait(1)
@@ -1132,6 +1140,7 @@ func (s *CameraService) GetDeviceCameraSense(serial string) (*ResponseCameraGetD
 
 
 */
+
 func (s *CameraService) GetDeviceCameraSenseObjectDetectionModels(serial string) (*ResponseCameraGetDeviceCameraSenseObjectDetectionModels, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/sense/objectDetectionModels"
 	s.rateLimiterBucket.Wait(1)
@@ -1165,6 +1174,7 @@ func (s *CameraService) GetDeviceCameraSenseObjectDetectionModels(serial string)
 
 
 */
+
 func (s *CameraService) GetDeviceCameraVideoSettings(serial string) (*ResponseCameraGetDeviceCameraVideoSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/video/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -1199,6 +1209,7 @@ func (s *CameraService) GetDeviceCameraVideoSettings(serial string) (*ResponseCa
 
 
 */
+
 func (s *CameraService) GetDeviceCameraVideoLink(serial string, getDeviceCameraVideoLinkQueryParams *GetDeviceCameraVideoLinkQueryParams) (*ResponseCameraGetDeviceCameraVideoLink, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/videoLink"
 	s.rateLimiterBucket.Wait(1)
@@ -1234,6 +1245,7 @@ func (s *CameraService) GetDeviceCameraVideoLink(serial string, getDeviceCameraV
 
 
 */
+
 func (s *CameraService) GetDeviceCameraWirelessProfiles(serial string) (*ResponseCameraGetDeviceCameraWirelessProfiles, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/camera/wirelessProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1267,6 +1279,7 @@ func (s *CameraService) GetDeviceCameraWirelessProfiles(serial string) (*Respons
 
 
 */
+
 func (s *CameraService) GetNetworkCameraQualityRetentionProfiles(networkID string) (*ResponseCameraGetNetworkCameraQualityRetentionProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/qualityRetentionProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1301,6 +1314,7 @@ func (s *CameraService) GetNetworkCameraQualityRetentionProfiles(networkID strin
 
 
 */
+
 func (s *CameraService) GetNetworkCameraQualityRetentionProfile(networkID string, qualityRetentionProfileID string) (*ResponseCameraGetNetworkCameraQualityRetentionProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/qualityRetentionProfiles/{qualityRetentionProfileId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1335,6 +1349,7 @@ func (s *CameraService) GetNetworkCameraQualityRetentionProfile(networkID string
 
 
 */
+
 func (s *CameraService) GetNetworkCameraSchedules(networkID string) (*ResponseCameraGetNetworkCameraSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/schedules"
 	s.rateLimiterBucket.Wait(1)
@@ -1368,6 +1383,7 @@ func (s *CameraService) GetNetworkCameraSchedules(networkID string) (*ResponseCa
 
 
 */
+
 func (s *CameraService) GetNetworkCameraWirelessProfiles(networkID string) (*ResponseCameraGetNetworkCameraWirelessProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/wirelessProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1402,6 +1418,7 @@ func (s *CameraService) GetNetworkCameraWirelessProfiles(networkID string) (*Res
 
 
 */
+
 func (s *CameraService) GetNetworkCameraWirelessProfile(networkID string, wirelessProfileID string) (*ResponseCameraGetNetworkCameraWirelessProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/camera/wirelessProfiles/{wirelessProfileId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1437,6 +1454,7 @@ func (s *CameraService) GetNetworkCameraWirelessProfile(networkID string, wirele
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraBoundariesAreasByDevice(organizationID string, getOrganizationCameraBoundariesAreasByDeviceQueryParams *GetOrganizationCameraBoundariesAreasByDeviceQueryParams) (*ResponseCameraGetOrganizationCameraBoundariesAreasByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/boundaries/areas/byDevice"
 	s.rateLimiterBucket.Wait(1)
@@ -1473,6 +1491,7 @@ func (s *CameraService) GetOrganizationCameraBoundariesAreasByDevice(organizatio
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraBoundariesLinesByDevice(organizationID string, getOrganizationCameraBoundariesLinesByDeviceQueryParams *GetOrganizationCameraBoundariesLinesByDeviceQueryParams) (*ResponseCameraGetOrganizationCameraBoundariesLinesByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/boundaries/lines/byDevice"
 	s.rateLimiterBucket.Wait(1)
@@ -1508,6 +1527,7 @@ func (s *CameraService) GetOrganizationCameraBoundariesLinesByDevice(organizatio
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraCustomAnalyticsArtifacts(organizationID string) (*ResponseCameraGetOrganizationCameraCustomAnalyticsArtifacts, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/customAnalytics/artifacts"
 	s.rateLimiterBucket.Wait(1)
@@ -1542,6 +1562,7 @@ func (s *CameraService) GetOrganizationCameraCustomAnalyticsArtifacts(organizati
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraCustomAnalyticsArtifact(organizationID string, artifactID string) (*ResponseCameraGetOrganizationCameraCustomAnalyticsArtifact, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/customAnalytics/artifacts/{artifactId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1577,6 +1598,7 @@ func (s *CameraService) GetOrganizationCameraCustomAnalyticsArtifact(organizatio
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraDetectionsHistoryByBoundaryByInterval(organizationID string, getOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams *GetOrganizationCameraDetectionsHistoryByBoundaryByIntervalQueryParams) (*ResponseCameraGetOrganizationCameraDetectionsHistoryByBoundaryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/detections/history/byBoundary/byInterval"
 	s.rateLimiterBucket.Wait(1)
@@ -1613,6 +1635,7 @@ func (s *CameraService) GetOrganizationCameraDetectionsHistoryByBoundaryByInterv
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraOnboardingStatuses(organizationID string, getOrganizationCameraOnboardingStatusesQueryParams *GetOrganizationCameraOnboardingStatusesQueryParams) (*ResponseCameraGetOrganizationCameraOnboardingStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/onboarding/statuses"
 	s.rateLimiterBucket.Wait(1)
@@ -1648,6 +1671,7 @@ func (s *CameraService) GetOrganizationCameraOnboardingStatuses(organizationID s
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraPermissions(organizationID string) (*ResponseCameraGetOrganizationCameraPermissions, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/permissions"
 	s.rateLimiterBucket.Wait(1)
@@ -1682,6 +1706,7 @@ func (s *CameraService) GetOrganizationCameraPermissions(organizationID string) 
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraPermission(organizationID string, permissionScopeID string) (*ResponseCameraGetOrganizationCameraPermission, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/permissions/{permissionScopeId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1716,6 +1741,7 @@ func (s *CameraService) GetOrganizationCameraPermission(organizationID string, p
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraRoles(organizationID string) (*ResponseCameraGetOrganizationCameraRoles, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/roles"
 	s.rateLimiterBucket.Wait(1)
@@ -1750,6 +1776,7 @@ func (s *CameraService) GetOrganizationCameraRoles(organizationID string) (*Resp
 
 
 */
+
 func (s *CameraService) GetOrganizationCameraRole(organizationID string, roleID string) (*ResponseCameraGetOrganizationCameraRole, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/camera/roles/{roleId}"
 	s.rateLimiterBucket.Wait(1)

--- a/sdk/cellular_gateway.go
+++ b/sdk/cellular_gateway.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -69,7 +70,7 @@ type ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRules struct {
 	Rules *[]ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
 }
 type ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRulesRules struct {
-	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
+	Access     string   `json:"access,omitempty"`     // *any* or *restricted*. Specify the right to make inbound connections on the specified ports or port ranges. If *restricted*, a list of allowed IPs is mandatory.
 	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
 	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
 	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
@@ -81,7 +82,7 @@ type ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules struc
 	Rules *[]ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
 }
 type ResponseCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules struct {
-	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
+	Access     string   `json:"access,omitempty"`     // *any* or *restricted*. Specify the right to make inbound connections on the specified ports or port ranges. If *restricted*, a list of allowed IPs is mandatory.
 	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
 	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
 	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
@@ -259,7 +260,7 @@ type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersM
 	Remaining *int `json:"remaining,omitempty"` // Remaining number of Service Providers
 	Total     *int `json:"total,omitempty"`     // Total number of Service Providers
 }
-type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts // Array of ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts
+type ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts []ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts // Array of ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts
 type ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts struct {
 	Items *[]ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsItems `json:"items,omitempty"` // IList of Cellular Service Provider Accounts
 	Meta  *ResponseItemCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsMeta    `json:"meta,omitempty"`  // Meta details about the result
@@ -412,7 +413,7 @@ type RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRules struct
 	Rules *[]RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules `json:"rules,omitempty"` // An array of port forwarding params
 }
 type RequestCellularGatewayUpdateDeviceCellularGatewayPortForwardingRulesRules struct {
-	Access     string   `json:"access,omitempty"`     // `any` or `restricted`. Specify the right to make inbound connections on the specified ports or port ranges. If `restricted`, a list of allowed IPs is mandatory.
+	Access     string   `json:"access,omitempty"`     // *any* or *restricted*. Specify the right to make inbound connections on the specified ports or port ranges. If *restricted*, a list of allowed IPs is mandatory.
 	AllowedIPs []string `json:"allowedIps,omitempty"` // An array of ranges of WAN IP addresses that are allowed to make inbound connections on the specified ports or port ranges.
 	LanIP      string   `json:"lanIp,omitempty"`      // The IP address of the server or device that hosts the internal resource that you wish to make available on the WAN
 	LocalPort  string   `json:"localPort,omitempty"`  // A port or port ranges that will receive the forwarded traffic from the WAN
@@ -481,6 +482,7 @@ type RequestCellularGatewayCreateOrganizationCellularGatewayEsimsSwapSwapsTarget
 
 
 */
+
 func (s *CellularGatewayService) GetDeviceCellularGatewayLan(serial string) (*ResponseCellularGatewayGetDeviceCellularGatewayLan, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellularGateway/lan"
 	s.rateLimiterBucket.Wait(1)
@@ -514,6 +516,7 @@ func (s *CellularGatewayService) GetDeviceCellularGatewayLan(serial string) (*Re
 
 
 */
+
 func (s *CellularGatewayService) GetDeviceCellularGatewayPortForwardingRules(serial string) (*ResponseCellularGatewayGetDeviceCellularGatewayPortForwardingRules, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellularGateway/portForwardingRules"
 	s.rateLimiterBucket.Wait(1)
@@ -547,6 +550,7 @@ func (s *CellularGatewayService) GetDeviceCellularGatewayPortForwardingRules(ser
 
 
 */
+
 func (s *CellularGatewayService) GetNetworkCellularGatewayConnectivityMonitoringDestinations(networkID string) (*ResponseCellularGatewayGetNetworkCellularGatewayConnectivityMonitoringDestinations, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/connectivityMonitoringDestinations"
 	s.rateLimiterBucket.Wait(1)
@@ -580,6 +584,7 @@ func (s *CellularGatewayService) GetNetworkCellularGatewayConnectivityMonitoring
 
 
 */
+
 func (s *CellularGatewayService) GetNetworkCellularGatewayDhcp(networkID string) (*ResponseCellularGatewayGetNetworkCellularGatewayDhcp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/dhcp"
 	s.rateLimiterBucket.Wait(1)
@@ -613,6 +618,7 @@ func (s *CellularGatewayService) GetNetworkCellularGatewayDhcp(networkID string)
 
 
 */
+
 func (s *CellularGatewayService) GetNetworkCellularGatewaySubnetPool(networkID string) (*ResponseCellularGatewayGetNetworkCellularGatewaySubnetPool, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/subnetPool"
 	s.rateLimiterBucket.Wait(1)
@@ -646,6 +652,7 @@ func (s *CellularGatewayService) GetNetworkCellularGatewaySubnetPool(networkID s
 
 
 */
+
 func (s *CellularGatewayService) GetNetworkCellularGatewayUplink(networkID string) (*ResponseCellularGatewayGetNetworkCellularGatewayUplink, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/cellularGateway/uplink"
 	s.rateLimiterBucket.Wait(1)
@@ -680,6 +687,7 @@ func (s *CellularGatewayService) GetNetworkCellularGatewayUplink(networkID strin
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsInventory(organizationID string, getOrganizationCellularGatewayEsimsInventoryQueryParams *GetOrganizationCellularGatewayEsimsInventoryQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsInventory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/inventory"
 	s.rateLimiterBucket.Wait(1)
@@ -715,6 +723,7 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsInventory(or
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProviders(organizationID string) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProviders, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders"
 	s.rateLimiterBucket.Wait(1)
@@ -749,6 +758,7 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvi
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccounts(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccounts, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts"
 	s.rateLimiterBucket.Wait(1)
@@ -785,6 +795,7 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvi
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlansQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsCommunicationPlans, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/communicationPlans"
 	s.rateLimiterBucket.Wait(1)
@@ -821,6 +832,7 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvi
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans(organizationID string, getOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams *GetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlansQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayEsimsServiceProvidersAccountsRatePlans, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/esims/serviceProviders/accounts/ratePlans"
 	s.rateLimiterBucket.Wait(1)
@@ -857,9 +869,40 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayEsimsServiceProvi
 
 
 */
+
 func (s *CellularGatewayService) GetOrganizationCellularGatewayUplinkStatuses(organizationID string, getOrganizationCellularGatewayUplinkStatusesQueryParams *GetOrganizationCellularGatewayUplinkStatusesQueryParams) (*ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/cellularGateway/uplink/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationCellularGatewayUplinkStatusesQueryParams != nil && getOrganizationCellularGatewayUplinkStatusesQueryParams.PerPage == -1 {
+		var result *ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses
+		println("Paginate")
+		getOrganizationCellularGatewayUplinkStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationCellularGatewayUplinkStatusesPaginate, organizationID, "", getOrganizationCellularGatewayUplinkStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationCellularGatewayUplinkStatusesQueryParams)
@@ -883,6 +926,11 @@ func (s *CellularGatewayService) GetOrganizationCellularGatewayUplinkStatuses(or
 	result := response.Result().(*ResponseCellularGatewayGetOrganizationCellularGatewayUplinkStatuses)
 	return result, response, err
 
+}
+func (s *CellularGatewayService) GetOrganizationCellularGatewayUplinkStatusesPaginate(organizationID string, getOrganizationCellularGatewayUplinkStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationCellularGatewayUplinkStatusesQueryParamsConverted := getOrganizationCellularGatewayUplinkStatusesQueryParams.(*GetOrganizationCellularGatewayUplinkStatusesQueryParams)
+
+	return s.GetOrganizationCellularGatewayUplinkStatuses(organizationID, getOrganizationCellularGatewayUplinkStatusesQueryParamsConverted)
 }
 
 //CreateOrganizationCellularGatewayEsimsServiceProvidersAccount Add a service provider account.

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -21,86 +22,6 @@ type GetDeviceLossAndLatencyHistoryQueryParams struct {
 	Resolution int     `url:"resolution,omitempty"` //The time resolution in seconds for returned data. The valid resolutions are: 60, 600, 3600, 86400. The default is 60.
 	Uplink     string  `url:"uplink,omitempty"`     //The WAN uplink used to obtain the requested stats. Valid uplinks are wan1, wan2, wan3, cellular. The default is wan1.
 	IP         string  `url:"ip,omitempty"`         //The destination IP used to obtain the requested stats. This is required.
-}
-type GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
-	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
-}
-type GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
-	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
-}
-type GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
-	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
-}
-type GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
-	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
-}
-type GetOrganizationWirelessDevicesPacketLossByClientQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
-	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
-	Macs          []string `url:"macs[],omitempty"`        //Filter results by client mac address(es).
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
-}
-type GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
-	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
-}
-type GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams struct {
-	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
-	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
-	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
-	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
-	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
-	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
-	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
-	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
-	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
 }
 
 type ResponseDevicesGetDevice struct {
@@ -503,35 +424,7 @@ type ResponseDevicesGetDeviceLldpCdp struct {
 	Ports     *ResponseDevicesGetDeviceLldpCdpPorts `json:"ports,omitempty"`     // Mapping of ports to lldp and/or cdp information
 	SourceMac string                                `json:"sourceMac,omitempty"` // Source MAC address
 }
-type ResponseDevicesGetDeviceLldpCdpPorts struct {
-	Status12 *ResponseDevicesGetDeviceLldpCdpPorts12 `json:"12,omitempty"` //
-	Status8  *ResponseDevicesGetDeviceLldpCdpPorts8  `json:"8,omitempty"`  //
-}
-type ResponseDevicesGetDeviceLldpCdpPorts12 struct {
-	Cdp  *ResponseDevicesGetDeviceLldpCdpPorts12Cdp  `json:"cdp,omitempty"`  //
-	Lldp *ResponseDevicesGetDeviceLldpCdpPorts12Lldp `json:"lldp,omitempty"` //
-}
-type ResponseDevicesGetDeviceLldpCdpPorts12Cdp struct {
-	Address    string `json:"address,omitempty"`    //
-	DeviceID   string `json:"deviceId,omitempty"`   //
-	PortID     string `json:"portId,omitempty"`     //
-	SourcePort string `json:"sourcePort,omitempty"` //
-}
-type ResponseDevicesGetDeviceLldpCdpPorts12Lldp struct {
-	ManagementAddress string `json:"managementAddress,omitempty"` //
-	PortID            string `json:"portId,omitempty"`            //
-	SourcePort        string `json:"sourcePort,omitempty"`        //
-	SystemName        string `json:"systemName,omitempty"`        //
-}
-type ResponseDevicesGetDeviceLldpCdpPorts8 struct {
-	Cdp *ResponseDevicesGetDeviceLldpCdpPorts8Cdp `json:"cdp,omitempty"` //
-}
-type ResponseDevicesGetDeviceLldpCdpPorts8Cdp struct {
-	Address    string `json:"address,omitempty"`    //
-	DeviceID   string `json:"deviceId,omitempty"`   //
-	PortID     string `json:"portId,omitempty"`     //
-	SourcePort string `json:"sourcePort,omitempty"` //
-}
+type ResponseDevicesGetDeviceLldpCdpPorts interface{}
 type ResponseDevicesGetDeviceLossAndLatencyHistory []ResponseItemDevicesGetDeviceLossAndLatencyHistory // Array of ResponseDevicesGetDeviceLossAndLatencyHistory
 type ResponseItemDevicesGetDeviceLossAndLatencyHistory struct {
 	EndTime     string   `json:"endTime,omitempty"`     // End time of the sample
@@ -791,589 +684,747 @@ type ResponseItemDevicesGetNetworkSmDeviceWLANLists struct {
 	ID        string `json:"id,omitempty"`        // The Meraki managed Id of the wlanList record.
 	Xml       string `json:"xml,omitempty"`       // An XML string containing the WLAN List for the device.
 }
-type ResponseOrganizationsCloneOrganizationSwitchDevices struct {
+type ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory []ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistory // Array of ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistory struct {
+	Details *ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetails `json:"details,omitempty"` // Details about the status changes
+	Device  *ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDevice  `json:"device,omitempty"`  // Device information
+	Network *ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryNetwork `json:"network,omitempty"` // Network information
+	Ts      string                                                                       `json:"ts,omitempty"`      // Timestamp, in iso8601 format, at which the event happened
+}
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetails struct {
+	New *[]ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsNew `json:"new,omitempty"` // Details about the new status
+	Old *[]ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsOld `json:"old,omitempty"` // Details about the old status
+}
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsNew struct {
+	Name  string `json:"name,omitempty"`  // Name of the detail
+	Value string `json:"value,omitempty"` // Value of the detail
+}
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDetailsOld struct {
+	Name  string `json:"name,omitempty"`  // Name of the detail
+	Value string `json:"value,omitempty"` // Value of the detail
+}
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryDevice struct {
+	Model       string `json:"model,omitempty"`       // Device model
+	Name        string `json:"name,omitempty"`        // Device name
+	ProductType string `json:"productType,omitempty"` // Device product type.
+	Serial      string `json:"serial,omitempty"`      // Device serial number
+}
+type ResponseItemDevicesGetOrganizationDevicesAvailabilitiesChangeHistoryNetwork struct {
+	ID   string   `json:"id,omitempty"`   // Network id
+	Name string   `json:"name,omitempty"` // Network name
+	Tags []string `json:"tags,omitempty"` // Network tags
+	URL  string   `json:"url,omitempty"`  // Network dashboard url
+}
+type ResponseDevicesBulkUpdateOrganizationDevicesDetails struct {
+	Serials []string `json:"serials,omitempty"` // A list of serials of devices updated
+}
+type ResponseDevicesGetOrganizationDevicesOverviewByModel struct {
+	Counts *[]ResponseDevicesGetOrganizationDevicesOverviewByModelCounts `json:"counts,omitempty"` // Counts of devices per model
+}
+type ResponseDevicesGetOrganizationDevicesOverviewByModelCounts struct {
+	Model string `json:"model,omitempty"` // Device model
+	Total *int   `json:"total,omitempty"` // Total number of devices for the model
+}
+type ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices []ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevices // Array of ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevices struct {
+	Items *[]ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItems `json:"items,omitempty"` // Items in the paginated dataset
+	Meta  *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItems struct {
+	AutoLocate *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsAutoLocate `json:"autoLocate,omitempty"` // The auto locate position for this device
+	FloorPlan  *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsFloorPlan  `json:"floorPlan,omitempty"`  // The assigned floor plan for this device
+	IsAnchor   *bool                                                                         `json:"isAnchor,omitempty"`   // Whether or not this auto locate position is an anchor
+	Lat        *float64                                                                      `json:"lat,omitempty"`        // Latitude
+	Lng        *float64                                                                      `json:"lng,omitempty"`        // Longitude
+	Mac        string                                                                        `json:"mac,omitempty"`        // MAC Address
+	Model      string                                                                        `json:"model,omitempty"`      // Model
+	Name       string                                                                        `json:"name,omitempty"`       // Device Name
+	Network    *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsNetwork    `json:"network,omitempty"`    // Network info
+	Serial     string                                                                        `json:"serial,omitempty"`     // Device Serial Number
+	Status     string                                                                        `json:"status,omitempty"`     // Device Status
+	Tags       []string                                                                      `json:"tags,omitempty"`       // Tags
+	Type       string                                                                        `json:"type,omitempty"`       // The type of auto locate position. Possible values: 'user', 'gnss', and 'calculated'
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsAutoLocate struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude
+	Lng *float64 `json:"lng,omitempty"` // Longitude
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsFloorPlan struct {
+	ID     string `json:"id,omitempty"`     // Floor plan ID
+	Status string `json:"status,omitempty"` // Floor plan name
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesItemsNetwork struct {
+	ID string `json:"id,omitempty"` // ID for the network containing this device
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMeta struct {
+	Counts *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMetaCounts struct {
+	Items *ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+}
+type ResponseItemDevicesGetOrganizationFloorPlansAutoLocateDevicesMetaCountsItems struct {
+	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
+	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
+}
+type ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulk struct {
+	JobID string                                                             `json:"jobId,omitempty"` // The ID of the job that was used to create all of the device swaps.
+	Swaps *[]ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // An array of recent swap requests and their statuses.
+}
+type ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                                  `json:"afterAction,omitempty"` // An action to perform on the devices.old object after swap is complete.
+	CompletedAt string                                                                  `json:"completedAt,omitempty"` // An iso8601 timestamp for when the swap completed or failed.
+	CreatedAt   string                                                                  `json:"createdAt,omitempty"`   // An iso8601 timestamp for the creation of the swap request.
+	Devices     *ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap
+	Errors      []string                                                                `json:"errors,omitempty"`      // A list of error messages for why a swap failed.
+	ID          string                                                                  `json:"id,omitempty"`          // Swap Request ID
+	Status      string                                                                  `json:"status,omitempty"`      // The current status of the swap job.
+}
+type ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New *ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew `json:"new,omitempty"` // The device that will have settings cloned to
+	Old *ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld `json:"old,omitempty"` // The device that will be cloned
+}
+type ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseDevicesGetOrganizationInventoryDevicesSwapsBulk struct {
+	JobID string                                                          `json:"jobId,omitempty"` // The ID of the job that was used to create all of the device swaps.
+	Swaps *[]ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // An array of recent swap requests and their statuses.
+}
+type ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                               `json:"afterAction,omitempty"` // An action to perform on the devices.old object after swap is complete.
+	CompletedAt string                                                               `json:"completedAt,omitempty"` // An iso8601 timestamp for when the swap completed or failed.
+	CreatedAt   string                                                               `json:"createdAt,omitempty"`   // An iso8601 timestamp for the creation of the swap request.
+	Devices     *ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap
+	Errors      []string                                                             `json:"errors,omitempty"`      // A list of error messages for why a swap failed.
+	ID          string                                                               `json:"id,omitempty"`          // Swap Request ID
+	Status      string                                                               `json:"status,omitempty"`      // The current status of the swap job.
+}
+type ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New *ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew `json:"new,omitempty"` // The device that will have settings cloned to
+	Old *ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld `json:"old,omitempty"` // The device that will be cloned
+}
+type ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesNew struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseDevicesGetOrganizationInventoryDevicesSwapsBulkSwapsDevicesOld struct {
+	Mac    string `json:"mac,omitempty"`    // MAC address of the device
+	Model  string `json:"model,omitempty"`  // Model name for device
+	Name   string `json:"name,omitempty"`   // Customized name for device, or MAC address
+	Serial string `json:"serial,omitempty"` // Serial number of device
+}
+type ResponseDevicesGetOrganizationInventoryDevice struct {
+	ClaimedAt             string                                                  `json:"claimedAt,omitempty"`             // Claimed time of the device
+	CountryCode           string                                                  `json:"countryCode,omitempty"`           // Country/region code from device, network, or store order
+	Details               *[]ResponseDevicesGetOrganizationInventoryDeviceDetails `json:"details,omitempty"`               // Additional device information
+	LicenseExpirationDate string                                                  `json:"licenseExpirationDate,omitempty"` // License expiration date of the device
+	Mac                   string                                                  `json:"mac,omitempty"`                   // MAC address of the device
+	Model                 string                                                  `json:"model,omitempty"`                 // Model type of the device
+	Name                  string                                                  `json:"name,omitempty"`                  // Name of the device
+	NetworkID             string                                                  `json:"networkId,omitempty"`             // Network Id of the device
+	OrderNumber           string                                                  `json:"orderNumber,omitempty"`           // Order number of the device
+	ProductType           string                                                  `json:"productType,omitempty"`           // Product type of the device
+	Serial                string                                                  `json:"serial,omitempty"`                // Serial number of the device
+	Tags                  []string                                                `json:"tags,omitempty"`                  // Device tags
+}
+type ResponseDevicesGetOrganizationInventoryDeviceDetails struct {
+	Name  string `json:"name,omitempty"`  // Additional property name
+	Value string `json:"value,omitempty"` // Additional property value
+}
+type ResponseDevicesCloneOrganizationSwitchDevices struct {
 	SourceSerial  string   `json:"sourceSerial,omitempty"`  // Serial number of the source switch (must be on a network not bound to a template)
 	TargetSerials []string `json:"targetSerials,omitempty"` // Array of serial numbers of one or more target switches (must be on a network not bound to a template)
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
-	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
-	Mac     string                                                                                     `json:"mac,omitempty"`     // The MAC address of the device.
-	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
-	Serial  string                                                                                     `json:"serial,omitempty"`  // The serial number for the device.
+type ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice []ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice // Array of ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice struct {
+	ByBand  *[]ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Mac     string                                                                               `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                               `json:"serial,omitempty"`  // The serial number for the device.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand struct {
-	Band    string                                                                                          `json:"band,omitempty"`    // The band for the given metrics.
-	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
-	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
-	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBand struct {
+	Band    string                                                                                    `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandNonWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandTotal struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceByBandWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByDeviceNetwork struct {
 	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetwork struct {
-	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
-	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+type ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork []ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork // Array of ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork struct {
+	ByBand  *[]ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	Network *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand struct {
-	Band    string                                                                                           `json:"band,omitempty"`    // The band for the given metrics.
-	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
-	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
-	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBand struct {
+	Band    string                                                                                     `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandNonWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandTotal struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkByBandWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetworkNetwork struct {
 	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval struct {
-	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
-	EndTs   string                                                                                                      `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
-	Mac     string                                                                                                      `json:"mac,omitempty"`     // The MAC address of the device.
-	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
-	Serial  string                                                                                                      `json:"serial,omitempty"`  // The serial number for the device.
-	StartTs string                                                                                                      `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+type ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval []ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval // Array of ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval struct {
+	ByBand  *[]ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Mac     string                                                                                                `json:"mac,omitempty"`     // The MAC address of the device.
+	Network *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	Serial  string                                                                                                `json:"serial,omitempty"`  // The serial number for the device.
+	StartTs string                                                                                                `json:"startTs,omitempty"` // The start time of the channel utilization interval.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand struct {
-	Band    string                                                                                                           `json:"band,omitempty"`    // The band for the given metrics.
-	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
-	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
-	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBand struct {
+	Band    string                                                                                                     `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandNonWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandTotal struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalByBandWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalNetwork struct {
 	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval []ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval // Array of ResponseOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval struct {
-	ByBand  *[]ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
-	EndTs   string                                                                                                       `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
-	Network *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
-	StartTs string                                                                                                       `json:"startTs,omitempty"` // The start time of the channel utilization interval.
+type ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval []ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval // Array of ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval struct {
+	ByBand  *[]ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand `json:"byBand,omitempty"`  // Channel utilization broken down by band.
+	EndTs   string                                                                                                 `json:"endTs,omitempty"`   // The end time of the channel utilization interval.
+	Network *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork  `json:"network,omitempty"` // Network for the given utilization metrics.
+	StartTs string                                                                                                 `json:"startTs,omitempty"` // The start time of the channel utilization interval.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand struct {
-	Band    string                                                                                                            `json:"band,omitempty"`    // The band for the given metrics.
-	NonWifi *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
-	Total   *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
-	Wifi    *ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBand struct {
+	Band    string                                                                                                      `json:"band,omitempty"`    // The band for the given metrics.
+	NonWifi *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi `json:"nonWifi,omitempty"` // An object containing non-wifi utilization.
+	Total   *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal   `json:"total,omitempty"`   // An object containing total channel utilization.
+	Wifi    *ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi    `json:"wifi,omitempty"`    // An object containing wifi utilization.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandNonWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of non-wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandTotal struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of total channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalByBandWifi struct {
 	Percentage *float64 `json:"percentage,omitempty"` // Percentage of wifi channel utiliation for the given band.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalNetwork struct {
 	ID string `json:"id,omitempty"` // Network ID of the given utilization metrics.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByClient []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClient // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByClient
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClient struct {
-	Client     *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientClient     `json:"client,omitempty"`     // Client.
-	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
-	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientNetwork    `json:"network,omitempty"`    // Network.
-	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+type ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient []ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClient // Array of ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClient struct {
+	Client     *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientClient     `json:"client,omitempty"`     // Client.
+	Downstream *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientClient struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientClient struct {
 	ID  string `json:"id,omitempty"`  // Client ID.
 	Mac string `json:"mac,omitempty"` // MAC address.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientDownstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientDownstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
 	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientNetwork struct {
 	ID   string `json:"id,omitempty"`   // Network ID.
 	Name string `json:"name,omitempty"` // Name of the network.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByClientUpstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByClientUpstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
 	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDevice struct {
-	Device     *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDevice     `json:"device,omitempty"`     // Device.
-	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
-	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceNetwork    `json:"network,omitempty"`    // Network.
-	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+type ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice []ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDevice // Array of ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDevice struct {
+	Device     *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceDevice     `json:"device,omitempty"`     // Device.
+	Downstream *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDevice struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceDevice struct {
 	Mac    string `json:"mac,omitempty"`    // MAC address
 	Name   string `json:"name,omitempty"`   // Name
 	Serial string `json:"serial,omitempty"` // Serial Number
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceDownstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceDownstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
 	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceNetwork struct {
 	ID   string `json:"id,omitempty"`   // Network ID.
 	Name string `json:"name,omitempty"` // Name of the network.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByDeviceUpstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByDeviceUpstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
 	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork []ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork // Array of ResponseOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetwork struct {
-	Downstream *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
-	Network    *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkNetwork    `json:"network,omitempty"`    // Network.
-	Upstream   *ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
+type ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork []ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetwork // Array of ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetwork struct {
+	Downstream *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkDownstream `json:"downstream,omitempty"` // Packets sent from an AP to a client.
+	Network    *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkNetwork    `json:"network,omitempty"`    // Network.
+	Upstream   *ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkUpstream   `json:"upstream,omitempty"`   // Packets sent from a client to an AP.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkDownstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkDownstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by an AP that did not reach the client.
 	Total          *int     `json:"total,omitempty"`          // Total packets received by a client.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkNetwork struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkNetwork struct {
 	ID   string `json:"id,omitempty"`   // Network ID.
 	Name string `json:"name,omitempty"` // Name of the network.
 }
-type ResponseItemOrganizationsGetOrganizationWirelessDevicesPacketLossByNetworkUpstream struct {
+type ResponseItemDevicesGetOrganizationWirelessDevicesPacketLossByNetworkUpstream struct {
 	LossPercentage *float64 `json:"lossPercentage,omitempty"` // Percentage of lost packets.
 	Lost           *int     `json:"lost,omitempty"`           // Total packets sent by a client and did not reach the AP.
 	Total          *int     `json:"total,omitempty"`          // Total packets sent by a client to an AP.
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItems `json:"items,omitempty"` // List of Catalyst access points information
-	Meta  *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItems `json:"items,omitempty"` // List of Catalyst access points information
+	Meta  *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItems struct {
-	Controller  *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController `json:"controller,omitempty"`  // Associated wireless controller
-	CountryCode string                                                                                         `json:"countryCode,omitempty"` // Country code (2 characters)
-	Details     *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails  `json:"details,omitempty"`     // Catalyst access point details
-	JoinedAt    string                                                                                         `json:"joinedAt,omitempty"`    // The time when AP joins wireless controller
-	Mode        string                                                                                         `json:"mode,omitempty"`        // AP mode (local, flex, etc.)
-	Model       string                                                                                         `json:"model,omitempty"`       // AP model
-	Network     *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork    `json:"network,omitempty"`     // Catalyst access point network
-	Serial      string                                                                                         `json:"serial,omitempty"`      // AP cloud ID
-	Tags        *[]ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags     `json:"tags,omitempty"`        // The tags of the catalyst access point
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItems struct {
+	Controller  *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController `json:"controller,omitempty"`  // Associated wireless controller
+	CountryCode string                                                                                   `json:"countryCode,omitempty"` // Country code (2 characters)
+	Details     *[]ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails  `json:"details,omitempty"`     // Catalyst access point details
+	JoinedAt    string                                                                                   `json:"joinedAt,omitempty"`    // The time when AP joins wireless controller
+	Mode        string                                                                                   `json:"mode,omitempty"`        // AP mode (local, flex, etc.)
+	Model       string                                                                                   `json:"model,omitempty"`       // AP model
+	Network     *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork    `json:"network,omitempty"`     // Catalyst access point network
+	Serial      string                                                                                   `json:"serial,omitempty"`      // AP cloud ID
+	Tags        *[]ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags     `json:"tags,omitempty"`        // The tags of the catalyst access point
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController struct {
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsController struct {
 	Serial string `json:"serial,omitempty"` // Associated wireless controller cloud ID
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails struct {
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsDetails struct {
 	Name  string `json:"name,omitempty"`  // Item name
 	Value string `json:"value,omitempty"` // Item value
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork struct {
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsNetwork struct {
 	ID string `json:"id,omitempty"` // Catalyst access point network ID
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags struct {
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceItemsTags struct {
 	Policy string `json:"policy,omitempty"` // Policy tag
 	Rf     string `json:"rf,omitempty"`     // RF tag
 	Site   string `json:"site,omitempty"`   // Site tag
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L2 interfaces
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L2 interfaces
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems struct {
-	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 2 interfaces belongs to the wireless LAN controller
-	Serial     string                                                                                              `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItems struct {
+	Interfaces *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                        `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces struct {
-	ChannelGroup     *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`     // The channel group of this wireless LAN controller interface
-	Description      string                                                                                                        `json:"description,omitempty"`      // The description of the wireless LAN controller interface
-	Enabled          *bool                                                                                                         `json:"enabled,omitempty"`          // The status of the wireless LAN controller interface
-	IsRedundancyPort *bool                                                                                                         `json:"isRedundancyPort,omitempty"` // Indicate whether the interface is a redundancy port used to perform HA role negotiation
-	IsUplink         *bool                                                                                                         `json:"isUplink,omitempty"`         // Indicate whether the interface is uplink
-	LinkNegotiation  string                                                                                                        `json:"linkNegotiation,omitempty"`  // The interface negotiation mode
-	Mac              string                                                                                                        `json:"mac,omitempty"`              // The MAC address of the wireless LAN controller interface
-	Module           *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule       `json:"module,omitempty"`           // The module of this wireless LAN controller interface
-	Name             string                                                                                                        `json:"name,omitempty"`             // The name of the wireless LAN controller interface
-	Speed            string                                                                                                        `json:"speed,omitempty"`            // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
-	Status           string                                                                                                        `json:"status,omitempty"`           // The status of the wireless LAN controller interface
-	VLAN             *int                                                                                                          `json:"vlan,omitempty"`             // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfaces struct {
+	ChannelGroup     *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`     // The channel group of this wireless LAN controller interface
+	Description      string                                                                                                  `json:"description,omitempty"`      // The description of the wireless LAN controller interface
+	Enabled          *bool                                                                                                   `json:"enabled,omitempty"`          // The status of the wireless LAN controller interface
+	IsRedundancyPort *bool                                                                                                   `json:"isRedundancyPort,omitempty"` // Indicate whether the interface is a redundancy port used to perform HA role negotiation
+	IsUplink         *bool                                                                                                   `json:"isUplink,omitempty"`         // Indicate whether the interface is uplink
+	LinkNegotiation  string                                                                                                  `json:"linkNegotiation,omitempty"`  // The interface negotiation mode
+	Mac              string                                                                                                  `json:"mac,omitempty"`              // The MAC address of the wireless LAN controller interface
+	Module           *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule       `json:"module,omitempty"`           // The module of this wireless LAN controller interface
+	Name             string                                                                                                  `json:"name,omitempty"`             // The name of the wireless LAN controller interface
+	Speed            string                                                                                                  `json:"speed,omitempty"`            // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status           string                                                                                                  `json:"status,omitempty"`           // The status of the wireless LAN controller interface
+	VLAN             *int                                                                                                    `json:"vlan,omitempty"`             // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesChannelGroup struct {
 	Number *int `json:"number,omitempty"` // The interface channel group number
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceItemsInterfacesModule struct {
 	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces historical status
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces historical status
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems struct {
-	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 2 interfaces belongs to the wireless LAN controller
-	Serial     string                                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 2 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                             `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces struct {
-	Changes *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 2 interfaces of the wireless LAN controller
-	Mac     string                                                                                                                          `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
-	Name    string                                                                                                                          `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 2 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                    `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                    `json:"name,omitempty"`    // The name of the wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
 	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
 	Status   string   `json:"status,omitempty"`   // The status of the interface
 	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
 	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces usage
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 2 interfaces usage
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems struct {
-	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 2 interfaces of the wireless LAN controller. Usage is in bytes
-	Serial   string                                                                                                          `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 2 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                    `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalItemsReadings struct {
 	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
 	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
 	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
 	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L3 interfaces
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems `json:"items,omitempty"` // Wireless LAN controller L3 interfaces
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems struct {
-	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 3 interfaces belongs to the wireless LAN controller
-	Serial     string                                                                                              `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItems struct {
+	Interfaces *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                        `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces struct {
-	Addresses       *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses  `json:"addresses,omitempty"`       // Available addresses for the interface.
-	ChannelGroup    *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`    // The channel group of this wireless LAN controller interface
-	Description     string                                                                                                        `json:"description,omitempty"`     // The description of the wireless LAN controller interface
-	IsUplink        *bool                                                                                                         `json:"isUplink,omitempty"`        // Indicate whether the interface is uplink
-	LinkNegotiation string                                                                                                        `json:"linkNegotiation,omitempty"` // The interface negotiation mode
-	Mac             string                                                                                                        `json:"mac,omitempty"`             // The MAC address of the wireless LAN controller interface
-	Module          *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule       `json:"module,omitempty"`          // The module of this wireless LAN controller interface
-	Name            string                                                                                                        `json:"name,omitempty"`            // The name of the wireless LAN controller interface
-	Speed           string                                                                                                        `json:"speed,omitempty"`           // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
-	Status          string                                                                                                        `json:"status,omitempty"`          // The status of the wireless LAN controller interface
-	VLAN            *int                                                                                                          `json:"vlan,omitempty"`            // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
-	Vrf             *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf          `json:"vrf,omitempty"`             // The virtual routing and forwarding (VRF) for the wireless LAN controller interface
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfaces struct {
+	Addresses       *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses  `json:"addresses,omitempty"`       // Available addresses for the interface.
+	ChannelGroup    *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup `json:"channelGroup,omitempty"`    // The channel group of this wireless LAN controller interface
+	Description     string                                                                                                  `json:"description,omitempty"`     // The description of the wireless LAN controller interface
+	IsUplink        *bool                                                                                                   `json:"isUplink,omitempty"`        // Indicate whether the interface is uplink
+	LinkNegotiation string                                                                                                  `json:"linkNegotiation,omitempty"` // The interface negotiation mode
+	Mac             string                                                                                                  `json:"mac,omitempty"`             // The MAC address of the wireless LAN controller interface
+	Module          *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule       `json:"module,omitempty"`          // The module of this wireless LAN controller interface
+	Name            string                                                                                                  `json:"name,omitempty"`            // The name of the wireless LAN controller interface
+	Speed           string                                                                                                  `json:"speed,omitempty"`           // The current data transfer rate which the interface is operating at. enum = [1 Gbps, 2 Gbps, 5 Gbps, 10 Gbps, 20 Gbps, 40 Gbps, 100 Gbps]
+	Status          string                                                                                                  `json:"status,omitempty"`          // The status of the wireless LAN controller interface
+	VLAN            *int                                                                                                    `json:"vlan,omitempty"`            // The VLAN of the switch port. For a trunk port, this is the native VLAN. A null value will clear the value set for trunk ports.
+	Vrf             *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf          `json:"vrf,omitempty"`             // The virtual routing and forwarding (VRF) for the wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesAddresses struct {
 	Address  string `json:"address,omitempty"`  // The address of the wireless LAN controller interface
 	Protocol string `json:"protocol,omitempty"` // Type of address for the device uplink. Available options are: ipv4, ipv6. enum = [ipv4, ipv6]
 	Subnet   string `json:"subnet,omitempty"`   // The address of the wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesChannelGroup struct {
 	Number *int `json:"number,omitempty"` // The interface channel group number
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesModule struct {
 	Model string `json:"model,omitempty"` // The module type of this wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceItemsInterfacesVrf struct {
 	Name string `json:"name,omitempty"` // The virtual routing and forwarding (VRF) name
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces historical status
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces historical status
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems struct {
-	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 3 interfaces belongs to the wireless LAN controller
-	Serial     string                                                                                                                   `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItems struct {
+	Interfaces *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces `json:"interfaces,omitempty"` // layer 3 interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                             `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces struct {
-	Changes *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 3 interfaces of the wireless LAN controller
-	Mac     string                                                                                                                          `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
-	Name    string                                                                                                                          `json:"name,omitempty"`    // The name of the wireless LAN controller interface
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfaces struct {
+	Changes *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges `json:"changes,omitempty"` // The statuses of layer 3 interfaces of the wireless LAN controller
+	Mac     string                                                                                                                    `json:"mac,omitempty"`     // The MAC address of the wireless LAN controller interface
+	Name    string                                                                                                                    `json:"name,omitempty"`    // The name of the wireless LAN controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceItemsInterfacesChanges struct {
 	Errors   []string `json:"errors,omitempty"`   // All errors present on the port
 	Status   string   `json:"status,omitempty"`   // The status of the interface
 	Ts       string   `json:"ts,omitempty"`       // The timestamp of current status of the interface
 	Warnings []string `json:"warnings,omitempty"` // All warnings present on the port
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces usage
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller layer 3 interfaces usage
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems struct {
-	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 3 interfaces of the wireless LAN controller. Usage is in bytes
-	Serial   string                                                                                                          `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItems struct {
+	Readings *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings `json:"readings,omitempty"` // The usages of layer 3 interfaces of the wireless LAN controller. Usage is in bytes
+	Serial   string                                                                                                    `json:"serial,omitempty"`   // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalItemsReadings struct {
 	Mac  string `json:"mac,omitempty"`  // The MAC address of the wireless controller interface
 	Name string `json:"name,omitempty"` // The name of the wireless LAN controller interface
 	Recv *int   `json:"recv,omitempty"` // The volume of data, in bytes/sec, received by wireless controller interface
 	Send *int   `json:"send,omitempty"` // The volume of data, in bytes/sec, transmitted by wireless controller interface
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems `json:"items,omitempty"` // Wireless LAN controller interfaces packets statuses
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems `json:"items,omitempty"` // Wireless LAN controller interfaces packets statuses
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems struct {
-	Interfaces *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Interfaces belongs to the wireless LAN controller
-	Serial     string                                                                                                           `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItems struct {
+	Interfaces *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces `json:"interfaces,omitempty"` // Interfaces belongs to the wireless LAN controller
+	Serial     string                                                                                                     `json:"serial,omitempty"`     // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces struct {
-	Name     string                                                                                                                   `json:"name,omitempty"`     // The name of the wireless LAN controller interface
-	Readings *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings `json:"readings,omitempty"` // The status of packets counter on the interfaces of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfaces struct {
+	Name     string                                                                                                             `json:"name,omitempty"`     // The name of the wireless LAN controller interface
+	Readings *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings `json:"readings,omitempty"` // The status of packets counter on the interfaces of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings struct {
-	Name  string                                                                                                                     `json:"name,omitempty"`  // The type of packets being counted
-	Rate  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate `json:"rate,omitempty"`  // The interface packet rates measured in packets per second
-	Recv  *int                                                                                                                       `json:"recv,omitempty"`  // The total count of packets received by the interface during the timespan
-	Send  *int                                                                                                                       `json:"send,omitempty"`  // The total count of packets sent by the interface during the timespan
-	Total *int                                                                                                                       `json:"total,omitempty"` // The total count of sent and received packets during the timespan
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadings struct {
+	Name  string                                                                                                               `json:"name,omitempty"`  // The type of packets being counted
+	Rate  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate `json:"rate,omitempty"`  // The interface packet rates measured in packets per second
+	Recv  *int                                                                                                                 `json:"recv,omitempty"`  // The total count of packets received by the interface during the timespan
+	Send  *int                                                                                                                 `json:"send,omitempty"`  // The total count of packets sent by the interface during the timespan
+	Total *int                                                                                                                 `json:"total,omitempty"` // The total count of sent and received packets during the timespan
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceItemsInterfacesReadingsRate struct {
 	Recv  *int `json:"recv,omitempty"`  // The rate of packets received during the timespan
 	Send  *int `json:"send,omitempty"`  // The rate of packets sent during the timespan
 	Total *int `json:"total,omitempty"` // The rate of all packets sent and received during the timespan
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller interfaces usage data
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller interfaces usage data
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems struct {
-	Intervals *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of interfaces usage data of the wireless LAN controller
-	Serial    string                                                                                                         `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItems struct {
+	Intervals *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of interfaces usage data of the wireless LAN controller
+	Serial    string                                                                                                   `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals struct {
-	ByInterface *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface `json:"byInterface,omitempty"` // The usage data on the interfaces of the wireless LAN controller
-	EndTs       string                                                                                                                    `json:"endTs,omitempty"`       // The end time interval snapshots of the query range with iso8601 format
-	Overall     *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall       `json:"overall,omitempty"`     // The overall usage of all queried interfaces of the wireless LAN controller
-	StartTs     string                                                                                                                    `json:"startTs,omitempty"`     // The start time interval snapshots of the query range with iso8601 format
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervals struct {
+	ByInterface *[]ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface `json:"byInterface,omitempty"` // The usage data on the interfaces of the wireless LAN controller
+	EndTs       string                                                                                                              `json:"endTs,omitempty"`       // The end time interval snapshots of the query range with iso8601 format
+	Overall     *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall       `json:"overall,omitempty"`     // The overall usage of all queried interfaces of the wireless LAN controller
+	StartTs     string                                                                                                              `json:"startTs,omitempty"`     // The start time interval snapshots of the query range with iso8601 format
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface struct {
-	Name  string                                                                                                                       `json:"name,omitempty"`  // The name of the wireless LAN controller interface
-	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage `json:"usage,omitempty"` // The usage on the interfaces of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterface struct {
+	Name  string                                                                                                                 `json:"name,omitempty"`  // The name of the wireless LAN controller interface
+	Usage *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage `json:"usage,omitempty"` // The usage on the interfaces of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsByInterfaceUsage struct {
 	Recv  *int `json:"recv,omitempty"`  // The received usage on the interface during the interval, unit is bit/sec
 	Send  *int `json:"send,omitempty"`  // The sent usage on the interface during the interval, unit is bit/sec
 	Total *int `json:"total,omitempty"` // The total usage on the interface during the interval, unit is bit/sec
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalItemsIntervalsOverall struct {
 	Recv  *int `json:"recv,omitempty"`  // The received usage of all queried interfaces during the interval, unit is bit/sec
 	Send  *int `json:"send,omitempty"`  // The sent usage of all queried interfaces during the interval, unit is bit/sec
 	Total *int `json:"total,omitempty"` // The total usage of all queried interfaces during the interval, unit is bit/sec
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory []ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory // Array of ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory struct {
-	Items *[]ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems `json:"items,omitempty"` // Wireless LAN controller HA failover events
-	Meta  *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory []ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory // Array of ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory struct {
+	Items *[]ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems `json:"items,omitempty"` // Wireless LAN controller HA failover events
+	Meta  *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems struct {
-	Active *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive `json:"active,omitempty"` // Details about the active unit
-	Failed *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed `json:"failed,omitempty"` // Details about the failed unit
-	Reason string                                                                                                 `json:"reason,omitempty"` // Failover reason
-	Serial string                                                                                                 `json:"serial,omitempty"` // Wireless LAN controller cloud ID
-	Ts     string                                                                                                 `json:"ts,omitempty"`     // Failover time
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItems struct {
+	Active *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive `json:"active,omitempty"` // Details about the active unit
+	Failed *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed `json:"failed,omitempty"` // Details about the failed unit
+	Reason string                                                                                           `json:"reason,omitempty"` // Failover reason
+	Serial string                                                                                           `json:"serial,omitempty"` // Wireless LAN controller cloud ID
+	Ts     string                                                                                           `json:"ts,omitempty"`     // Failover time
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive struct {
-	Chassis *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis `json:"chassis,omitempty"` // Details about the active unit chassis
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActive struct {
+	Chassis *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis `json:"chassis,omitempty"` // Details about the active unit chassis
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis struct {
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsActiveChassis struct {
 	Name string `json:"name,omitempty"` // The name of the active chassis unit
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed struct {
-	Chassis *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis `json:"chassis,omitempty"` // Details about the failed unit chassis
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailed struct {
+	Chassis *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis `json:"chassis,omitempty"` // Details about the failed unit chassis
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis struct {
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryItemsFailedChassis struct {
 	Name string `json:"name,omitempty"` // The name of the failed chassis unit
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta struct {
-	Counts *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMeta struct {
+	Counts *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts struct {
-	Items *ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCounts struct {
+	Items *ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseItemOrganizationsGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems struct {
+type ResponseItemDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatuses struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItems `json:"items,omitempty"` // Wireless LAN controller redundancy statuses
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItems `json:"items,omitempty"` // Wireless LAN controller redundancy statuses
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItems struct {
-	Enabled     *bool                                                                                         `json:"enabled,omitempty"`     // Wireless LAN controller redundancy enablement
-	Failover    *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover `json:"failover,omitempty"`    // Wireless LAN controller failover information
-	MobilityMac string                                                                                        `json:"mobilityMac,omitempty"` // Wireless LAN controller redundancy mobility mac
-	Mode        string                                                                                        `json:"mode,omitempty"`        // Wireless LAN controller redundancy SSO (stateful switchover)
-	Serial      string                                                                                        `json:"serial,omitempty"`      // Wireless LAN controller cloud ID
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItems struct {
+	Enabled     *bool                                                                                   `json:"enabled,omitempty"`     // Wireless LAN controller redundancy enablement
+	Failover    *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover `json:"failover,omitempty"`    // Wireless LAN controller failover information
+	MobilityMac string                                                                                  `json:"mobilityMac,omitempty"` // Wireless LAN controller redundancy mobility mac
+	Mode        string                                                                                  `json:"mode,omitempty"`        // Wireless LAN controller redundancy SSO (stateful switchover)
+	Serial      string                                                                                  `json:"serial,omitempty"`      // Wireless LAN controller cloud ID
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts `json:"counts,omitempty"` // Wireless LAN controller switchover counts
-	Last   *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast   `json:"last,omitempty"`   // Wireless LAN controller last failover information
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailover struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts `json:"counts,omitempty"` // Wireless LAN controller switchover counts
+	Last   *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast   `json:"last,omitempty"`   // Wireless LAN controller last failover information
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverCounts struct {
 	Total *int `json:"total,omitempty"` // Total number of failovers
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesItemsFailoverLast struct {
 	Reason string `json:"reason,omitempty"` // Wireless LAN controller last redundancy switchover reason
 	Ts     string `json:"ts,omitempty"`     // Wireless LAN controller last redundancy switchover time
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatusesMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval struct {
-	Items *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller CPU usage data
-	Meta  *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval struct {
+	Items *[]ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems `json:"items,omitempty"` // Wireless LAN controller CPU usage data
+	Meta  *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta    `json:"meta,omitempty"`  // Metadata relevant to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems struct {
-	Intervals *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of CPU usage data of the wireless LAN controller
-	Serial    string                                                                                                           `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItems struct {
+	Intervals *[]ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals `json:"intervals,omitempty"` // Time interval snapshots of CPU usage data of the wireless LAN controller
+	Serial    string                                                                                                     `json:"serial,omitempty"`    // The cloud ID of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals struct {
-	ByCore  *[]ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore `json:"byCore,omitempty"`  // The CPU usage per core of the wireless LAN controller
-	EndTs   string                                                                                                                 `json:"endTs,omitempty"`   // The end time of the query range  with iso8601 format
-	Overall *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall  `json:"overall,omitempty"` // The overall CPU usage of the wireless LAN controller
-	StartTs string                                                                                                                 `json:"startTs,omitempty"` // The start time of the query range with iso8601 format
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervals struct {
+	ByCore  *[]ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore `json:"byCore,omitempty"`  // The CPU usage per core of the wireless LAN controller
+	EndTs   string                                                                                                           `json:"endTs,omitempty"`   // The end time of the query range  with iso8601 format
+	Overall *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall  `json:"overall,omitempty"` // The overall CPU usage of the wireless LAN controller
+	StartTs string                                                                                                           `json:"startTs,omitempty"` // The start time of the query range with iso8601 format
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore struct {
-	Name  string                                                                                                                    `json:"name,omitempty"`  // The CPU core name
-	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage `json:"usage,omitempty"` // The specific core CPU usage of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCore struct {
+	Name  string                                                                                                              `json:"name,omitempty"`  // The CPU core name
+	Usage *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage `json:"usage,omitempty"` // The specific core CPU usage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage struct {
-	Average *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage `json:"average,omitempty"` // The specific core average CPU usage of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsage struct {
+	Average *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage `json:"average,omitempty"` // The specific core average CPU usage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsByCoreUsageAverage struct {
 	Percentage *float64 `json:"percentage,omitempty"` // The specific core CPU usage percentage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall struct {
-	Usage *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage `json:"usage,omitempty"` // The CPU usage of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverall struct {
+	Usage *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage `json:"usage,omitempty"` // The CPU usage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage struct {
-	Average *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage `json:"average,omitempty"` // The average CPU usage of the wireless LAN controller
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsage struct {
+	Average *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage `json:"average,omitempty"` // The average CPU usage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalItemsIntervalsOverallUsageAverage struct {
 	Percentage *float64 `json:"percentage,omitempty"` // The CPU usage percentage of the wireless LAN controller
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta struct {
-	Counts *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMeta struct {
+	Counts *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts `json:"counts,omitempty"` // Counts relating to the paginated dataset
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts struct {
-	Items *ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCounts struct {
+	Items *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems `json:"items,omitempty"` // Counts relating to the paginated items
 }
-type ResponseOrganizationsGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems struct {
+type ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalMetaCountsItems struct {
 	Remaining *int `json:"remaining,omitempty"` // The number of items in the dataset that are available on subsequent pages
 	Total     *int `json:"total,omitempty"`     // The total number of items in the dataset
 }
@@ -1638,7 +1689,26 @@ type RequestDevicesInstallNetworkSmDeviceApps struct {
 type RequestDevicesUninstallNetworkSmDeviceApps struct {
 	AppIDs []string `json:"appIds,omitempty"` // ids of applications to be uninstalled
 }
-type RequestOrganizationsCloneOrganizationSwitchDevices struct {
+type RequestDevicesBulkUpdateOrganizationDevicesDetails struct {
+	Details *[]RequestDevicesBulkUpdateOrganizationDevicesDetailsDetails `json:"details,omitempty"` // An array of details
+	Serials []string                                                     `json:"serials,omitempty"` // A list of serials of devices to update
+}
+type RequestDevicesBulkUpdateOrganizationDevicesDetailsDetails struct {
+	Name  string `json:"name,omitempty"`  // Name of device detail
+	Value string `json:"value,omitempty"` // Value of device detail
+}
+type RequestDevicesCreateOrganizationInventoryDevicesSwapsBulk struct {
+	Swaps *[]RequestDevicesCreateOrganizationInventoryDevicesSwapsBulkSwaps `json:"swaps,omitempty"` // List of replacments to perform
+}
+type RequestDevicesCreateOrganizationInventoryDevicesSwapsBulkSwaps struct {
+	AfterAction string                                                                 `json:"afterAction,omitempty"` // What action to perform on devices.old after the device cloning is complete. 'remove from network' will return the device to inventory, while 'release from organization inventory' will free up the license attached to the device.
+	Devices     *RequestDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices `json:"devices,omitempty"`     // The devices involved in the swap.
+}
+type RequestDevicesCreateOrganizationInventoryDevicesSwapsBulkSwapsDevices struct {
+	New string `json:"new,omitempty"` // The serial of the device that the old device's settings will be cloned to.
+	Old string `json:"old,omitempty"` // The serial of the device to be cloned.
+}
+type RequestDevicesCloneOrganizationSwitchDevices struct {
 	SourceSerial  string   `json:"sourceSerial,omitempty"`  // Serial number of the source switch (must be on a network not bound to a template)
 	TargetSerials []string `json:"targetSerials,omitempty"` // Array of serial numbers of one or more target switches (must be on a network not bound to a template)
 }
@@ -1650,6 +1720,7 @@ type RequestOrganizationsCloneOrganizationSwitchDevices struct {
 
 
 */
+
 func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}"
 	s.rateLimiterBucket.Wait(1)
@@ -1683,6 +1754,7 @@ func (s *DevicesService) GetDevice(serial string) (*ResponseDevicesGetDevice, *r
 
 
 */
+
 func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesGetDeviceCellularSims, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/cellular/sims"
 	s.rateLimiterBucket.Wait(1)
@@ -1717,6 +1789,7 @@ func (s *DevicesService) GetDeviceCellularSims(serial string) (*ResponseDevicesG
 
 
 */
+
 func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryParams *GetDeviceClientsQueryParams) (*ResponseDevicesGetDeviceClients, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/clients"
 	s.rateLimiterBucket.Wait(1)
@@ -1753,6 +1826,7 @@ func (s *DevicesService) GetDeviceClients(serial string, getDeviceClientsQueryPa
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsArpTable(serial string, arpTableID string) (*ResponseDevicesGetDeviceLiveToolsArpTable, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/arpTable/{arpTableId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1788,6 +1862,7 @@ func (s *DevicesService) GetDeviceLiveToolsArpTable(serial string, arpTableID st
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsCableTest(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsCableTest, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/cableTest/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -1823,6 +1898,7 @@ func (s *DevicesService) GetDeviceLiveToolsCableTest(serial string, id string) (
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsLedsBlink(serial string, ledsBlinkID string) (*ResponseDevicesGetDeviceLiveToolsLedsBlink, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/leds/blink/{ledsBlinkId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1858,6 +1934,7 @@ func (s *DevicesService) GetDeviceLiveToolsLedsBlink(serial string, ledsBlinkID 
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPing, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/ping/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -1893,6 +1970,7 @@ func (s *DevicesService) GetDeviceLiveToolsPing(serial string, id string) (*Resp
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) (*ResponseDevicesGetDeviceLiveToolsPingDevice, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/pingDevice/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -1928,6 +2006,7 @@ func (s *DevicesService) GetDeviceLiveToolsPingDevice(serial string, id string) 
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsThroughputTest(serial string, throughputTestID string) (*ResponseDevicesGetDeviceLiveToolsThroughputTest, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/throughputTest/{throughputTestId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1963,6 +2042,7 @@ func (s *DevicesService) GetDeviceLiveToolsThroughputTest(serial string, through
 
 
 */
+
 func (s *DevicesService) GetDeviceLiveToolsWakeOnLan(serial string, wakeOnLanID string) (*ResponseDevicesGetDeviceLiveToolsWakeOnLan, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/liveTools/wakeOnLan/{wakeOnLanId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1997,6 +2077,7 @@ func (s *DevicesService) GetDeviceLiveToolsWakeOnLan(serial string, wakeOnLanID 
 
 
 */
+
 func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDeviceLldpCdp, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lldpCdp"
 	s.rateLimiterBucket.Wait(1)
@@ -2031,6 +2112,7 @@ func (s *DevicesService) GetDeviceLldpCdp(serial string) (*ResponseDevicesGetDev
 
 
 */
+
 func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDeviceLossAndLatencyHistoryQueryParams *GetDeviceLossAndLatencyHistoryQueryParams) (*ResponseDevicesGetDeviceLossAndLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/lossAndLatencyHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -2066,6 +2148,7 @@ func (s *DevicesService) GetDeviceLossAndLatencyHistory(serial string, getDevice
 
 
 */
+
 func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseDevicesGetDeviceManagementInterface, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/managementInterface"
 	s.rateLimiterBucket.Wait(1)
@@ -2099,6 +2182,7 @@ func (s *DevicesService) GetDeviceManagementInterface(serial string) (*ResponseD
 
 
 */
+
 func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGetNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices"
 	s.rateLimiterBucket.Wait(1)
@@ -2133,6 +2217,7 @@ func (s *DevicesService) GetNetworkDevices(networkID string) (*ResponseDevicesGe
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCellularUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/cellularUsageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -2168,6 +2253,7 @@ func (s *DevicesService) GetNetworkSmDeviceCellularUsageHistory(networkID string
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceCerts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/certs"
 	s.rateLimiterBucket.Wait(1)
@@ -2203,6 +2289,7 @@ func (s *DevicesService) GetNetworkSmDeviceCerts(networkID string, deviceID stri
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceDeviceProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/deviceProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -2238,6 +2325,7 @@ func (s *DevicesService) GetNetworkSmDeviceDeviceProfiles(networkID string, devi
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceNetworkAdapters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/networkAdapters"
 	s.rateLimiterBucket.Wait(1)
@@ -2273,6 +2361,7 @@ func (s *DevicesService) GetNetworkSmDeviceNetworkAdapters(networkID string, dev
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceRestrictions, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/restrictions"
 	s.rateLimiterBucket.Wait(1)
@@ -2308,6 +2397,7 @@ func (s *DevicesService) GetNetworkSmDeviceRestrictions(networkID string, device
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSecurityCenters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/securityCenters"
 	s.rateLimiterBucket.Wait(1)
@@ -2343,6 +2433,7 @@ func (s *DevicesService) GetNetworkSmDeviceSecurityCenters(networkID string, dev
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceSoftwares, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/softwares"
 	s.rateLimiterBucket.Wait(1)
@@ -2378,6 +2469,7 @@ func (s *DevicesService) GetNetworkSmDeviceSoftwares(networkID string, deviceID 
 
 
 */
+
 func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID string) (*ResponseDevicesGetNetworkSmDeviceWLANLists, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/wlanLists"
 	s.rateLimiterBucket.Wait(1)
@@ -2413,9 +2505,40 @@ func (s *DevicesService) GetNetworkSmDeviceWLANLists(networkID string, deviceID 
 
 
 */
-func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/availabilities/changeHistory"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams != nil && getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory
+		println("Paginate")
+		getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesAvailabilitiesChangeHistoryPaginate, organizationID, "", getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
@@ -2423,21 +2546,27 @@ func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organ
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationDevicesAvailabilitiesChangeHistory")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesAvailabilitiesChangeHistory")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationDevicesAvailabilitiesChangeHistory)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistoryPaginate(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesAvailabilitiesChangeHistoryQueryParamsConverted := getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.(*GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+
+	return s.GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParamsConverted)
 }
 
 //GetOrganizationDevicesOverviewByModel Lists the count for each device model
@@ -2448,7 +2577,8 @@ func (s *DevicesService) GetOrganizationDevicesAvailabilitiesChangeHistory(organ
 
 
 */
-func (s *DevicesService) GetOrganizationDevicesOverviewByModel(organizationID string, getOrganizationDevicesOverviewByModelQueryParams *GetOrganizationDevicesOverviewByModelQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationDevicesOverviewByModel(organizationID string, getOrganizationDevicesOverviewByModelQueryParams *GetOrganizationDevicesOverviewByModelQueryParams) (*ResponseDevicesGetOrganizationDevicesOverviewByModel, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/overview/byModel"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -2458,20 +2588,21 @@ func (s *DevicesService) GetOrganizationDevicesOverviewByModel(organizationID st
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationDevicesOverviewByModel{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationDevicesOverviewByModel")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationDevicesOverviewByModel")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationDevicesOverviewByModel)
+	return result, response, err
 
 }
 
@@ -2483,9 +2614,40 @@ func (s *DevicesService) GetOrganizationDevicesOverviewByModel(organizationID st
 
 
 */
-func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevices(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams *GetOrganizationFloorPlansAutoLocateDevicesQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevices(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams *GetOrganizationFloorPlansAutoLocateDevicesQueryParams) (*ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/devices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationFloorPlansAutoLocateDevicesQueryParams != nil && getOrganizationFloorPlansAutoLocateDevicesQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices
+		println("Paginate")
+		getOrganizationFloorPlansAutoLocateDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationFloorPlansAutoLocateDevicesPaginate, organizationID, "", getOrganizationFloorPlansAutoLocateDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateDevicesQueryParams)
@@ -2493,21 +2655,27 @@ func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevices(organization
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationFloorPlansAutoLocateDevices")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationFloorPlansAutoLocateDevices")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationFloorPlansAutoLocateDevices)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevicesPaginate(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationFloorPlansAutoLocateDevicesQueryParamsConverted := getOrganizationFloorPlansAutoLocateDevicesQueryParams.(*GetOrganizationFloorPlansAutoLocateDevicesQueryParams)
+
+	return s.GetOrganizationFloorPlansAutoLocateDevices(organizationID, getOrganizationFloorPlansAutoLocateDevicesQueryParamsConverted)
 }
 
 //GetOrganizationInventoryDevicesSwapsBulk List of device swaps for a given request ID ({id}).
@@ -2518,7 +2686,8 @@ func (s *DevicesService) GetOrganizationFloorPlansAutoLocateDevices(organization
 
 
 */
-func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*ResponseDevicesGetOrganizationInventoryDevicesSwapsBulk, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk/{id}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -2527,19 +2696,21 @@ func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetOrganizationInventoryDevicesSwapsBulk{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationInventoryDevicesSwapsBulk")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationInventoryDevicesSwapsBulk")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationInventoryDevicesSwapsBulk)
+	return result, response, err
 
 }
 
@@ -2551,7 +2722,8 @@ func (s *DevicesService) GetOrganizationInventoryDevicesSwapsBulk(organizationID
 
 
 */
-func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, serial string) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, serial string) (*ResponseDevicesGetOrganizationInventoryDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/{serial}"
 	s.rateLimiterBucket.Wait(1)
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
@@ -2560,19 +2732,21 @@ func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, s
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
+		SetResult(&ResponseDevicesGetOrganizationInventoryDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationInventoryDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationInventoryDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationInventoryDevice)
+	return result, response, err
 
 }
 
@@ -2584,9 +2758,40 @@ func (s *DevicesService) GetOrganizationInventoryDevice(organizationID string, s
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
@@ -2594,21 +2799,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevic
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevicePaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesChannelUtilizationByNetwork Get average channel utilization across all bands for all networks in the organization
@@ -2619,9 +2830,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByDevic
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationByNetworkPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
@@ -2629,21 +2871,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwo
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByNetwork")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationByNetwork")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationByNetwork)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetworkPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval Get a time-series of average channel utilization for all bands, segmented by device.
@@ -2654,9 +2902,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationByNetwo
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
@@ -2664,21 +2943,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval Get a time-series of average channel utilization for all bands
@@ -2689,9 +2974,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
@@ -2699,21 +3015,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesPacketLossByClient Get average packet loss for the given timespan for all clients in the organization.
@@ -2724,9 +3046,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesChannelUtilizationHistory
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByClientQueryParams != nil && getOrganizationWirelessDevicesPacketLossByClientQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByClientQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByClientPaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByClientQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByClientQueryParams)
@@ -2734,21 +3087,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organi
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByClient")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByClient")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByClient)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClientPaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByClientQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByClientQueryParams.(*GetOrganizationWirelessDevicesPacketLossByClientQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByClient(organizationID, getOrganizationWirelessDevicesPacketLossByClientQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesPacketLossByDevice Get average packet loss for the given timespan for all devices in the organization
@@ -2759,9 +3118,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByClient(organi
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByDeviceQueryParams != nil && getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
@@ -2769,21 +3159,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organi
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevicePaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByDeviceQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.(*GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByDevice(organizationID, getOrganizationWirelessDevicesPacketLossByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesPacketLossByNetwork Get average packet loss for the given timespan for all networks in the organization.
@@ -2794,9 +3190,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByDevice(organi
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByNetworkQueryParams != nil && getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByNetworkPaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
@@ -2804,21 +3231,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organ
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByNetwork")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesPacketLossByNetwork")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesPacketLossByNetwork)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetworkPaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByNetworkQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.(*GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID, getOrganizationWirelessDevicesPacketLossByNetworkQueryParamsConverted)
 }
 
 //GetOrganizationWirelessDevicesWirelessControllersByDevice List of Catalyst access points information
@@ -2829,9 +3262,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesPacketLossByNetwork(organ
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams *GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams *GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/wirelessControllers/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams != nil && getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesWirelessControllersByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
@@ -2839,21 +3303,27 @@ func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevi
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesWirelessControllersByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessDevicesWirelessControllersByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessDevicesWirelessControllersByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevicePaginate(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParamsConverted := getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.(*GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice List wireless LAN controller layer 2 interfaces in an organization
@@ -2864,9 +3334,40 @@ func (s *DevicesService) GetOrganizationWirelessDevicesWirelessControllersByDevi
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2ByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
@@ -2874,21 +3375,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByD
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice List wireless LAN controller layer 2 interfaces history status in an organization
@@ -2899,9 +3406,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2ByD
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/statuses/changeHistory/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
@@ -2909,21 +3447,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2Sta
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval List wireless LAN controller layer 2 interfaces history usage in an organization
@@ -2934,9 +3478,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2Sta
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
@@ -2944,21 +3519,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2Usa
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice List wireless LAN controller layer 3 interfaces in an organization
@@ -2969,9 +3550,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL2Usa
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3ByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
@@ -2979,21 +3591,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByD
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice List wireless LAN controller layer 3 interfaces history status in an organization
@@ -3004,9 +3622,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3ByD
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/statuses/changeHistory/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
@@ -3014,21 +3663,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3Sta
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval List wireless LAN controller layer 3 interfaces history usage in an organization
@@ -3039,9 +3694,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3Sta
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
@@ -3049,21 +3735,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3Usa
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice Retrieve the packet counters for the interfaces of a Wireless LAN controller
@@ -3074,9 +3766,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesL3Usa
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/packets/overview/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
@@ -3084,21 +3807,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacke
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval Retrieve the traffic for the interfaces of a Wireless LAN controller
@@ -3109,9 +3838,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesPacke
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
@@ -3119,21 +3879,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsage
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory List the failover events of wireless LAN controllers in an organization
@@ -3144,9 +3910,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesInterfacesUsage
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams *GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams *GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/failover/history"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams != nil && getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryPaginate, organizationID, "", getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
@@ -3154,21 +3951,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailo
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryPaginate(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParamsConverted := getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.(*GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesRedundancyStatuses List redundancy details of wireless LAN controllers in an organization
@@ -3179,9 +3982,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyFailo
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams *GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams *GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams != nil && getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesRedundancyStatusesPaginate, organizationID, "", getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
@@ -3189,21 +4023,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatu
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyStatuses")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesRedundancyStatuses")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesRedundancyStatuses)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatusesPaginate(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParamsConverted := getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.(*GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParamsConverted)
 }
 
 //GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval List cpu utilization data of wireless LAN controllers in an organization
@@ -3214,9 +4054,40 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesRedundancyStatu
 
 
 */
-func (s *DevicesService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams) (*resty.Response, error) {
+
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams) (*ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/system/utilization/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
@@ -3224,21 +4095,27 @@ func (s *DevicesService) GetOrganizationWirelessControllerDevicesSystemUtilizati
 	response, err := s.client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetQueryString(queryString.Encode()).
+		SetQueryString(queryString.Encode()).SetResult(&ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval{}).
 		SetError(&Error).
 		Get(path)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 
 	if response.IsError() {
-		return response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval")
+		return nil, response, fmt.Errorf("error with operation GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval")
 	}
 
-	return response, err
+	result := response.Result().(*ResponseDevicesGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval)
+	return result, response, err
 
+}
+func (s *DevicesService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParamsConverted)
 }
 
 //BlinkDeviceLeds Blink the LEDs on a device

--- a/sdk/insight.go
+++ b/sdk/insight.go
@@ -92,6 +92,7 @@ type RequestInsightUpdateOrganizationInsightMonitoredMediaServer struct {
 
 
 */
+
 func (s *InsightService) GetNetworkInsightApplicationHealthByTime(networkID string, applicationID string, getNetworkInsightApplicationHealthByTimeQueryParams *GetNetworkInsightApplicationHealthByTimeQueryParams) (*ResponseInsightGetNetworkInsightApplicationHealthByTime, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/insight/applications/{applicationId}/healthByTime"
 	s.rateLimiterBucket.Wait(1)
@@ -128,6 +129,7 @@ func (s *InsightService) GetNetworkInsightApplicationHealthByTime(networkID stri
 
 
 */
+
 func (s *InsightService) GetOrganizationInsightApplications(organizationID string) (*ResponseInsightGetOrganizationInsightApplications, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/insight/applications"
 	s.rateLimiterBucket.Wait(1)
@@ -161,6 +163,7 @@ func (s *InsightService) GetOrganizationInsightApplications(organizationID strin
 
 
 */
+
 func (s *InsightService) GetOrganizationInsightMonitoredMediaServers(organizationID string) (*ResponseInsightGetOrganizationInsightMonitoredMediaServers, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/insight/monitoredMediaServers"
 	s.rateLimiterBucket.Wait(1)
@@ -195,6 +198,7 @@ func (s *InsightService) GetOrganizationInsightMonitoredMediaServers(organizatio
 
 
 */
+
 func (s *InsightService) GetOrganizationInsightMonitoredMediaServer(organizationID string, monitoredMediaServerID string) (*ResponseInsightGetOrganizationInsightMonitoredMediaServer, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/insight/monitoredMediaServers/{monitoredMediaServerId}"
 	s.rateLimiterBucket.Wait(1)

--- a/sdk/licensing.go
+++ b/sdk/licensing.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -342,6 +343,7 @@ type RequestLicensingMoveOrganizationLicensingCotermLicensesLicensesCounts struc
 
 
 */
+
 func (s *LicensingService) GetAdministeredLicensingSubscriptionEntitlements(getAdministeredLicensingSubscriptionEntitlementsQueryParams *GetAdministeredLicensingSubscriptionEntitlementsQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionEntitlements, *resty.Response, error) {
 	path := "/api/v1/administered/licensing/subscription/entitlements"
 	s.rateLimiterBucket.Wait(1)
@@ -376,9 +378,40 @@ func (s *LicensingService) GetAdministeredLicensingSubscriptionEntitlements(getA
 
 
 */
+
 func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptions(getAdministeredLicensingSubscriptionSubscriptionsQueryParams *GetAdministeredLicensingSubscriptionSubscriptionsQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions, *resty.Response, error) {
 	path := "/api/v1/administered/licensing/subscription/subscriptions"
 	s.rateLimiterBucket.Wait(1)
+
+	if getAdministeredLicensingSubscriptionSubscriptionsQueryParams != nil && getAdministeredLicensingSubscriptionSubscriptionsQueryParams.PerPage == -1 {
+		var result *ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions
+		println("Paginate")
+		getAdministeredLicensingSubscriptionSubscriptionsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetAdministeredLicensingSubscriptionSubscriptionsPaginate, "", "", getAdministeredLicensingSubscriptionSubscriptionsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptions
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 
 	queryString, _ := query.Values(getAdministeredLicensingSubscriptionSubscriptionsQueryParams)
 
@@ -402,6 +435,11 @@ func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptions(get
 	return result, response, err
 
 }
+func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptionsPaginate(getAdministeredLicensingSubscriptionSubscriptionsQueryParams any) (any, *resty.Response, error) {
+	getAdministeredLicensingSubscriptionSubscriptionsQueryParamsConverted := getAdministeredLicensingSubscriptionSubscriptionsQueryParams.(*GetAdministeredLicensingSubscriptionSubscriptionsQueryParams)
+
+	return s.GetAdministeredLicensingSubscriptionSubscriptions(getAdministeredLicensingSubscriptionSubscriptionsQueryParamsConverted)
+}
 
 //GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses Get compliance status for requested subscriptions
 /* Get compliance status for requested subscriptions
@@ -410,6 +448,7 @@ func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptions(get
 
 
 */
+
 func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses(getAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams *GetAdministeredLicensingSubscriptionSubscriptionsComplianceStatusesQueryParams) (*ResponseLicensingGetAdministeredLicensingSubscriptionSubscriptionsComplianceStatuses, *resty.Response, error) {
 	path := "/api/v1/administered/licensing/subscription/subscriptions/compliance/statuses"
 	s.rateLimiterBucket.Wait(1)
@@ -445,9 +484,40 @@ func (s *LicensingService) GetAdministeredLicensingSubscriptionSubscriptionsComp
 
 
 */
+
 func (s *LicensingService) GetOrganizationLicensingCotermLicenses(organizationID string, getOrganizationLicensingCotermLicensesQueryParams *GetOrganizationLicensingCotermLicensesQueryParams) (*ResponseLicensingGetOrganizationLicensingCotermLicenses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/licensing/coterm/licenses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationLicensingCotermLicensesQueryParams != nil && getOrganizationLicensingCotermLicensesQueryParams.PerPage == -1 {
+		var result *ResponseLicensingGetOrganizationLicensingCotermLicenses
+		println("Paginate")
+		getOrganizationLicensingCotermLicensesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationLicensingCotermLicensesPaginate, organizationID, "", getOrganizationLicensingCotermLicensesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseLicensingGetOrganizationLicensingCotermLicenses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationLicensingCotermLicensesQueryParams)
@@ -471,6 +541,11 @@ func (s *LicensingService) GetOrganizationLicensingCotermLicenses(organizationID
 	result := response.Result().(*ResponseLicensingGetOrganizationLicensingCotermLicenses)
 	return result, response, err
 
+}
+func (s *LicensingService) GetOrganizationLicensingCotermLicensesPaginate(organizationID string, getOrganizationLicensingCotermLicensesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationLicensingCotermLicensesQueryParamsConverted := getOrganizationLicensingCotermLicensesQueryParams.(*GetOrganizationLicensingCotermLicensesQueryParams)
+
+	return s.GetOrganizationLicensingCotermLicenses(organizationID, getOrganizationLicensingCotermLicensesQueryParamsConverted)
 }
 
 //ClaimAdministeredLicensingSubscriptionSubscriptions Claim a subscription into an organization.

--- a/sdk/networks.go
+++ b/sdk/networks.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -4431,6 +4432,7 @@ type RequestNetworksCreateNetworkWebhooksWebhookTest struct {
 
 
 */
+
 func (s *NetworksService) GetNetwork(networkID string) (*ResponseNetworksGetNetwork, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4465,9 +4467,40 @@ func (s *NetworksService) GetNetwork(networkID string) (*ResponseNetworksGetNetw
 
 
 */
+
 func (s *NetworksService) GetNetworkAlertsHistory(networkID string, getNetworkAlertsHistoryQueryParams *GetNetworkAlertsHistoryQueryParams) (*ResponseNetworksGetNetworkAlertsHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/alerts/history"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkAlertsHistoryQueryParams != nil && getNetworkAlertsHistoryQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkAlertsHistory
+		println("Paginate")
+		getNetworkAlertsHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkAlertsHistoryPaginate, networkID, "", getNetworkAlertsHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkAlertsHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkAlertsHistoryQueryParams)
@@ -4492,6 +4525,11 @@ func (s *NetworksService) GetNetworkAlertsHistory(networkID string, getNetworkAl
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkAlertsHistoryPaginate(networkID string, getNetworkAlertsHistoryQueryParams any) (any, *resty.Response, error) {
+	getNetworkAlertsHistoryQueryParamsConverted := getNetworkAlertsHistoryQueryParams.(*GetNetworkAlertsHistoryQueryParams)
+
+	return s.GetNetworkAlertsHistory(networkID, getNetworkAlertsHistoryQueryParamsConverted)
+}
 
 //GetNetworkAlertsSettings Return the alert configuration for this network
 /* Return the alert configuration for this network
@@ -4500,6 +4538,7 @@ func (s *NetworksService) GetNetworkAlertsHistory(networkID string, getNetworkAl
 
 
 */
+
 func (s *NetworksService) GetNetworkAlertsSettings(networkID string) (*ResponseNetworksGetNetworkAlertsSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/alerts/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -4534,9 +4573,40 @@ func (s *NetworksService) GetNetworkAlertsSettings(networkID string) (*ResponseN
 
 
 */
+
 func (s *NetworksService) GetNetworkBluetoothClients(networkID string, getNetworkBluetoothClientsQueryParams *GetNetworkBluetoothClientsQueryParams) (*ResponseNetworksGetNetworkBluetoothClients, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/bluetoothClients"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkBluetoothClientsQueryParams != nil && getNetworkBluetoothClientsQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkBluetoothClients
+		println("Paginate")
+		getNetworkBluetoothClientsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkBluetoothClientsPaginate, networkID, "", getNetworkBluetoothClientsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkBluetoothClients
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkBluetoothClientsQueryParams)
@@ -4561,6 +4631,11 @@ func (s *NetworksService) GetNetworkBluetoothClients(networkID string, getNetwor
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkBluetoothClientsPaginate(networkID string, getNetworkBluetoothClientsQueryParams any) (any, *resty.Response, error) {
+	getNetworkBluetoothClientsQueryParamsConverted := getNetworkBluetoothClientsQueryParams.(*GetNetworkBluetoothClientsQueryParams)
+
+	return s.GetNetworkBluetoothClients(networkID, getNetworkBluetoothClientsQueryParamsConverted)
+}
 
 //GetNetworkBluetoothClient Return a Bluetooth client
 /* Return a Bluetooth client. Bluetooth clients can be identified by their ID or their MAC.
@@ -4571,6 +4646,7 @@ func (s *NetworksService) GetNetworkBluetoothClients(networkID string, getNetwor
 
 
 */
+
 func (s *NetworksService) GetNetworkBluetoothClient(networkID string, bluetoothClientID string, getNetworkBluetoothClientQueryParams *GetNetworkBluetoothClientQueryParams) (*ResponseNetworksGetNetworkBluetoothClient, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/bluetoothClients/{bluetoothClientId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4608,9 +4684,40 @@ func (s *NetworksService) GetNetworkBluetoothClient(networkID string, bluetoothC
 
 
 */
+
 func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQueryParams *GetNetworkClientsQueryParams) (*ResponseNetworksGetNetworkClients, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkClientsQueryParams != nil && getNetworkClientsQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkClients
+		println("Paginate")
+		getNetworkClientsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkClientsPaginate, networkID, "", getNetworkClientsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkClients
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkClientsQueryParams)
@@ -4635,6 +4742,11 @@ func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQ
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkClientsPaginate(networkID string, getNetworkClientsQueryParams any) (any, *resty.Response, error) {
+	getNetworkClientsQueryParamsConverted := getNetworkClientsQueryParams.(*GetNetworkClientsQueryParams)
+
+	return s.GetNetworkClients(networkID, getNetworkClientsQueryParamsConverted)
+}
 
 //GetNetworkClientsApplicationUsage Return the application usage data for clients
 /* Return the application usage data for clients. Usage data is in kilobytes. Clients can be identified by client keys or either the MACs or IPs depending on whether the network uses Track-by-IP.
@@ -4644,9 +4756,40 @@ func (s *NetworksService) GetNetworkClients(networkID string, getNetworkClientsQ
 
 
 */
+
 func (s *NetworksService) GetNetworkClientsApplicationUsage(networkID string, getNetworkClientsApplicationUsageQueryParams *GetNetworkClientsApplicationUsageQueryParams) (*ResponseNetworksGetNetworkClientsApplicationUsage, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/applicationUsage"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkClientsApplicationUsageQueryParams != nil && getNetworkClientsApplicationUsageQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkClientsApplicationUsage
+		println("Paginate")
+		getNetworkClientsApplicationUsageQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkClientsApplicationUsagePaginate, networkID, "", getNetworkClientsApplicationUsageQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkClientsApplicationUsage
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkClientsApplicationUsageQueryParams)
@@ -4671,6 +4814,11 @@ func (s *NetworksService) GetNetworkClientsApplicationUsage(networkID string, ge
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkClientsApplicationUsagePaginate(networkID string, getNetworkClientsApplicationUsageQueryParams any) (any, *resty.Response, error) {
+	getNetworkClientsApplicationUsageQueryParamsConverted := getNetworkClientsApplicationUsageQueryParams.(*GetNetworkClientsApplicationUsageQueryParams)
+
+	return s.GetNetworkClientsApplicationUsage(networkID, getNetworkClientsApplicationUsageQueryParamsConverted)
+}
 
 //GetNetworkClientsBandwidthUsageHistory Returns a timeseries of total traffic consumption rates for all clients on a network within a given timespan, in megabits per second.
 /* Returns a timeseries of total traffic consumption rates for all clients on a network within a given timespan, in megabits per second.
@@ -4680,9 +4828,40 @@ func (s *NetworksService) GetNetworkClientsApplicationUsage(networkID string, ge
 
 
 */
+
 func (s *NetworksService) GetNetworkClientsBandwidthUsageHistory(networkID string, getNetworkClientsBandwidthUsageHistoryQueryParams *GetNetworkClientsBandwidthUsageHistoryQueryParams) (*ResponseNetworksGetNetworkClientsBandwidthUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/bandwidthUsageHistory"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkClientsBandwidthUsageHistoryQueryParams != nil && getNetworkClientsBandwidthUsageHistoryQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkClientsBandwidthUsageHistory
+		println("Paginate")
+		getNetworkClientsBandwidthUsageHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkClientsBandwidthUsageHistoryPaginate, networkID, "", getNetworkClientsBandwidthUsageHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkClientsBandwidthUsageHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkClientsBandwidthUsageHistoryQueryParams)
@@ -4707,6 +4886,11 @@ func (s *NetworksService) GetNetworkClientsBandwidthUsageHistory(networkID strin
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkClientsBandwidthUsageHistoryPaginate(networkID string, getNetworkClientsBandwidthUsageHistoryQueryParams any) (any, *resty.Response, error) {
+	getNetworkClientsBandwidthUsageHistoryQueryParamsConverted := getNetworkClientsBandwidthUsageHistoryQueryParams.(*GetNetworkClientsBandwidthUsageHistoryQueryParams)
+
+	return s.GetNetworkClientsBandwidthUsageHistory(networkID, getNetworkClientsBandwidthUsageHistoryQueryParamsConverted)
+}
 
 //GetNetworkClientsOverview Return overview statistics for network clients
 /* Return overview statistics for network clients
@@ -4716,6 +4900,7 @@ func (s *NetworksService) GetNetworkClientsBandwidthUsageHistory(networkID strin
 
 
 */
+
 func (s *NetworksService) GetNetworkClientsOverview(networkID string, getNetworkClientsOverviewQueryParams *GetNetworkClientsOverviewQueryParams) (*ResponseNetworksGetNetworkClientsOverview, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4752,9 +4937,40 @@ func (s *NetworksService) GetNetworkClientsOverview(networkID string, getNetwork
 
 
 */
+
 func (s *NetworksService) GetNetworkClientsUsageHistories(networkID string, getNetworkClientsUsageHistoriesQueryParams *GetNetworkClientsUsageHistoriesQueryParams) (*ResponseNetworksGetNetworkClientsUsageHistories, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/usageHistories"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkClientsUsageHistoriesQueryParams != nil && getNetworkClientsUsageHistoriesQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkClientsUsageHistories
+		println("Paginate")
+		getNetworkClientsUsageHistoriesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkClientsUsageHistoriesPaginate, networkID, "", getNetworkClientsUsageHistoriesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkClientsUsageHistories
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkClientsUsageHistoriesQueryParams)
@@ -4779,6 +4995,11 @@ func (s *NetworksService) GetNetworkClientsUsageHistories(networkID string, getN
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkClientsUsageHistoriesPaginate(networkID string, getNetworkClientsUsageHistoriesQueryParams any) (any, *resty.Response, error) {
+	getNetworkClientsUsageHistoriesQueryParamsConverted := getNetworkClientsUsageHistoriesQueryParams.(*GetNetworkClientsUsageHistoriesQueryParams)
+
+	return s.GetNetworkClientsUsageHistories(networkID, getNetworkClientsUsageHistoriesQueryParamsConverted)
+}
 
 //GetNetworkClient Return the client associated with the given identifier
 /* Return the client associated with the given identifier. Clients can be identified by a client key or either the MAC or IP depending on whether the network uses Track-by-IP.
@@ -4788,6 +5009,7 @@ func (s *NetworksService) GetNetworkClientsUsageHistories(networkID string, getN
 
 
 */
+
 func (s *NetworksService) GetNetworkClient(networkID string, clientID string) (*ResponseNetworksGetNetworkClient, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4823,6 +5045,7 @@ func (s *NetworksService) GetNetworkClient(networkID string, clientID string) (*
 
 
 */
+
 func (s *NetworksService) GetNetworkClientPolicy(networkID string, clientID string) (*ResponseNetworksGetNetworkClientPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}/policy"
 	s.rateLimiterBucket.Wait(1)
@@ -4858,6 +5081,7 @@ func (s *NetworksService) GetNetworkClientPolicy(networkID string, clientID stri
 
 
 */
+
 func (s *NetworksService) GetNetworkClientSplashAuthorizationStatus(networkID string, clientID string) (*ResponseNetworksGetNetworkClientSplashAuthorizationStatus, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}/splashAuthorizationStatus"
 	s.rateLimiterBucket.Wait(1)
@@ -4894,9 +5118,40 @@ func (s *NetworksService) GetNetworkClientSplashAuthorizationStatus(networkID st
 
 
 */
+
 func (s *NetworksService) GetNetworkClientTrafficHistory(networkID string, clientID string, getNetworkClientTrafficHistoryQueryParams *GetNetworkClientTrafficHistoryQueryParams) (*ResponseNetworksGetNetworkClientTrafficHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}/trafficHistory"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkClientTrafficHistoryQueryParams != nil && getNetworkClientTrafficHistoryQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkClientTrafficHistory
+		println("Paginate")
+		getNetworkClientTrafficHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkClientTrafficHistoryPaginate, networkID, clientID, getNetworkClientTrafficHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkClientTrafficHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{clientId}", fmt.Sprintf("%v", clientID), -1)
 
@@ -4922,6 +5177,11 @@ func (s *NetworksService) GetNetworkClientTrafficHistory(networkID string, clien
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkClientTrafficHistoryPaginate(networkID string, clientID string, getNetworkClientTrafficHistoryQueryParams any) (any, *resty.Response, error) {
+	getNetworkClientTrafficHistoryQueryParamsConverted := getNetworkClientTrafficHistoryQueryParams.(*GetNetworkClientTrafficHistoryQueryParams)
+
+	return s.GetNetworkClientTrafficHistory(networkID, clientID, getNetworkClientTrafficHistoryQueryParamsConverted)
+}
 
 //GetNetworkClientUsageHistory Return the client's daily usage history
 /* Return the client's daily usage history. Usage data is in kilobytes. Clients can be identified by a client key or either the MAC or IP depending on whether the network uses Track-by-IP.
@@ -4931,6 +5191,7 @@ func (s *NetworksService) GetNetworkClientTrafficHistory(networkID string, clien
 
 
 */
+
 func (s *NetworksService) GetNetworkClientUsageHistory(networkID string, clientID string) (*ResponseNetworksGetNetworkClientUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/clients/{clientId}/usageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4965,6 +5226,7 @@ func (s *NetworksService) GetNetworkClientUsageHistory(networkID string, clientI
 
 
 */
+
 func (s *NetworksService) GetNetworkDevices(networkID string) (*ResponseNetworksGetNetworkDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/devices"
 	s.rateLimiterBucket.Wait(1)
@@ -4999,9 +5261,40 @@ func (s *NetworksService) GetNetworkDevices(networkID string) (*ResponseNetworks
 
 
 */
+
 func (s *NetworksService) GetNetworkEvents(networkID string, getNetworkEventsQueryParams *GetNetworkEventsQueryParams) (*ResponseNetworksGetNetworkEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/events"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkEventsQueryParams != nil && getNetworkEventsQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkEvents
+		println("Paginate")
+		getNetworkEventsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkEventsPaginate, networkID, "", getNetworkEventsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkEvents
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Events = append(*result.Events, *resultTmp.Events...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkEventsQueryParams)
@@ -5026,6 +5319,11 @@ func (s *NetworksService) GetNetworkEvents(networkID string, getNetworkEventsQue
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkEventsPaginate(networkID string, getNetworkEventsQueryParams any) (any, *resty.Response, error) {
+	getNetworkEventsQueryParamsConverted := getNetworkEventsQueryParams.(*GetNetworkEventsQueryParams)
+
+	return s.GetNetworkEvents(networkID, getNetworkEventsQueryParamsConverted)
+}
 
 //GetNetworkEventsEventTypes List the event type to human-readable description
 /* List the event type to human-readable description
@@ -5034,6 +5332,7 @@ func (s *NetworksService) GetNetworkEvents(networkID string, getNetworkEventsQue
 
 
 */
+
 func (s *NetworksService) GetNetworkEventsEventTypes(networkID string) (*ResponseNetworksGetNetworkEventsEventTypes, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/events/eventTypes"
 	s.rateLimiterBucket.Wait(1)
@@ -5067,6 +5366,7 @@ func (s *NetworksService) GetNetworkEventsEventTypes(networkID string) (*Respons
 
 
 */
+
 func (s *NetworksService) GetNetworkFirmwareUpgrades(networkID string) (*ResponseNetworksGetNetworkFirmwareUpgrades, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades"
 	s.rateLimiterBucket.Wait(1)
@@ -5100,6 +5400,7 @@ func (s *NetworksService) GetNetworkFirmwareUpgrades(networkID string) (*Respons
 
 
 */
+
 func (s *NetworksService) GetNetworkFirmwareUpgradesStagedEvents(networkID string) (*ResponseNetworksGetNetworkFirmwareUpgradesStagedEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/events"
 	s.rateLimiterBucket.Wait(1)
@@ -5133,6 +5434,7 @@ func (s *NetworksService) GetNetworkFirmwareUpgradesStagedEvents(networkID strin
 
 
 */
+
 func (s *NetworksService) GetNetworkFirmwareUpgradesStagedGroups(networkID string) (*ResponseNetworksGetNetworkFirmwareUpgradesStagedGroups, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/groups"
 	s.rateLimiterBucket.Wait(1)
@@ -5167,6 +5469,7 @@ func (s *NetworksService) GetNetworkFirmwareUpgradesStagedGroups(networkID strin
 
 
 */
+
 func (s *NetworksService) GetNetworkFirmwareUpgradesStagedGroup(networkID string, groupID string) (*ResponseNetworksGetNetworkFirmwareUpgradesStagedGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/groups/{groupId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5201,6 +5504,7 @@ func (s *NetworksService) GetNetworkFirmwareUpgradesStagedGroup(networkID string
 
 
 */
+
 func (s *NetworksService) GetNetworkFirmwareUpgradesStagedStages(networkID string) (*ResponseNetworksGetNetworkFirmwareUpgradesStagedStages, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/firmwareUpgrades/staged/stages"
 	s.rateLimiterBucket.Wait(1)
@@ -5234,6 +5538,7 @@ func (s *NetworksService) GetNetworkFirmwareUpgradesStagedStages(networkID strin
 
 
 */
+
 func (s *NetworksService) GetNetworkFloorPlans(networkID string) (*ResponseNetworksGetNetworkFloorPlans, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/floorPlans"
 	s.rateLimiterBucket.Wait(1)
@@ -5268,6 +5573,7 @@ func (s *NetworksService) GetNetworkFloorPlans(networkID string) (*ResponseNetwo
 
 
 */
+
 func (s *NetworksService) GetNetworkFloorPlan(networkID string, floorPlanID string) (*ResponseNetworksGetNetworkFloorPlan, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/floorPlans/{floorPlanId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5302,6 +5608,7 @@ func (s *NetworksService) GetNetworkFloorPlan(networkID string, floorPlanID stri
 
 
 */
+
 func (s *NetworksService) GetNetworkGroupPolicies(networkID string) (*ResponseNetworksGetNetworkGroupPolicies, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/groupPolicies"
 	s.rateLimiterBucket.Wait(1)
@@ -5336,6 +5643,7 @@ func (s *NetworksService) GetNetworkGroupPolicies(networkID string) (*ResponseNe
 
 
 */
+
 func (s *NetworksService) GetNetworkGroupPolicy(networkID string, groupPolicyID string) (*ResponseNetworksGetNetworkGroupPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/groupPolicies/{groupPolicyId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5370,6 +5678,7 @@ func (s *NetworksService) GetNetworkGroupPolicy(networkID string, groupPolicyID 
 
 
 */
+
 func (s *NetworksService) GetNetworkHealthAlerts(networkID string) (*ResponseNetworksGetNetworkHealthAlerts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/health/alerts"
 	s.rateLimiterBucket.Wait(1)
@@ -5403,6 +5712,7 @@ func (s *NetworksService) GetNetworkHealthAlerts(networkID string) (*ResponseNet
 
 
 */
+
 func (s *NetworksService) GetNetworkMerakiAuthUsers(networkID string) (*ResponseNetworksGetNetworkMerakiAuthUsers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/merakiAuthUsers"
 	s.rateLimiterBucket.Wait(1)
@@ -5437,6 +5747,7 @@ func (s *NetworksService) GetNetworkMerakiAuthUsers(networkID string) (*Response
 
 
 */
+
 func (s *NetworksService) GetNetworkMerakiAuthUser(networkID string, merakiAuthUserID string) (*ResponseNetworksGetNetworkMerakiAuthUser, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/merakiAuthUsers/{merakiAuthUserId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5471,6 +5782,7 @@ func (s *NetworksService) GetNetworkMerakiAuthUser(networkID string, merakiAuthU
 
 
 */
+
 func (s *NetworksService) GetNetworkMqttBrokers(networkID string) (*ResponseNetworksGetNetworkMqttBrokers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/mqttBrokers"
 	s.rateLimiterBucket.Wait(1)
@@ -5505,6 +5817,7 @@ func (s *NetworksService) GetNetworkMqttBrokers(networkID string) (*ResponseNetw
 
 
 */
+
 func (s *NetworksService) GetNetworkMqttBroker(networkID string, mqttBrokerID string) (*ResponseNetworksGetNetworkMqttBroker, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/mqttBrokers/{mqttBrokerId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5539,6 +5852,7 @@ func (s *NetworksService) GetNetworkMqttBroker(networkID string, mqttBrokerID st
 
 
 */
+
 func (s *NetworksService) GetNetworkNetflow(networkID string) (*ResponseNetworksGetNetworkNetflow, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/netflow"
 	s.rateLimiterBucket.Wait(1)
@@ -5573,9 +5887,40 @@ func (s *NetworksService) GetNetworkNetflow(networkID string) (*ResponseNetworks
 
 
 */
+
 func (s *NetworksService) GetNetworkNetworkHealthChannelUtilization(networkID string, getNetworkNetworkHealthChannelUtilizationQueryParams *GetNetworkNetworkHealthChannelUtilizationQueryParams) (*ResponseNetworksGetNetworkNetworkHealthChannelUtilization, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/networkHealth/channelUtilization"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkNetworkHealthChannelUtilizationQueryParams != nil && getNetworkNetworkHealthChannelUtilizationQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkNetworkHealthChannelUtilization
+		println("Paginate")
+		getNetworkNetworkHealthChannelUtilizationQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkNetworkHealthChannelUtilizationPaginate, networkID, "", getNetworkNetworkHealthChannelUtilizationQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkNetworkHealthChannelUtilization
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkNetworkHealthChannelUtilizationQueryParams)
@@ -5600,21 +5945,27 @@ func (s *NetworksService) GetNetworkNetworkHealthChannelUtilization(networkID st
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkNetworkHealthChannelUtilizationPaginate(networkID string, getNetworkNetworkHealthChannelUtilizationQueryParams any) (any, *resty.Response, error) {
+	getNetworkNetworkHealthChannelUtilizationQueryParamsConverted := getNetworkNetworkHealthChannelUtilizationQueryParams.(*GetNetworkNetworkHealthChannelUtilizationQueryParams)
+
+	return s.GetNetworkNetworkHealthChannelUtilization(networkID, getNetworkNetworkHealthChannelUtilizationQueryParamsConverted)
+}
 
 //GetNetworkPiiPiiKeys List the keys required to access Personally Identifiable Information (PII) for a given identifier
 /* List the keys required to access Personally Identifiable Information (PII) for a given identifier. Exactly one identifier will be accepted. If the organization contains org-wide Systems Manager users matching the key provided then there will be an entry with the key "0" containing the applicable keys.
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/piiKeys
-```
+***
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiPiiKeysQueryParams Filtering parameter
 
 
 */
+
 func (s *NetworksService) GetNetworkPiiPiiKeys(networkID string, getNetworkPiiPiiKeysQueryParams *GetNetworkPiiPiiKeysQueryParams) (*ResponseNetworksGetNetworkPiiPiiKeys, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/piiKeys"
 	s.rateLimiterBucket.Wait(1)
@@ -5648,14 +5999,15 @@ func (s *NetworksService) GetNetworkPiiPiiKeys(networkID string, getNetworkPiiPi
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/requests
-```
+***
 
 @param networkID networkId path parameter. Network ID
 
 
 */
+
 func (s *NetworksService) GetNetworkPiiRequests(networkID string) (*ResponseNetworksGetNetworkPiiRequests, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/requests"
 	s.rateLimiterBucket.Wait(1)
@@ -5687,15 +6039,16 @@ func (s *NetworksService) GetNetworkPiiRequests(networkID string) (*ResponseNetw
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/requests/{requestId}
-```
+***
 
 @param networkID networkId path parameter. Network ID
 @param requestID requestId path parameter. Request ID
 
 
 */
+
 func (s *NetworksService) GetNetworkPiiRequest(networkID string, requestID string) (*ResponseNetworksGetNetworkPiiRequest, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/requests/{requestId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5728,15 +6081,16 @@ func (s *NetworksService) GetNetworkPiiRequest(networkID string, requestID strin
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/smDevicesForKey
-```
+***
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiSmDevicesForKeyQueryParams Filtering parameter
 
 
 */
+
 func (s *NetworksService) GetNetworkPiiSmDevicesForKey(networkID string, getNetworkPiiSmDevicesForKeyQueryParams *GetNetworkPiiSmDevicesForKeyQueryParams) (*ResponseNetworksGetNetworkPiiSmDevicesForKey, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/smDevicesForKey"
 	s.rateLimiterBucket.Wait(1)
@@ -5770,15 +6124,16 @@ func (s *NetworksService) GetNetworkPiiSmDevicesForKey(networkID string, getNetw
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/smOwnersForKey
-```
+***
 
 @param networkID networkId path parameter. Network ID
 @param getNetworkPiiSmOwnersForKeyQueryParams Filtering parameter
 
 
 */
+
 func (s *NetworksService) GetNetworkPiiSmOwnersForKey(networkID string, getNetworkPiiSmOwnersForKeyQueryParams *GetNetworkPiiSmOwnersForKeyQueryParams) (*ResponseNetworksGetNetworkPiiSmOwnersForKey, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/pii/smOwnersForKey"
 	s.rateLimiterBucket.Wait(1)
@@ -5815,9 +6170,40 @@ func (s *NetworksService) GetNetworkPiiSmOwnersForKey(networkID string, getNetwo
 
 
 */
+
 func (s *NetworksService) GetNetworkPoliciesByClient(networkID string, getNetworkPoliciesByClientQueryParams *GetNetworkPoliciesByClientQueryParams) (*ResponseNetworksGetNetworkPoliciesByClient, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/policies/byClient"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkPoliciesByClientQueryParams != nil && getNetworkPoliciesByClientQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkPoliciesByClient
+		println("Paginate")
+		getNetworkPoliciesByClientQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkPoliciesByClientPaginate, networkID, "", getNetworkPoliciesByClientQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkPoliciesByClient
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkPoliciesByClientQueryParams)
@@ -5842,6 +6228,11 @@ func (s *NetworksService) GetNetworkPoliciesByClient(networkID string, getNetwor
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkPoliciesByClientPaginate(networkID string, getNetworkPoliciesByClientQueryParams any) (any, *resty.Response, error) {
+	getNetworkPoliciesByClientQueryParamsConverted := getNetworkPoliciesByClientQueryParams.(*GetNetworkPoliciesByClientQueryParams)
+
+	return s.GetNetworkPoliciesByClient(networkID, getNetworkPoliciesByClientQueryParamsConverted)
+}
 
 //GetNetworkSettings Return the settings for a network
 /* Return the settings for a network
@@ -5850,6 +6241,7 @@ func (s *NetworksService) GetNetworkPoliciesByClient(networkID string, getNetwor
 
 
 */
+
 func (s *NetworksService) GetNetworkSettings(networkID string) (*ResponseNetworksGetNetworkSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -5883,6 +6275,7 @@ func (s *NetworksService) GetNetworkSettings(networkID string) (*ResponseNetwork
 
 
 */
+
 func (s *NetworksService) GetNetworkSNMP(networkID string) (*ResponseNetworksGetNetworkSNMP, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/snmp"
 	s.rateLimiterBucket.Wait(1)
@@ -5917,6 +6310,7 @@ func (s *NetworksService) GetNetworkSNMP(networkID string) (*ResponseNetworksGet
 
 
 */
+
 func (s *NetworksService) GetNetworkSplashLoginAttempts(networkID string, getNetworkSplashLoginAttemptsQueryParams *GetNetworkSplashLoginAttemptsQueryParams) (*ResponseNetworksGetNetworkSplashLoginAttempts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/splashLoginAttempts"
 	s.rateLimiterBucket.Wait(1)
@@ -5952,6 +6346,7 @@ func (s *NetworksService) GetNetworkSplashLoginAttempts(networkID string, getNet
 
 
 */
+
 func (s *NetworksService) GetNetworkSyslogServers(networkID string) (*ResponseNetworksGetNetworkSyslogServers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/syslogServers"
 	s.rateLimiterBucket.Wait(1)
@@ -5985,6 +6380,7 @@ func (s *NetworksService) GetNetworkSyslogServers(networkID string) (*ResponseNe
 
 
 */
+
 func (s *NetworksService) GetNetworkTopologyLinkLayer(networkID string) (*ResponseNetworksGetNetworkTopologyLinkLayer, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/topology/linkLayer"
 	s.rateLimiterBucket.Wait(1)
@@ -6019,6 +6415,7 @@ func (s *NetworksService) GetNetworkTopologyLinkLayer(networkID string) (*Respon
 
 
 */
+
 func (s *NetworksService) GetNetworkTraffic(networkID string, getNetworkTrafficQueryParams *GetNetworkTrafficQueryParams) (*ResponseNetworksGetNetworkTraffic, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/traffic"
 	s.rateLimiterBucket.Wait(1)
@@ -6054,6 +6451,7 @@ func (s *NetworksService) GetNetworkTraffic(networkID string, getNetworkTrafficQ
 
 
 */
+
 func (s *NetworksService) GetNetworkTrafficAnalysis(networkID string) (*ResponseNetworksGetNetworkTrafficAnalysis, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/trafficAnalysis"
 	s.rateLimiterBucket.Wait(1)
@@ -6087,6 +6485,7 @@ func (s *NetworksService) GetNetworkTrafficAnalysis(networkID string) (*Response
 
 
 */
+
 func (s *NetworksService) GetNetworkTrafficShapingApplicationCategories(networkID string) (*ResponseNetworksGetNetworkTrafficShapingApplicationCategories, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/trafficShaping/applicationCategories"
 	s.rateLimiterBucket.Wait(1)
@@ -6120,6 +6519,7 @@ func (s *NetworksService) GetNetworkTrafficShapingApplicationCategories(networkI
 
 
 */
+
 func (s *NetworksService) GetNetworkTrafficShapingDscpTaggingOptions(networkID string) (*ResponseNetworksGetNetworkTrafficShapingDscpTaggingOptions, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/trafficShaping/dscpTaggingOptions"
 	s.rateLimiterBucket.Wait(1)
@@ -6153,6 +6553,7 @@ func (s *NetworksService) GetNetworkTrafficShapingDscpTaggingOptions(networkID s
 
 
 */
+
 func (s *NetworksService) GetNetworkVLANProfiles(networkID string) (*ResponseNetworksGetNetworkVLANProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/vlanProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -6187,9 +6588,40 @@ func (s *NetworksService) GetNetworkVLANProfiles(networkID string) (*ResponseNet
 
 
 */
+
 func (s *NetworksService) GetNetworkVLANProfilesAssignmentsByDevice(networkID string, getNetworkVlanProfilesAssignmentsByDeviceQueryParams *GetNetworkVLANProfilesAssignmentsByDeviceQueryParams) (*ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/vlanProfiles/assignments/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkVlanProfilesAssignmentsByDeviceQueryParams != nil && getNetworkVlanProfilesAssignmentsByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice
+		println("Paginate")
+		getNetworkVlanProfilesAssignmentsByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkVLANProfilesAssignmentsByDevicePaginate, networkID, "", getNetworkVlanProfilesAssignmentsByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseNetworksGetNetworkVLANProfilesAssignmentsByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkVlanProfilesAssignmentsByDeviceQueryParams)
@@ -6214,6 +6646,11 @@ func (s *NetworksService) GetNetworkVLANProfilesAssignmentsByDevice(networkID st
 	return result, response, err
 
 }
+func (s *NetworksService) GetNetworkVLANProfilesAssignmentsByDevicePaginate(networkID string, getNetworkVlanProfilesAssignmentsByDeviceQueryParams any) (any, *resty.Response, error) {
+	getNetworkVlanProfilesAssignmentsByDeviceQueryParamsConverted := getNetworkVlanProfilesAssignmentsByDeviceQueryParams.(*GetNetworkVLANProfilesAssignmentsByDeviceQueryParams)
+
+	return s.GetNetworkVLANProfilesAssignmentsByDevice(networkID, getNetworkVlanProfilesAssignmentsByDeviceQueryParamsConverted)
+}
 
 //GetNetworkVLANProfile Get an existing VLAN profile of a network
 /* Get an existing VLAN profile of a network
@@ -6223,6 +6660,7 @@ func (s *NetworksService) GetNetworkVLANProfilesAssignmentsByDevice(networkID st
 
 
 */
+
 func (s *NetworksService) GetNetworkVLANProfile(networkID string, iname string) (*ResponseNetworksGetNetworkVLANProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/vlanProfiles/{iname}"
 	s.rateLimiterBucket.Wait(1)
@@ -6257,6 +6695,7 @@ func (s *NetworksService) GetNetworkVLANProfile(networkID string, iname string) 
 
 
 */
+
 func (s *NetworksService) GetNetworkWebhooksHTTPServers(networkID string) (*ResponseNetworksGetNetworkWebhooksHTTPServers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/webhooks/httpServers"
 	s.rateLimiterBucket.Wait(1)
@@ -6291,6 +6730,7 @@ func (s *NetworksService) GetNetworkWebhooksHTTPServers(networkID string) (*Resp
 
 
 */
+
 func (s *NetworksService) GetNetworkWebhooksHTTPServer(networkID string, httpServerID string) (*ResponseNetworksGetNetworkWebhooksHTTPServer, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/webhooks/httpServers/{httpServerId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6325,6 +6765,7 @@ func (s *NetworksService) GetNetworkWebhooksHTTPServer(networkID string, httpSer
 
 
 */
+
 func (s *NetworksService) GetNetworkWebhooksPayloadTemplates(networkID string) (*ResponseNetworksGetNetworkWebhooksPayloadTemplates, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/webhooks/payloadTemplates"
 	s.rateLimiterBucket.Wait(1)
@@ -6359,6 +6800,7 @@ func (s *NetworksService) GetNetworkWebhooksPayloadTemplates(networkID string) (
 
 
 */
+
 func (s *NetworksService) GetNetworkWebhooksPayloadTemplate(networkID string, payloadTemplateID string) (*ResponseNetworksGetNetworkWebhooksPayloadTemplate, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/webhooks/payloadTemplates/{payloadTemplateId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6394,6 +6836,7 @@ func (s *NetworksService) GetNetworkWebhooksPayloadTemplate(networkID string, pa
 
 
 */
+
 func (s *NetworksService) GetNetworkWebhooksWebhookTest(networkID string, webhookTestID string) (*ResponseNetworksGetNetworkWebhooksWebhookTest, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/webhooks/webhookTests/{webhookTestId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6429,6 +6872,7 @@ func (s *NetworksService) GetNetworkWebhooksWebhookTest(networkID string, webhoo
 
 
 */
+
 func (s *NetworksService) GetOrganizationSummaryTopNetworksByStatus(organizationID string, getOrganizationSummaryTopNetworksByStatusQueryParams *GetOrganizationSummaryTopNetworksByStatusQueryParams) (*resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/networks/byStatus"
 	s.rateLimiterBucket.Wait(1)
@@ -7129,9 +7573,9 @@ func (s *NetworksService) CreateNetworkMqttBroker(networkID string, requestNetwo
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/requests
-```
+***
 
 @param networkID networkId path parameter. Network ID
 
@@ -8316,9 +8760,9 @@ func (s *NetworksService) DeleteNetworkMqttBroker(networkID string, mqttBrokerID
 
 ## ALTERNATE PATH
 
-```
+***
 /organizations/{organizationId}/pii/requests/{requestId}
-```
+***
 
 @param networkID networkId path parameter. Network ID
 @param requestID requestId path parameter. Request ID

--- a/sdk/organizations.go
+++ b/sdk/organizations.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -3676,9 +3677,40 @@ type RequestOrganizationsCreateOrganizationSplashThemeAsset struct {
 
 
 */
+
 func (s *OrganizationsService) GetOrganizations(getOrganizationsQueryParams *GetOrganizationsQueryParams) (*ResponseOrganizationsGetOrganizations, *resty.Response, error) {
 	path := "/api/v1/organizations"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationsQueryParams != nil && getOrganizationsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizations
+		println("Paginate")
+		getOrganizationsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationsPaginate, "", "", getOrganizationsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizations
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 
 	queryString, _ := query.Values(getOrganizationsQueryParams)
 
@@ -3702,6 +3734,11 @@ func (s *OrganizationsService) GetOrganizations(getOrganizationsQueryParams *Get
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationsPaginate(getOrganizationsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationsQueryParamsConverted := getOrganizationsQueryParams.(*GetOrganizationsQueryParams)
+
+	return s.GetOrganizations(getOrganizationsQueryParamsConverted)
+}
 
 //GetOrganization Return an organization
 /* Return an organization
@@ -3710,6 +3747,7 @@ func (s *OrganizationsService) GetOrganizations(getOrganizationsQueryParams *Get
 
 
 */
+
 func (s *OrganizationsService) GetOrganization(organizationID string) (*ResponseOrganizationsGetOrganization, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3744,6 +3782,7 @@ func (s *OrganizationsService) GetOrganization(organizationID string) (*Response
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationActionBatches(organizationID string, getOrganizationActionBatchesQueryParams *GetOrganizationActionBatchesQueryParams) (*ResponseOrganizationsGetOrganizationActionBatches, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/actionBatches"
 	s.rateLimiterBucket.Wait(1)
@@ -3780,6 +3819,7 @@ func (s *OrganizationsService) GetOrganizationActionBatches(organizationID strin
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationActionBatch(organizationID string, actionBatchID string) (*ResponseOrganizationsGetOrganizationActionBatch, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/actionBatches/{actionBatchId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3814,6 +3854,7 @@ func (s *OrganizationsService) GetOrganizationActionBatch(organizationID string,
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyACLs(organizationID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyACLs, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/acls"
 	s.rateLimiterBucket.Wait(1)
@@ -3848,6 +3889,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyACLs(organizationID 
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyACL(organizationID string, aclID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyACL, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/acls/{aclId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3882,6 +3924,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyACL(organizationID s
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyGroups(organizationID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyGroups, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/groups"
 	s.rateLimiterBucket.Wait(1)
@@ -3916,6 +3959,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyGroups(organizationI
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyGroup(organizationID string, id string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/groups/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -3950,6 +3994,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyGroup(organizationID
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyOverview(organizationID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -3983,6 +4028,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyOverview(organizatio
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyPolicies(organizationID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyPolicies, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/policies"
 	s.rateLimiterBucket.Wait(1)
@@ -4017,6 +4063,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyPolicies(organizatio
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicyPolicy(organizationID string, id string) (*ResponseOrganizationsGetOrganizationAdaptivePolicyPolicy, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/policies/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -4051,6 +4098,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicyPolicy(organizationI
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdaptivePolicySettings(organizationID string) (*ResponseOrganizationsGetOrganizationAdaptivePolicySettings, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/adaptivePolicy/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -4085,6 +4133,7 @@ func (s *OrganizationsService) GetOrganizationAdaptivePolicySettings(organizatio
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAdmins(organizationID string, getOrganizationAdminsQueryParams *GetOrganizationAdminsQueryParams) (*ResponseOrganizationsGetOrganizationAdmins, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/admins"
 	s.rateLimiterBucket.Wait(1)
@@ -4120,6 +4169,7 @@ func (s *OrganizationsService) GetOrganizationAdmins(organizationID string, getO
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAlertsProfiles(organizationID string) (*ResponseOrganizationsGetOrganizationAlertsProfiles, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/alerts/profiles"
 	s.rateLimiterBucket.Wait(1)
@@ -4154,9 +4204,40 @@ func (s *OrganizationsService) GetOrganizationAlertsProfiles(organizationID stri
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAPIRequests(organizationID string, getOrganizationApiRequestsQueryParams *GetOrganizationAPIRequestsQueryParams) (*ResponseOrganizationsGetOrganizationAPIRequests, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/apiRequests"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationApiRequestsQueryParams != nil && getOrganizationApiRequestsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationAPIRequests
+		println("Paginate")
+		getOrganizationApiRequestsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationAPIRequestsPaginate, organizationID, "", getOrganizationApiRequestsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationAPIRequests
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationApiRequestsQueryParams)
@@ -4181,6 +4262,11 @@ func (s *OrganizationsService) GetOrganizationAPIRequests(organizationID string,
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationAPIRequestsPaginate(organizationID string, getOrganizationApiRequestsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationApiRequestsQueryParamsConverted := getOrganizationApiRequestsQueryParams.(*GetOrganizationAPIRequestsQueryParams)
+
+	return s.GetOrganizationAPIRequests(organizationID, getOrganizationApiRequestsQueryParamsConverted)
+}
 
 //GetOrganizationAPIRequestsOverview Return an aggregated overview of API requests data
 /* Return an aggregated overview of API requests data
@@ -4190,6 +4276,7 @@ func (s *OrganizationsService) GetOrganizationAPIRequests(organizationID string,
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAPIRequestsOverview(organizationID string, getOrganizationApiRequestsOverviewQueryParams *GetOrganizationAPIRequestsOverviewQueryParams) (*ResponseOrganizationsGetOrganizationAPIRequestsOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/apiRequests/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4226,6 +4313,7 @@ func (s *OrganizationsService) GetOrganizationAPIRequestsOverview(organizationID
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAPIRequestsOverviewResponseCodesByInterval(organizationID string, getOrganizationApiRequestsOverviewResponseCodesByIntervalQueryParams *GetOrganizationAPIRequestsOverviewResponseCodesByIntervalQueryParams) (*ResponseOrganizationsGetOrganizationAPIRequestsOverviewResponseCodesByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/apiRequests/overview/responseCodes/byInterval"
 	s.rateLimiterBucket.Wait(1)
@@ -4262,9 +4350,40 @@ func (s *OrganizationsService) GetOrganizationAPIRequestsOverviewResponseCodesBy
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlerts(organizationID string, getOrganizationAssuranceAlertsQueryParams *GetOrganizationAssuranceAlertsQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlerts, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationAssuranceAlertsQueryParams != nil && getOrganizationAssuranceAlertsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationAssuranceAlerts
+		println("Paginate")
+		getOrganizationAssuranceAlertsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationAssuranceAlertsPaginate, organizationID, "", getOrganizationAssuranceAlertsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationAssuranceAlerts
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationAssuranceAlertsQueryParams)
@@ -4289,6 +4408,11 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlerts(organizationID str
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsPaginate(organizationID string, getOrganizationAssuranceAlertsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationAssuranceAlertsQueryParamsConverted := getOrganizationAssuranceAlertsQueryParams.(*GetOrganizationAssuranceAlertsQueryParams)
+
+	return s.GetOrganizationAssuranceAlerts(organizationID, getOrganizationAssuranceAlertsQueryParamsConverted)
+}
 
 //GetOrganizationAssuranceAlertsOverview Return overview of active health alerts for an organization
 /* Return overview of active health alerts for an organization
@@ -4298,6 +4422,7 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlerts(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverview(organizationID string, getOrganizationAssuranceAlertsOverviewQueryParams *GetOrganizationAssuranceAlertsOverviewQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4334,9 +4459,40 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverview(organizati
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByNetwork(organizationID string, getOrganizationAssuranceAlertsOverviewByNetworkQueryParams *GetOrganizationAssuranceAlertsOverviewByNetworkQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationAssuranceAlertsOverviewByNetworkQueryParams != nil && getOrganizationAssuranceAlertsOverviewByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork
+		println("Paginate")
+		getOrganizationAssuranceAlertsOverviewByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationAssuranceAlertsOverviewByNetworkPaginate, organizationID, "", getOrganizationAssuranceAlertsOverviewByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewByNetworkQueryParams)
@@ -4361,6 +4517,11 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByNetwork(o
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByNetworkPaginate(organizationID string, getOrganizationAssuranceAlertsOverviewByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationAssuranceAlertsOverviewByNetworkQueryParamsConverted := getOrganizationAssuranceAlertsOverviewByNetworkQueryParams.(*GetOrganizationAssuranceAlertsOverviewByNetworkQueryParams)
+
+	return s.GetOrganizationAssuranceAlertsOverviewByNetwork(organizationID, getOrganizationAssuranceAlertsOverviewByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationAssuranceAlertsOverviewByType Return a Summary of Alerts grouped by type and severity
 /* Return a Summary of Alerts grouped by type and severity
@@ -4370,9 +4531,40 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByNetwork(o
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByType(organizationID string, getOrganizationAssuranceAlertsOverviewByTypeQueryParams *GetOrganizationAssuranceAlertsOverviewByTypeQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/byType"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationAssuranceAlertsOverviewByTypeQueryParams != nil && getOrganizationAssuranceAlertsOverviewByTypeQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType
+		println("Paginate")
+		getOrganizationAssuranceAlertsOverviewByTypeQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationAssuranceAlertsOverviewByTypePaginate, organizationID, "", getOrganizationAssuranceAlertsOverviewByTypeQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewByType
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationAssuranceAlertsOverviewByTypeQueryParams)
@@ -4397,6 +4589,11 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByType(orga
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByTypePaginate(organizationID string, getOrganizationAssuranceAlertsOverviewByTypeQueryParams any) (any, *resty.Response, error) {
+	getOrganizationAssuranceAlertsOverviewByTypeQueryParamsConverted := getOrganizationAssuranceAlertsOverviewByTypeQueryParams.(*GetOrganizationAssuranceAlertsOverviewByTypeQueryParams)
+
+	return s.GetOrganizationAssuranceAlertsOverviewByType(organizationID, getOrganizationAssuranceAlertsOverviewByTypeQueryParamsConverted)
+}
 
 //GetOrganizationAssuranceAlertsOverviewHistorical Returns historical health alert overviews
 /* Returns historical health alert overviews
@@ -4406,6 +4603,7 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewByType(orga
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewHistorical(organizationID string, getOrganizationAssuranceAlertsOverviewHistoricalQueryParams *GetOrganizationAssuranceAlertsOverviewHistoricalQueryParams) (*ResponseOrganizationsGetOrganizationAssuranceAlertsOverviewHistorical, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts/overview/historical"
 	s.rateLimiterBucket.Wait(1)
@@ -4442,6 +4640,7 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlertsOverviewHistorical(
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationAssuranceAlert(organizationID string, id string) (*ResponseOrganizationsGetOrganizationAssuranceAlert, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/assurance/alerts/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -4476,6 +4675,7 @@ func (s *OrganizationsService) GetOrganizationAssuranceAlert(organizationID stri
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationBrandingPolicies(organizationID string) (*ResponseOrganizationsGetOrganizationBrandingPolicies, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/brandingPolicies"
 	s.rateLimiterBucket.Wait(1)
@@ -4509,6 +4709,7 @@ func (s *OrganizationsService) GetOrganizationBrandingPolicies(organizationID st
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationBrandingPoliciesPriorities(organizationID string) (*ResponseOrganizationsGetOrganizationBrandingPoliciesPriorities, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/brandingPolicies/priorities"
 	s.rateLimiterBucket.Wait(1)
@@ -4543,6 +4744,7 @@ func (s *OrganizationsService) GetOrganizationBrandingPoliciesPriorities(organiz
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationBrandingPolicy(organizationID string, brandingPolicyID string) (*ResponseOrganizationsGetOrganizationBrandingPolicy, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/brandingPolicies/{brandingPolicyId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4578,6 +4780,7 @@ func (s *OrganizationsService) GetOrganizationBrandingPolicy(organizationID stri
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationClientsBandwidthUsageHistory(organizationID string, getOrganizationClientsBandwidthUsageHistoryQueryParams *GetOrganizationClientsBandwidthUsageHistoryQueryParams) (*ResponseOrganizationsGetOrganizationClientsBandwidthUsageHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/clients/bandwidthUsageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4614,6 +4817,7 @@ func (s *OrganizationsService) GetOrganizationClientsBandwidthUsageHistory(organ
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationClientsOverview(organizationID string, getOrganizationClientsOverviewQueryParams *GetOrganizationClientsOverviewQueryParams) (*ResponseOrganizationsGetOrganizationClientsOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/clients/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4650,9 +4854,40 @@ func (s *OrganizationsService) GetOrganizationClientsOverview(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationClientsSearch(organizationID string, getOrganizationClientsSearchQueryParams *GetOrganizationClientsSearchQueryParams) (*ResponseOrganizationsGetOrganizationClientsSearch, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/clients/search"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationClientsSearchQueryParams != nil && getOrganizationClientsSearchQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationClientsSearch
+		println("Paginate")
+		getOrganizationClientsSearchQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationClientsSearchPaginate, organizationID, "", getOrganizationClientsSearchQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationClientsSearch
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Records = append(*result.Records, *resultTmp.Records...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationClientsSearchQueryParams)
@@ -4677,6 +4912,11 @@ func (s *OrganizationsService) GetOrganizationClientsSearch(organizationID strin
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationClientsSearchPaginate(organizationID string, getOrganizationClientsSearchQueryParams any) (any, *resty.Response, error) {
+	getOrganizationClientsSearchQueryParamsConverted := getOrganizationClientsSearchQueryParams.(*GetOrganizationClientsSearchQueryParams)
+
+	return s.GetOrganizationClientsSearch(organizationID, getOrganizationClientsSearchQueryParamsConverted)
+}
 
 //GetOrganizationConfigTemplates List the configuration templates for this organization
 /* List the configuration templates for this organization
@@ -4685,6 +4925,7 @@ func (s *OrganizationsService) GetOrganizationClientsSearch(organizationID strin
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationConfigTemplates(organizationID string) (*ResponseOrganizationsGetOrganizationConfigTemplates, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates"
 	s.rateLimiterBucket.Wait(1)
@@ -4719,6 +4960,7 @@ func (s *OrganizationsService) GetOrganizationConfigTemplates(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationConfigTemplate(organizationID string, configTemplateID string) (*ResponseOrganizationsGetOrganizationConfigTemplate, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates/{configTemplateId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4754,9 +4996,40 @@ func (s *OrganizationsService) GetOrganizationConfigTemplate(organizationID stri
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationConfigurationChanges(organizationID string, getOrganizationConfigurationChangesQueryParams *GetOrganizationConfigurationChangesQueryParams) (*ResponseOrganizationsGetOrganizationConfigurationChanges, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configurationChanges"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationConfigurationChangesQueryParams != nil && getOrganizationConfigurationChangesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationConfigurationChanges
+		println("Paginate")
+		getOrganizationConfigurationChangesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationConfigurationChangesPaginate, organizationID, "", getOrganizationConfigurationChangesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationConfigurationChanges
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationConfigurationChangesQueryParams)
@@ -4781,6 +5054,11 @@ func (s *OrganizationsService) GetOrganizationConfigurationChanges(organizationI
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationConfigurationChangesPaginate(organizationID string, getOrganizationConfigurationChangesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationConfigurationChangesQueryParamsConverted := getOrganizationConfigurationChangesQueryParams.(*GetOrganizationConfigurationChangesQueryParams)
+
+	return s.GetOrganizationConfigurationChanges(organizationID, getOrganizationConfigurationChangesQueryParamsConverted)
+}
 
 //GetOrganizationDevices List the devices in an organization that have been assigned to a network.
 /* List the devices in an organization that have been assigned to a network.
@@ -4790,9 +5068,40 @@ func (s *OrganizationsService) GetOrganizationConfigurationChanges(organizationI
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevices(organizationID string, getOrganizationDevicesQueryParams *GetOrganizationDevicesQueryParams) (*ResponseOrganizationsGetOrganizationDevices, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesQueryParams != nil && getOrganizationDevicesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevices
+		println("Paginate")
+		getOrganizationDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesPaginate, organizationID, "", getOrganizationDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesQueryParams)
@@ -4817,6 +5126,11 @@ func (s *OrganizationsService) GetOrganizationDevices(organizationID string, get
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesPaginate(organizationID string, getOrganizationDevicesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesQueryParamsConverted := getOrganizationDevicesQueryParams.(*GetOrganizationDevicesQueryParams)
+
+	return s.GetOrganizationDevices(organizationID, getOrganizationDevicesQueryParamsConverted)
+}
 
 //GetOrganizationDevicesAvailabilities List the availability information for devices in an organization
 /* List the availability information for devices in an organization. The data returned by this endpoint is updated every 5 minutes.
@@ -4826,9 +5140,40 @@ func (s *OrganizationsService) GetOrganizationDevices(organizationID string, get
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesAvailabilities(organizationID string, getOrganizationDevicesAvailabilitiesQueryParams *GetOrganizationDevicesAvailabilitiesQueryParams) (*ResponseOrganizationsGetOrganizationDevicesAvailabilities, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/availabilities"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesAvailabilitiesQueryParams != nil && getOrganizationDevicesAvailabilitiesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesAvailabilities
+		println("Paginate")
+		getOrganizationDevicesAvailabilitiesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesAvailabilitiesPaginate, organizationID, "", getOrganizationDevicesAvailabilitiesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesAvailabilities
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesAvailabilitiesQueryParams)
@@ -4853,6 +5198,11 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilities(organization
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesPaginate(organizationID string, getOrganizationDevicesAvailabilitiesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesAvailabilitiesQueryParamsConverted := getOrganizationDevicesAvailabilitiesQueryParams.(*GetOrganizationDevicesAvailabilitiesQueryParams)
+
+	return s.GetOrganizationDevicesAvailabilities(organizationID, getOrganizationDevicesAvailabilitiesQueryParamsConverted)
+}
 
 //GetOrganizationDevicesAvailabilitiesChangeHistory List the availability history information for devices in an organization.
 /* List the availability history information for devices in an organization.
@@ -4862,9 +5212,40 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilities(organization
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams *GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams) (*ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/availabilities/changeHistory"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams != nil && getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory
+		println("Paginate")
+		getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesAvailabilitiesChangeHistoryPaginate, organizationID, "", getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesAvailabilitiesChangeHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
@@ -4889,6 +5270,11 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistory
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistoryPaginate(organizationID string, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesAvailabilitiesChangeHistoryQueryParamsConverted := getOrganizationDevicesAvailabilitiesChangeHistoryQueryParams.(*GetOrganizationDevicesAvailabilitiesChangeHistoryQueryParams)
+
+	return s.GetOrganizationDevicesAvailabilitiesChangeHistory(organizationID, getOrganizationDevicesAvailabilitiesChangeHistoryQueryParamsConverted)
+}
 
 //GetOrganizationDevicesOverviewByModel Lists the count for each device model
 /* Lists the count for each device model
@@ -4898,6 +5284,7 @@ func (s *OrganizationsService) GetOrganizationDevicesAvailabilitiesChangeHistory
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesOverviewByModel(organizationID string, getOrganizationDevicesOverviewByModelQueryParams *GetOrganizationDevicesOverviewByModelQueryParams) (*ResponseOrganizationsGetOrganizationDevicesOverviewByModel, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/overview/byModel"
 	s.rateLimiterBucket.Wait(1)
@@ -4934,9 +5321,40 @@ func (s *OrganizationsService) GetOrganizationDevicesOverviewByModel(organizatio
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesPowerModulesStatusesByDevice(organizationID string, getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams *GetOrganizationDevicesPowerModulesStatusesByDeviceQueryParams) (*ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/powerModules/statuses/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams != nil && getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice
+		println("Paginate")
+		getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesPowerModulesStatusesByDevicePaginate, organizationID, "", getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesPowerModulesStatusesByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams)
@@ -4961,6 +5379,11 @@ func (s *OrganizationsService) GetOrganizationDevicesPowerModulesStatusesByDevic
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesPowerModulesStatusesByDevicePaginate(organizationID string, getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesPowerModulesStatusesByDeviceQueryParamsConverted := getOrganizationDevicesPowerModulesStatusesByDeviceQueryParams.(*GetOrganizationDevicesPowerModulesStatusesByDeviceQueryParams)
+
+	return s.GetOrganizationDevicesPowerModulesStatusesByDevice(organizationID, getOrganizationDevicesPowerModulesStatusesByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationDevicesProvisioningStatuses List the provisioning statuses information for devices in an organization.
 /* List the provisioning statuses information for devices in an organization.
@@ -4970,9 +5393,40 @@ func (s *OrganizationsService) GetOrganizationDevicesPowerModulesStatusesByDevic
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesProvisioningStatuses(organizationID string, getOrganizationDevicesProvisioningStatusesQueryParams *GetOrganizationDevicesProvisioningStatusesQueryParams) (*ResponseOrganizationsGetOrganizationDevicesProvisioningStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/provisioning/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesProvisioningStatusesQueryParams != nil && getOrganizationDevicesProvisioningStatusesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesProvisioningStatuses
+		println("Paginate")
+		getOrganizationDevicesProvisioningStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesProvisioningStatusesPaginate, organizationID, "", getOrganizationDevicesProvisioningStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesProvisioningStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesProvisioningStatusesQueryParams)
@@ -4997,6 +5451,11 @@ func (s *OrganizationsService) GetOrganizationDevicesProvisioningStatuses(organi
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesProvisioningStatusesPaginate(organizationID string, getOrganizationDevicesProvisioningStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesProvisioningStatusesQueryParamsConverted := getOrganizationDevicesProvisioningStatusesQueryParams.(*GetOrganizationDevicesProvisioningStatusesQueryParams)
+
+	return s.GetOrganizationDevicesProvisioningStatuses(organizationID, getOrganizationDevicesProvisioningStatusesQueryParamsConverted)
+}
 
 //GetOrganizationDevicesStatuses List the status of every Meraki device in the organization
 /* List the status of every Meraki device in the organization
@@ -5006,9 +5465,40 @@ func (s *OrganizationsService) GetOrganizationDevicesProvisioningStatuses(organi
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesStatuses(organizationID string, getOrganizationDevicesStatusesQueryParams *GetOrganizationDevicesStatusesQueryParams) (*ResponseOrganizationsGetOrganizationDevicesStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesStatusesQueryParams != nil && getOrganizationDevicesStatusesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesStatuses
+		println("Paginate")
+		getOrganizationDevicesStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesStatusesPaginate, organizationID, "", getOrganizationDevicesStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesStatusesQueryParams)
@@ -5033,6 +5523,11 @@ func (s *OrganizationsService) GetOrganizationDevicesStatuses(organizationID str
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesStatusesPaginate(organizationID string, getOrganizationDevicesStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesStatusesQueryParamsConverted := getOrganizationDevicesStatusesQueryParams.(*GetOrganizationDevicesStatusesQueryParams)
+
+	return s.GetOrganizationDevicesStatuses(organizationID, getOrganizationDevicesStatusesQueryParamsConverted)
+}
 
 //GetOrganizationDevicesStatusesOverview Return an overview of current device statuses
 /* Return an overview of current device statuses
@@ -5042,6 +5537,7 @@ func (s *OrganizationsService) GetOrganizationDevicesStatuses(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesStatusesOverview(organizationID string, getOrganizationDevicesStatusesOverviewQueryParams *GetOrganizationDevicesStatusesOverviewQueryParams) (*ResponseOrganizationsGetOrganizationDevicesStatusesOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/statuses/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -5078,9 +5574,40 @@ func (s *OrganizationsService) GetOrganizationDevicesStatusesOverview(organizati
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesUplinksAddressesByDevice(organizationID string, getOrganizationDevicesUplinksAddressesByDeviceQueryParams *GetOrganizationDevicesUplinksAddressesByDeviceQueryParams) (*ResponseOrganizationsGetOrganizationDevicesUplinksAddressesByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/uplinks/addresses/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationDevicesUplinksAddressesByDeviceQueryParams != nil && getOrganizationDevicesUplinksAddressesByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationDevicesUplinksAddressesByDevice
+		println("Paginate")
+		getOrganizationDevicesUplinksAddressesByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationDevicesUplinksAddressesByDevicePaginate, organizationID, "", getOrganizationDevicesUplinksAddressesByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationDevicesUplinksAddressesByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationDevicesUplinksAddressesByDeviceQueryParams)
@@ -5105,6 +5632,11 @@ func (s *OrganizationsService) GetOrganizationDevicesUplinksAddressesByDevice(or
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationDevicesUplinksAddressesByDevicePaginate(organizationID string, getOrganizationDevicesUplinksAddressesByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationDevicesUplinksAddressesByDeviceQueryParamsConverted := getOrganizationDevicesUplinksAddressesByDeviceQueryParams.(*GetOrganizationDevicesUplinksAddressesByDeviceQueryParams)
+
+	return s.GetOrganizationDevicesUplinksAddressesByDevice(organizationID, getOrganizationDevicesUplinksAddressesByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationDevicesUplinksLossAndLatency Return the uplink loss and latency for every MX in the organization from at latest 2 minutes ago
 /* Return the uplink loss and latency for every MX in the organization from at latest 2 minutes ago
@@ -5114,6 +5646,7 @@ func (s *OrganizationsService) GetOrganizationDevicesUplinksAddressesByDevice(or
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationDevicesUplinksLossAndLatency(organizationID string, getOrganizationDevicesUplinksLossAndLatencyQueryParams *GetOrganizationDevicesUplinksLossAndLatencyQueryParams) (*ResponseOrganizationsGetOrganizationDevicesUplinksLossAndLatency, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/devices/uplinksLossAndLatency"
 	s.rateLimiterBucket.Wait(1)
@@ -5149,6 +5682,7 @@ func (s *OrganizationsService) GetOrganizationDevicesUplinksLossAndLatency(organ
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationEarlyAccessFeatures(organizationID string) (*ResponseOrganizationsGetOrganizationEarlyAccessFeatures, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/earlyAccess/features"
 	s.rateLimiterBucket.Wait(1)
@@ -5182,6 +5716,7 @@ func (s *OrganizationsService) GetOrganizationEarlyAccessFeatures(organizationID
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationEarlyAccessFeaturesOptIns(organizationID string) (*ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIns, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/earlyAccess/features/optIns"
 	s.rateLimiterBucket.Wait(1)
@@ -5216,6 +5751,7 @@ func (s *OrganizationsService) GetOrganizationEarlyAccessFeaturesOptIns(organiza
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationEarlyAccessFeaturesOptIn(organizationID string, optInID string) (*ResponseOrganizationsGetOrganizationEarlyAccessFeaturesOptIn, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/earlyAccess/features/optIns/{optInId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5251,9 +5787,40 @@ func (s *OrganizationsService) GetOrganizationEarlyAccessFeaturesOptIn(organizat
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationFirmwareUpgrades(organizationID string, getOrganizationFirmwareUpgradesQueryParams *GetOrganizationFirmwareUpgradesQueryParams) (*ResponseOrganizationsGetOrganizationFirmwareUpgrades, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/firmware/upgrades"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationFirmwareUpgradesQueryParams != nil && getOrganizationFirmwareUpgradesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationFirmwareUpgrades
+		println("Paginate")
+		getOrganizationFirmwareUpgradesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationFirmwareUpgradesPaginate, organizationID, "", getOrganizationFirmwareUpgradesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationFirmwareUpgrades
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationFirmwareUpgradesQueryParams)
@@ -5278,6 +5845,11 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgrades(organizationID st
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationFirmwareUpgradesPaginate(organizationID string, getOrganizationFirmwareUpgradesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationFirmwareUpgradesQueryParamsConverted := getOrganizationFirmwareUpgradesQueryParams.(*GetOrganizationFirmwareUpgradesQueryParams)
+
+	return s.GetOrganizationFirmwareUpgrades(organizationID, getOrganizationFirmwareUpgradesQueryParamsConverted)
+}
 
 //GetOrganizationFirmwareUpgradesByDevice Get firmware upgrade status for the filtered devices
 /* Get firmware upgrade status for the filtered devices. This endpoint currently only supports Meraki switches.
@@ -5287,9 +5859,40 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgrades(organizationID st
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationFirmwareUpgradesByDevice(organizationID string, getOrganizationFirmwareUpgradesByDeviceQueryParams *GetOrganizationFirmwareUpgradesByDeviceQueryParams) (*ResponseOrganizationsGetOrganizationFirmwareUpgradesByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/firmware/upgrades/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationFirmwareUpgradesByDeviceQueryParams != nil && getOrganizationFirmwareUpgradesByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationFirmwareUpgradesByDevice
+		println("Paginate")
+		getOrganizationFirmwareUpgradesByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationFirmwareUpgradesByDevicePaginate, organizationID, "", getOrganizationFirmwareUpgradesByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationFirmwareUpgradesByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationFirmwareUpgradesByDeviceQueryParams)
@@ -5314,6 +5917,11 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgradesByDevice(organizat
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationFirmwareUpgradesByDevicePaginate(organizationID string, getOrganizationFirmwareUpgradesByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationFirmwareUpgradesByDeviceQueryParamsConverted := getOrganizationFirmwareUpgradesByDeviceQueryParams.(*GetOrganizationFirmwareUpgradesByDeviceQueryParams)
+
+	return s.GetOrganizationFirmwareUpgradesByDevice(organizationID, getOrganizationFirmwareUpgradesByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationFloorPlansAutoLocateDevices List auto locate details for each device in your organization
 /* List auto locate details for each device in your organization
@@ -5323,9 +5931,40 @@ func (s *OrganizationsService) GetOrganizationFirmwareUpgradesByDevice(organizat
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateDevices(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams *GetOrganizationFloorPlansAutoLocateDevicesQueryParams) (*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/devices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationFloorPlansAutoLocateDevicesQueryParams != nil && getOrganizationFloorPlansAutoLocateDevicesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices
+		println("Paginate")
+		getOrganizationFloorPlansAutoLocateDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationFloorPlansAutoLocateDevicesPaginate, organizationID, "", getOrganizationFloorPlansAutoLocateDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationFloorPlansAutoLocateDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateDevicesQueryParams)
@@ -5350,6 +5989,11 @@ func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateDevices(organi
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateDevicesPaginate(organizationID string, getOrganizationFloorPlansAutoLocateDevicesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationFloorPlansAutoLocateDevicesQueryParamsConverted := getOrganizationFloorPlansAutoLocateDevicesQueryParams.(*GetOrganizationFloorPlansAutoLocateDevicesQueryParams)
+
+	return s.GetOrganizationFloorPlansAutoLocateDevices(organizationID, getOrganizationFloorPlansAutoLocateDevicesQueryParamsConverted)
+}
 
 //GetOrganizationFloorPlansAutoLocateStatuses List the status of auto locate for each floorplan in your organization
 /* List the status of auto locate for each floorplan in your organization
@@ -5359,9 +6003,40 @@ func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateDevices(organi
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateStatuses(organizationID string, getOrganizationFloorPlansAutoLocateStatusesQueryParams *GetOrganizationFloorPlansAutoLocateStatusesQueryParams) (*ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/floorPlans/autoLocate/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationFloorPlansAutoLocateStatusesQueryParams != nil && getOrganizationFloorPlansAutoLocateStatusesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses
+		println("Paginate")
+		getOrganizationFloorPlansAutoLocateStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationFloorPlansAutoLocateStatusesPaginate, organizationID, "", getOrganizationFloorPlansAutoLocateStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationFloorPlansAutoLocateStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationFloorPlansAutoLocateStatusesQueryParams)
@@ -5386,6 +6061,11 @@ func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateStatuses(organ
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateStatusesPaginate(organizationID string, getOrganizationFloorPlansAutoLocateStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationFloorPlansAutoLocateStatusesQueryParamsConverted := getOrganizationFloorPlansAutoLocateStatusesQueryParams.(*GetOrganizationFloorPlansAutoLocateStatusesQueryParams)
+
+	return s.GetOrganizationFloorPlansAutoLocateStatuses(organizationID, getOrganizationFloorPlansAutoLocateStatusesQueryParamsConverted)
+}
 
 //GetOrganizationInventoryDevices Return the device inventory for an organization
 /* Return the device inventory for an organization
@@ -5395,9 +6075,40 @@ func (s *OrganizationsService) GetOrganizationFloorPlansAutoLocateStatuses(organ
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationInventoryDevices(organizationID string, getOrganizationInventoryDevicesQueryParams *GetOrganizationInventoryDevicesQueryParams) (*ResponseOrganizationsGetOrganizationInventoryDevices, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationInventoryDevicesQueryParams != nil && getOrganizationInventoryDevicesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationInventoryDevices
+		println("Paginate")
+		getOrganizationInventoryDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationInventoryDevicesPaginate, organizationID, "", getOrganizationInventoryDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationInventoryDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationInventoryDevicesQueryParams)
@@ -5422,6 +6133,11 @@ func (s *OrganizationsService) GetOrganizationInventoryDevices(organizationID st
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationInventoryDevicesPaginate(organizationID string, getOrganizationInventoryDevicesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationInventoryDevicesQueryParamsConverted := getOrganizationInventoryDevicesQueryParams.(*GetOrganizationInventoryDevicesQueryParams)
+
+	return s.GetOrganizationInventoryDevices(organizationID, getOrganizationInventoryDevicesQueryParamsConverted)
+}
 
 //GetOrganizationInventoryDevicesSwapsBulk List of device swaps for a given request ID ({id}).
 /* List of device swaps for a given request ID ({id}).
@@ -5431,6 +6147,7 @@ func (s *OrganizationsService) GetOrganizationInventoryDevices(organizationID st
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationInventoryDevicesSwapsBulk(organizationID string, id string) (*ResponseOrganizationsGetOrganizationInventoryDevicesSwapsBulk, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/swaps/bulk/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -5466,6 +6183,7 @@ func (s *OrganizationsService) GetOrganizationInventoryDevicesSwapsBulk(organiza
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationInventoryDevice(organizationID string, serial string) (*ResponseOrganizationsGetOrganizationInventoryDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/devices/{serial}"
 	s.rateLimiterBucket.Wait(1)
@@ -5501,6 +6219,7 @@ func (s *OrganizationsService) GetOrganizationInventoryDevice(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoringImports(organizationID string, getOrganizationInventoryOnboardingCloudMonitoringImportsQueryParams *GetOrganizationInventoryOnboardingCloudMonitoringImportsQueryParams) (*ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringImports, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/onboarding/cloudMonitoring/imports"
 	s.rateLimiterBucket.Wait(1)
@@ -5537,9 +6256,40 @@ func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoring
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoringNetworks(organizationID string, getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams *GetOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams) (*ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringNetworks, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/inventory/onboarding/cloudMonitoring/networks"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams != nil && getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringNetworks
+		println("Paginate")
+		getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationInventoryOnboardingCloudMonitoringNetworksPaginate, organizationID, "", getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationInventoryOnboardingCloudMonitoringNetworks
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams)
@@ -5564,6 +6314,11 @@ func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoring
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoringNetworksPaginate(organizationID string, getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams any) (any, *resty.Response, error) {
+	getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParamsConverted := getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams.(*GetOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParams)
+
+	return s.GetOrganizationInventoryOnboardingCloudMonitoringNetworks(organizationID, getOrganizationInventoryOnboardingCloudMonitoringNetworksQueryParamsConverted)
+}
 
 //GetOrganizationLicenses List the licenses for an organization
 /* List the licenses for an organization
@@ -5573,9 +6328,40 @@ func (s *OrganizationsService) GetOrganizationInventoryOnboardingCloudMonitoring
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationLicenses(organizationID string, getOrganizationLicensesQueryParams *GetOrganizationLicensesQueryParams) (*ResponseOrganizationsGetOrganizationLicenses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/licenses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationLicensesQueryParams != nil && getOrganizationLicensesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationLicenses
+		println("Paginate")
+		getOrganizationLicensesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationLicensesPaginate, organizationID, "", getOrganizationLicensesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationLicenses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationLicensesQueryParams)
@@ -5600,6 +6386,11 @@ func (s *OrganizationsService) GetOrganizationLicenses(organizationID string, ge
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationLicensesPaginate(organizationID string, getOrganizationLicensesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationLicensesQueryParamsConverted := getOrganizationLicensesQueryParams.(*GetOrganizationLicensesQueryParams)
+
+	return s.GetOrganizationLicenses(organizationID, getOrganizationLicensesQueryParamsConverted)
+}
 
 //GetOrganizationLicensesOverview Return an overview of the license state for an organization
 /* Return an overview of the license state for an organization
@@ -5608,6 +6399,7 @@ func (s *OrganizationsService) GetOrganizationLicenses(organizationID string, ge
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationLicensesOverview(organizationID string) (*ResponseOrganizationsGetOrganizationLicensesOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/licenses/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -5642,6 +6434,7 @@ func (s *OrganizationsService) GetOrganizationLicensesOverview(organizationID st
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationLicense(organizationID string, licenseID string) (*ResponseOrganizationsGetOrganizationLicense, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/licenses/{licenseId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5676,6 +6469,7 @@ func (s *OrganizationsService) GetOrganizationLicense(organizationID string, lic
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationLoginSecurity(organizationID string) (*ResponseOrganizationsGetOrganizationLoginSecurity, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/loginSecurity"
 	s.rateLimiterBucket.Wait(1)
@@ -5710,9 +6504,40 @@ func (s *OrganizationsService) GetOrganizationLoginSecurity(organizationID strin
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationNetworks(organizationID string, getOrganizationNetworksQueryParams *GetOrganizationNetworksQueryParams) (*ResponseOrganizationsGetOrganizationNetworks, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/networks"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationNetworksQueryParams != nil && getOrganizationNetworksQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationNetworks
+		println("Paginate")
+		getOrganizationNetworksQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationNetworksPaginate, organizationID, "", getOrganizationNetworksQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationNetworks
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationNetworksQueryParams)
@@ -5737,6 +6562,11 @@ func (s *OrganizationsService) GetOrganizationNetworks(organizationID string, ge
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationNetworksPaginate(organizationID string, getOrganizationNetworksQueryParams any) (any, *resty.Response, error) {
+	getOrganizationNetworksQueryParamsConverted := getOrganizationNetworksQueryParams.(*GetOrganizationNetworksQueryParams)
+
+	return s.GetOrganizationNetworks(organizationID, getOrganizationNetworksQueryParamsConverted)
+}
 
 //GetOrganizationOpenapiSpec Return the OpenAPI Specification of the organization's API documentation in JSON
 /* Return the OpenAPI Specification of the organization's API documentation in JSON
@@ -5746,6 +6576,7 @@ func (s *OrganizationsService) GetOrganizationNetworks(organizationID string, ge
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationOpenapiSpec(organizationID string, getOrganizationOpenapiSpecQueryParams *GetOrganizationOpenapiSpecQueryParams) (*ResponseOrganizationsGetOrganizationOpenapiSpec, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/openapiSpec"
 	s.rateLimiterBucket.Wait(1)
@@ -5782,9 +6613,40 @@ func (s *OrganizationsService) GetOrganizationOpenapiSpec(organizationID string,
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationPolicyObjects(organizationID string, getOrganizationPolicyObjectsQueryParams *GetOrganizationPolicyObjectsQueryParams) (*ResponseOrganizationsGetOrganizationPolicyObjects, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationPolicyObjectsQueryParams != nil && getOrganizationPolicyObjectsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationPolicyObjects
+		println("Paginate")
+		getOrganizationPolicyObjectsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationPolicyObjectsPaginate, organizationID, "", getOrganizationPolicyObjectsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationPolicyObjects
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationPolicyObjectsQueryParams)
@@ -5809,6 +6671,11 @@ func (s *OrganizationsService) GetOrganizationPolicyObjects(organizationID strin
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationPolicyObjectsPaginate(organizationID string, getOrganizationPolicyObjectsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationPolicyObjectsQueryParamsConverted := getOrganizationPolicyObjectsQueryParams.(*GetOrganizationPolicyObjectsQueryParams)
+
+	return s.GetOrganizationPolicyObjects(organizationID, getOrganizationPolicyObjectsQueryParamsConverted)
+}
 
 //GetOrganizationPolicyObjectsGroups Lists Policy Object Groups belonging to the organization.
 /* Lists Policy Object Groups belonging to the organization.
@@ -5818,9 +6685,40 @@ func (s *OrganizationsService) GetOrganizationPolicyObjects(organizationID strin
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID string, getOrganizationPolicyObjectsGroupsQueryParams *GetOrganizationPolicyObjectsGroupsQueryParams) (*ResponseOrganizationsGetOrganizationPolicyObjectsGroups, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/groups"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationPolicyObjectsGroupsQueryParams != nil && getOrganizationPolicyObjectsGroupsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationPolicyObjectsGroups
+		println("Paginate")
+		getOrganizationPolicyObjectsGroupsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationPolicyObjectsGroupsPaginate, organizationID, "", getOrganizationPolicyObjectsGroupsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationPolicyObjectsGroups
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.ObjectIDs = append(*result.ObjectIDs, *resultTmp.ObjectIDs...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationPolicyObjectsGroupsQueryParams)
@@ -5845,6 +6743,11 @@ func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationPolicyObjectsGroupsPaginate(organizationID string, getOrganizationPolicyObjectsGroupsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationPolicyObjectsGroupsQueryParamsConverted := getOrganizationPolicyObjectsGroupsQueryParams.(*GetOrganizationPolicyObjectsGroupsQueryParams)
+
+	return s.GetOrganizationPolicyObjectsGroups(organizationID, getOrganizationPolicyObjectsGroupsQueryParamsConverted)
+}
 
 //GetOrganizationPolicyObjectsGroup Shows details of a Policy Object Group.
 /* Shows details of a Policy Object Group.
@@ -5854,6 +6757,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObjectsGroups(organizationID
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationPolicyObjectsGroup(organizationID string, policyObjectGroupID string) (*ResponseOrganizationsGetOrganizationPolicyObjectsGroup, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/groups/{policyObjectGroupId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5889,6 +6793,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObjectsGroup(organizationID 
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationPolicyObject(organizationID string, policyObjectID string) (*ResponseOrganizationsGetOrganizationPolicyObject, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/policyObjects/{policyObjectId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5923,6 +6828,7 @@ func (s *OrganizationsService) GetOrganizationPolicyObject(organizationID string
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSaml(organizationID string) (*ResponseOrganizationsGetOrganizationSaml, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/saml"
 	s.rateLimiterBucket.Wait(1)
@@ -5956,6 +6862,7 @@ func (s *OrganizationsService) GetOrganizationSaml(organizationID string) (*Resp
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSamlIDps(organizationID string) (*ResponseOrganizationsGetOrganizationSamlIDps, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/saml/idps"
 	s.rateLimiterBucket.Wait(1)
@@ -5990,6 +6897,7 @@ func (s *OrganizationsService) GetOrganizationSamlIDps(organizationID string) (*
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSamlIDp(organizationID string, idpID string) (*ResponseOrganizationsGetOrganizationSamlIDp, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/saml/idps/{idpId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6024,6 +6932,7 @@ func (s *OrganizationsService) GetOrganizationSamlIDp(organizationID string, idp
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSamlRoles(organizationID string) (*ResponseOrganizationsGetOrganizationSamlRoles, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/samlRoles"
 	s.rateLimiterBucket.Wait(1)
@@ -6058,6 +6967,7 @@ func (s *OrganizationsService) GetOrganizationSamlRoles(organizationID string) (
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSamlRole(organizationID string, samlRoleID string) (*ResponseOrganizationsGetOrganizationSamlRole, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/samlRoles/{samlRoleId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6092,6 +7002,7 @@ func (s *OrganizationsService) GetOrganizationSamlRole(organizationID string, sa
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSNMP(organizationID string) (*ResponseOrganizationsGetOrganizationSNMP, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/snmp"
 	s.rateLimiterBucket.Wait(1)
@@ -6126,6 +7037,7 @@ func (s *OrganizationsService) GetOrganizationSNMP(organizationID string) (*Resp
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSplashAsset(organizationID string, id string) (*ResponseOrganizationsGetOrganizationSplashAsset, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/splash/assets/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -6160,6 +7072,7 @@ func (s *OrganizationsService) GetOrganizationSplashAsset(organizationID string,
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSplashThemes(organizationID string) (*ResponseOrganizationsGetOrganizationSplashThemes, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/splash/themes"
 	s.rateLimiterBucket.Wait(1)
@@ -6194,6 +7107,7 @@ func (s *OrganizationsService) GetOrganizationSplashThemes(organizationID string
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopAppliancesByUtilization(organizationID string, getOrganizationSummaryTopAppliancesByUtilizationQueryParams *GetOrganizationSummaryTopAppliancesByUtilizationQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopAppliancesByUtilization, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/appliances/byUtilization"
 	s.rateLimiterBucket.Wait(1)
@@ -6230,6 +7144,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopAppliancesByUtilization(
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsByUsage(organizationID string, getOrganizationSummaryTopApplicationsByUsageQueryParams *GetOrganizationSummaryTopApplicationsByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopApplicationsByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/applications/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6266,6 +7181,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsByUsage(orga
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsCategoriesByUsage(organizationID string, getOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams *GetOrganizationSummaryTopApplicationsCategoriesByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopApplicationsCategoriesByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/applications/categories/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6302,6 +7218,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopApplicationsCategoriesBy
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopClientsByUsage(organizationID string, getOrganizationSummaryTopClientsByUsageQueryParams *GetOrganizationSummaryTopClientsByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopClientsByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/clients/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6338,6 +7255,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopClientsByUsage(organizat
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopClientsManufacturersByUsage(organizationID string, getOrganizationSummaryTopClientsManufacturersByUsageQueryParams *GetOrganizationSummaryTopClientsManufacturersByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopClientsManufacturersByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/clients/manufacturers/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6374,6 +7292,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopClientsManufacturersByUs
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopDevicesByUsage(organizationID string, getOrganizationSummaryTopDevicesByUsageQueryParams *GetOrganizationSummaryTopDevicesByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopDevicesByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/devices/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6410,6 +7329,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopDevicesByUsage(organizat
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopDevicesModelsByUsage(organizationID string, getOrganizationSummaryTopDevicesModelsByUsageQueryParams *GetOrganizationSummaryTopDevicesModelsByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopDevicesModelsByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/devices/models/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6446,9 +7366,40 @@ func (s *OrganizationsService) GetOrganizationSummaryTopDevicesModelsByUsage(org
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopNetworksByStatus(organizationID string, getOrganizationSummaryTopNetworksByStatusQueryParams *GetOrganizationSummaryTopNetworksByStatusQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/networks/byStatus"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSummaryTopNetworksByStatusQueryParams != nil && getOrganizationSummaryTopNetworksByStatusQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus
+		println("Paginate")
+		getOrganizationSummaryTopNetworksByStatusQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSummaryTopNetworksByStatusPaginate, organizationID, "", getOrganizationSummaryTopNetworksByStatusQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationSummaryTopNetworksByStatus
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSummaryTopNetworksByStatusQueryParams)
@@ -6473,6 +7424,11 @@ func (s *OrganizationsService) GetOrganizationSummaryTopNetworksByStatus(organiz
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationSummaryTopNetworksByStatusPaginate(organizationID string, getOrganizationSummaryTopNetworksByStatusQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSummaryTopNetworksByStatusQueryParamsConverted := getOrganizationSummaryTopNetworksByStatusQueryParams.(*GetOrganizationSummaryTopNetworksByStatusQueryParams)
+
+	return s.GetOrganizationSummaryTopNetworksByStatus(organizationID, getOrganizationSummaryTopNetworksByStatusQueryParamsConverted)
+}
 
 //GetOrganizationSummaryTopSSIDsByUsage Return metrics for organization's top 10 ssids by data usage over given time range
 /* Return metrics for organization's top 10 ssids by data usage over given time range. Default unit is megabytes.
@@ -6482,6 +7438,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopNetworksByStatus(organiz
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopSSIDsByUsage(organizationID string, getOrganizationSummaryTopSsidsByUsageQueryParams *GetOrganizationSummaryTopSSIDsByUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopSSIDsByUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/ssids/byUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6518,6 +7475,7 @@ func (s *OrganizationsService) GetOrganizationSummaryTopSSIDsByUsage(organizatio
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationSummaryTopSwitchesByEnergyUsage(organizationID string, getOrganizationSummaryTopSwitchesByEnergyUsageQueryParams *GetOrganizationSummaryTopSwitchesByEnergyUsageQueryParams) (*ResponseOrganizationsGetOrganizationSummaryTopSwitchesByEnergyUsage, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/top/switches/byEnergyUsage"
 	s.rateLimiterBucket.Wait(1)
@@ -6554,9 +7512,40 @@ func (s *OrganizationsService) GetOrganizationSummaryTopSwitchesByEnergyUsage(or
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationUplinksStatuses(organizationID string, getOrganizationUplinksStatusesQueryParams *GetOrganizationUplinksStatusesQueryParams) (*ResponseOrganizationsGetOrganizationUplinksStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/uplinks/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationUplinksStatusesQueryParams != nil && getOrganizationUplinksStatusesQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationUplinksStatuses
+		println("Paginate")
+		getOrganizationUplinksStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationUplinksStatusesPaginate, organizationID, "", getOrganizationUplinksStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationUplinksStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationUplinksStatusesQueryParams)
@@ -6581,6 +7570,11 @@ func (s *OrganizationsService) GetOrganizationUplinksStatuses(organizationID str
 	return result, response, err
 
 }
+func (s *OrganizationsService) GetOrganizationUplinksStatusesPaginate(organizationID string, getOrganizationUplinksStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationUplinksStatusesQueryParamsConverted := getOrganizationUplinksStatusesQueryParams.(*GetOrganizationUplinksStatusesQueryParams)
+
+	return s.GetOrganizationUplinksStatuses(organizationID, getOrganizationUplinksStatusesQueryParamsConverted)
+}
 
 //GetOrganizationWebhooksAlertTypes Return a list of alert types to be used with managing webhook alerts
 /* Return a list of alert types to be used with managing webhook alerts
@@ -6590,6 +7584,7 @@ func (s *OrganizationsService) GetOrganizationUplinksStatuses(organizationID str
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationWebhooksAlertTypes(organizationID string, getOrganizationWebhooksAlertTypesQueryParams *GetOrganizationWebhooksAlertTypesQueryParams) (*ResponseOrganizationsGetOrganizationWebhooksAlertTypes, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/webhooks/alertTypes"
 	s.rateLimiterBucket.Wait(1)
@@ -6626,6 +7621,7 @@ func (s *OrganizationsService) GetOrganizationWebhooksAlertTypes(organizationID 
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationWebhooksCallbacksStatus(organizationID string, callbackID string) (*ResponseOrganizationsGetOrganizationWebhooksCallbacksStatus, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/webhooks/callbacks/statuses/{callbackId}"
 	s.rateLimiterBucket.Wait(1)
@@ -6661,9 +7657,40 @@ func (s *OrganizationsService) GetOrganizationWebhooksCallbacksStatus(organizati
 
 
 */
+
 func (s *OrganizationsService) GetOrganizationWebhooksLogs(organizationID string, getOrganizationWebhooksLogsQueryParams *GetOrganizationWebhooksLogsQueryParams) (*ResponseOrganizationsGetOrganizationWebhooksLogs, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/webhooks/logs"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWebhooksLogsQueryParams != nil && getOrganizationWebhooksLogsQueryParams.PerPage == -1 {
+		var result *ResponseOrganizationsGetOrganizationWebhooksLogs
+		println("Paginate")
+		getOrganizationWebhooksLogsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWebhooksLogsPaginate, organizationID, "", getOrganizationWebhooksLogsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseOrganizationsGetOrganizationWebhooksLogs
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWebhooksLogsQueryParams)
@@ -6687,6 +7714,11 @@ func (s *OrganizationsService) GetOrganizationWebhooksLogs(organizationID string
 	result := response.Result().(*ResponseOrganizationsGetOrganizationWebhooksLogs)
 	return result, response, err
 
+}
+func (s *OrganizationsService) GetOrganizationWebhooksLogsPaginate(organizationID string, getOrganizationWebhooksLogsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWebhooksLogsQueryParamsConverted := getOrganizationWebhooksLogsQueryParams.(*GetOrganizationWebhooksLogsQueryParams)
+
+	return s.GetOrganizationWebhooksLogs(organizationID, getOrganizationWebhooksLogsQueryParamsConverted)
 }
 
 //CreateOrganization Create a new organization

--- a/sdk/sensor.go
+++ b/sdk/sensor.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -1000,9 +1001,40 @@ type RequestSensorUpdateNetworkSensorMqttBroker struct {
 
 
 */
+
 func (s *SensorService) GetDeviceSensorCommands(serial string, getDeviceSensorCommandsQueryParams *GetDeviceSensorCommandsQueryParams) (*ResponseSensorGetDeviceSensorCommands, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/sensor/commands"
 	s.rateLimiterBucket.Wait(1)
+
+	if getDeviceSensorCommandsQueryParams != nil && getDeviceSensorCommandsQueryParams.PerPage == -1 {
+		var result *ResponseSensorGetDeviceSensorCommands
+		println("Paginate")
+		getDeviceSensorCommandsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetDeviceSensorCommandsPaginate, serial, "", getDeviceSensorCommandsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSensorGetDeviceSensorCommands
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{serial}", fmt.Sprintf("%v", serial), -1)
 
 	queryString, _ := query.Values(getDeviceSensorCommandsQueryParams)
@@ -1027,6 +1059,11 @@ func (s *SensorService) GetDeviceSensorCommands(serial string, getDeviceSensorCo
 	return result, response, err
 
 }
+func (s *SensorService) GetDeviceSensorCommandsPaginate(serial string, getDeviceSensorCommandsQueryParams any) (any, *resty.Response, error) {
+	getDeviceSensorCommandsQueryParamsConverted := getDeviceSensorCommandsQueryParams.(*GetDeviceSensorCommandsQueryParams)
+
+	return s.GetDeviceSensorCommands(serial, getDeviceSensorCommandsQueryParamsConverted)
+}
 
 //GetDeviceSensorCommand Returns information about the command's execution, including the status
 /* Returns information about the command's execution, including the status
@@ -1036,6 +1073,7 @@ func (s *SensorService) GetDeviceSensorCommands(serial string, getDeviceSensorCo
 
 
 */
+
 func (s *SensorService) GetDeviceSensorCommand(serial string, commandID string) (*ResponseSensorGetDeviceSensorCommand, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/sensor/commands/{commandId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1070,6 +1108,7 @@ func (s *SensorService) GetDeviceSensorCommand(serial string, commandID string) 
 
 
 */
+
 func (s *SensorService) GetDeviceSensorRelationships(serial string) (*ResponseSensorGetDeviceSensorRelationships, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/sensor/relationships"
 	s.rateLimiterBucket.Wait(1)
@@ -1103,6 +1142,7 @@ func (s *SensorService) GetDeviceSensorRelationships(serial string) (*ResponseSe
 
 
 */
+
 func (s *SensorService) GetNetworkSensorAlertsCurrentOverviewByMetric(networkID string) (*ResponseSensorGetNetworkSensorAlertsCurrentOverviewByMetric, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/alerts/current/overview/byMetric"
 	s.rateLimiterBucket.Wait(1)
@@ -1137,6 +1177,7 @@ func (s *SensorService) GetNetworkSensorAlertsCurrentOverviewByMetric(networkID 
 
 
 */
+
 func (s *SensorService) GetNetworkSensorAlertsOverviewByMetric(networkID string, getNetworkSensorAlertsOverviewByMetricQueryParams *GetNetworkSensorAlertsOverviewByMetricQueryParams) (*ResponseSensorGetNetworkSensorAlertsOverviewByMetric, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/alerts/overview/byMetric"
 	s.rateLimiterBucket.Wait(1)
@@ -1172,6 +1213,7 @@ func (s *SensorService) GetNetworkSensorAlertsOverviewByMetric(networkID string,
 
 
 */
+
 func (s *SensorService) GetNetworkSensorAlertsProfiles(networkID string) (*ResponseSensorGetNetworkSensorAlertsProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/alerts/profiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1206,6 +1248,7 @@ func (s *SensorService) GetNetworkSensorAlertsProfiles(networkID string) (*Respo
 
 
 */
+
 func (s *SensorService) GetNetworkSensorAlertsProfile(networkID string, id string) (*ResponseSensorGetNetworkSensorAlertsProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/alerts/profiles/{id}"
 	s.rateLimiterBucket.Wait(1)
@@ -1240,6 +1283,7 @@ func (s *SensorService) GetNetworkSensorAlertsProfile(networkID string, id strin
 
 
 */
+
 func (s *SensorService) GetNetworkSensorMqttBrokers(networkID string) (*ResponseSensorGetNetworkSensorMqttBrokers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/mqttBrokers"
 	s.rateLimiterBucket.Wait(1)
@@ -1274,6 +1318,7 @@ func (s *SensorService) GetNetworkSensorMqttBrokers(networkID string) (*Response
 
 
 */
+
 func (s *SensorService) GetNetworkSensorMqttBroker(networkID string, mqttBrokerID string) (*ResponseSensorGetNetworkSensorMqttBroker, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/mqttBrokers/{mqttBrokerId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1308,6 +1353,7 @@ func (s *SensorService) GetNetworkSensorMqttBroker(networkID string, mqttBrokerI
 
 
 */
+
 func (s *SensorService) GetNetworkSensorRelationships(networkID string) (*ResponseSensorGetNetworkSensorRelationships, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sensor/relationships"
 	s.rateLimiterBucket.Wait(1)
@@ -1342,9 +1388,40 @@ func (s *SensorService) GetNetworkSensorRelationships(networkID string) (*Respon
 
 
 */
+
 func (s *SensorService) GetOrganizationSensorReadingsHistory(organizationID string, getOrganizationSensorReadingsHistoryQueryParams *GetOrganizationSensorReadingsHistoryQueryParams) (*ResponseSensorGetOrganizationSensorReadingsHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sensor/readings/history"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSensorReadingsHistoryQueryParams != nil && getOrganizationSensorReadingsHistoryQueryParams.PerPage == -1 {
+		var result *ResponseSensorGetOrganizationSensorReadingsHistory
+		println("Paginate")
+		getOrganizationSensorReadingsHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSensorReadingsHistoryPaginate, organizationID, "", getOrganizationSensorReadingsHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSensorGetOrganizationSensorReadingsHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSensorReadingsHistoryQueryParams)
@@ -1369,6 +1446,11 @@ func (s *SensorService) GetOrganizationSensorReadingsHistory(organizationID stri
 	return result, response, err
 
 }
+func (s *SensorService) GetOrganizationSensorReadingsHistoryPaginate(organizationID string, getOrganizationSensorReadingsHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSensorReadingsHistoryQueryParamsConverted := getOrganizationSensorReadingsHistoryQueryParams.(*GetOrganizationSensorReadingsHistoryQueryParams)
+
+	return s.GetOrganizationSensorReadingsHistory(organizationID, getOrganizationSensorReadingsHistoryQueryParamsConverted)
+}
 
 //GetOrganizationSensorReadingsLatest Return the latest available reading for each metric from each sensor, sorted by sensor serial
 /* Return the latest available reading for each metric from each sensor, sorted by sensor serial
@@ -1378,9 +1460,40 @@ func (s *SensorService) GetOrganizationSensorReadingsHistory(organizationID stri
 
 
 */
+
 func (s *SensorService) GetOrganizationSensorReadingsLatest(organizationID string, getOrganizationSensorReadingsLatestQueryParams *GetOrganizationSensorReadingsLatestQueryParams) (*ResponseSensorGetOrganizationSensorReadingsLatest, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sensor/readings/latest"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSensorReadingsLatestQueryParams != nil && getOrganizationSensorReadingsLatestQueryParams.PerPage == -1 {
+		var result *ResponseSensorGetOrganizationSensorReadingsLatest
+		println("Paginate")
+		getOrganizationSensorReadingsLatestQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSensorReadingsLatestPaginate, organizationID, "", getOrganizationSensorReadingsLatestQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSensorGetOrganizationSensorReadingsLatest
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSensorReadingsLatestQueryParams)
@@ -1404,6 +1517,11 @@ func (s *SensorService) GetOrganizationSensorReadingsLatest(organizationID strin
 	result := response.Result().(*ResponseSensorGetOrganizationSensorReadingsLatest)
 	return result, response, err
 
+}
+func (s *SensorService) GetOrganizationSensorReadingsLatestPaginate(organizationID string, getOrganizationSensorReadingsLatestQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSensorReadingsLatestQueryParamsConverted := getOrganizationSensorReadingsLatestQueryParams.(*GetOrganizationSensorReadingsLatestQueryParams)
+
+	return s.GetOrganizationSensorReadingsLatest(organizationID, getOrganizationSensorReadingsLatestQueryParamsConverted)
 }
 
 //CreateDeviceSensorCommand Sends a command to a sensor

--- a/sdk/sm.go
+++ b/sdk/sm.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -663,6 +664,7 @@ type RequestSmUpdateOrganizationSmSentryPoliciesAssignmentsItemsPolicies struct 
 
 
 */
+
 func (s *SmService) GetNetworkSmBypassActivationLockAttempt(networkID string, attemptID string) (*ResponseSmGetNetworkSmBypassActivationLockAttempt, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/bypassActivationLockAttempts/{attemptId}"
 	s.rateLimiterBucket.Wait(1)
@@ -698,9 +700,40 @@ func (s *SmService) GetNetworkSmBypassActivationLockAttempt(networkID string, at
 
 
 */
+
 func (s *SmService) GetNetworkSmDevices(networkID string, getNetworkSmDevicesQueryParams *GetNetworkSmDevicesQueryParams) (*ResponseSmGetNetworkSmDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmDevicesQueryParams != nil && getNetworkSmDevicesQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmDevices
+		println("Paginate")
+		getNetworkSmDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmDevicesPaginate, networkID, "", getNetworkSmDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSmDevicesQueryParams)
@@ -725,6 +758,11 @@ func (s *SmService) GetNetworkSmDevices(networkID string, getNetworkSmDevicesQue
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmDevicesPaginate(networkID string, getNetworkSmDevicesQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmDevicesQueryParamsConverted := getNetworkSmDevicesQueryParams.(*GetNetworkSmDevicesQueryParams)
+
+	return s.GetNetworkSmDevices(networkID, getNetworkSmDevicesQueryParamsConverted)
+}
 
 //GetNetworkSmDeviceCellularUsageHistory Return the client's daily cellular data usage history
 /* Return the client's daily cellular data usage history. Usage data is in kilobytes.
@@ -734,6 +772,7 @@ func (s *SmService) GetNetworkSmDevices(networkID string, getNetworkSmDevicesQue
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceCellularUsageHistory(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceCellularUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/cellularUsageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -769,6 +808,7 @@ func (s *SmService) GetNetworkSmDeviceCellularUsageHistory(networkID string, dev
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceCerts(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceCerts, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/certs"
 	s.rateLimiterBucket.Wait(1)
@@ -805,9 +845,40 @@ func (s *SmService) GetNetworkSmDeviceCerts(networkID string, deviceID string) (
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceConnectivity(networkID string, deviceID string, getNetworkSmDeviceConnectivityQueryParams *GetNetworkSmDeviceConnectivityQueryParams) (*ResponseSmGetNetworkSmDeviceConnectivity, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/connectivity"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmDeviceConnectivityQueryParams != nil && getNetworkSmDeviceConnectivityQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmDeviceConnectivity
+		println("Paginate")
+		getNetworkSmDeviceConnectivityQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmDeviceConnectivityPaginate, networkID, deviceID, getNetworkSmDeviceConnectivityQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmDeviceConnectivity
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
 
@@ -833,6 +904,11 @@ func (s *SmService) GetNetworkSmDeviceConnectivity(networkID string, deviceID st
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmDeviceConnectivityPaginate(networkID string, deviceID string, getNetworkSmDeviceConnectivityQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmDeviceConnectivityQueryParamsConverted := getNetworkSmDeviceConnectivityQueryParams.(*GetNetworkSmDeviceConnectivityQueryParams)
+
+	return s.GetNetworkSmDeviceConnectivity(networkID, deviceID, getNetworkSmDeviceConnectivityQueryParamsConverted)
+}
 
 //GetNetworkSmDeviceDesktopLogs Return historical records of various Systems Manager network connection details for desktop devices.
 /* Return historical records of various Systems Manager network connection details for desktop devices.
@@ -843,9 +919,40 @@ func (s *SmService) GetNetworkSmDeviceConnectivity(networkID string, deviceID st
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceDesktopLogs(networkID string, deviceID string, getNetworkSmDeviceDesktopLogsQueryParams *GetNetworkSmDeviceDesktopLogsQueryParams) (*ResponseSmGetNetworkSmDeviceDesktopLogs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/desktopLogs"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmDeviceDesktopLogsQueryParams != nil && getNetworkSmDeviceDesktopLogsQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmDeviceDesktopLogs
+		println("Paginate")
+		getNetworkSmDeviceDesktopLogsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmDeviceDesktopLogsPaginate, networkID, deviceID, getNetworkSmDeviceDesktopLogsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmDeviceDesktopLogs
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
 
@@ -871,6 +978,11 @@ func (s *SmService) GetNetworkSmDeviceDesktopLogs(networkID string, deviceID str
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmDeviceDesktopLogsPaginate(networkID string, deviceID string, getNetworkSmDeviceDesktopLogsQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmDeviceDesktopLogsQueryParamsConverted := getNetworkSmDeviceDesktopLogsQueryParams.(*GetNetworkSmDeviceDesktopLogsQueryParams)
+
+	return s.GetNetworkSmDeviceDesktopLogs(networkID, deviceID, getNetworkSmDeviceDesktopLogsQueryParamsConverted)
+}
 
 //GetNetworkSmDeviceDeviceCommandLogs Return historical records of commands sent to Systems Manager devices
 /* Return historical records of commands sent to Systems Manager devices. Note that this will include the name of the Dashboard user who initiated the command if it was generated by a Dashboard admin rather than the automatic behavior of the system; you may wish to filter this out of any reports.
@@ -881,9 +993,40 @@ func (s *SmService) GetNetworkSmDeviceDesktopLogs(networkID string, deviceID str
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceDeviceCommandLogs(networkID string, deviceID string, getNetworkSmDeviceDeviceCommandLogsQueryParams *GetNetworkSmDeviceDeviceCommandLogsQueryParams) (*ResponseSmGetNetworkSmDeviceDeviceCommandLogs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/deviceCommandLogs"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmDeviceDeviceCommandLogsQueryParams != nil && getNetworkSmDeviceDeviceCommandLogsQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmDeviceDeviceCommandLogs
+		println("Paginate")
+		getNetworkSmDeviceDeviceCommandLogsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmDeviceDeviceCommandLogsPaginate, networkID, deviceID, getNetworkSmDeviceDeviceCommandLogsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmDeviceDeviceCommandLogs
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
 
@@ -909,6 +1052,11 @@ func (s *SmService) GetNetworkSmDeviceDeviceCommandLogs(networkID string, device
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmDeviceDeviceCommandLogsPaginate(networkID string, deviceID string, getNetworkSmDeviceDeviceCommandLogsQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmDeviceDeviceCommandLogsQueryParamsConverted := getNetworkSmDeviceDeviceCommandLogsQueryParams.(*GetNetworkSmDeviceDeviceCommandLogsQueryParams)
+
+	return s.GetNetworkSmDeviceDeviceCommandLogs(networkID, deviceID, getNetworkSmDeviceDeviceCommandLogsQueryParamsConverted)
+}
 
 //GetNetworkSmDeviceDeviceProfiles Get the installed profiles associated with a device
 /* Get the installed profiles associated with a device
@@ -918,6 +1066,7 @@ func (s *SmService) GetNetworkSmDeviceDeviceCommandLogs(networkID string, device
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceDeviceProfiles(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceDeviceProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/deviceProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -953,6 +1102,7 @@ func (s *SmService) GetNetworkSmDeviceDeviceProfiles(networkID string, deviceID 
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceNetworkAdapters(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceNetworkAdapters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/networkAdapters"
 	s.rateLimiterBucket.Wait(1)
@@ -989,9 +1139,40 @@ func (s *SmService) GetNetworkSmDeviceNetworkAdapters(networkID string, deviceID
 
 
 */
+
 func (s *SmService) GetNetworkSmDevicePerformanceHistory(networkID string, deviceID string, getNetworkSmDevicePerformanceHistoryQueryParams *GetNetworkSmDevicePerformanceHistoryQueryParams) (*ResponseSmGetNetworkSmDevicePerformanceHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/performanceHistory"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmDevicePerformanceHistoryQueryParams != nil && getNetworkSmDevicePerformanceHistoryQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmDevicePerformanceHistory
+		println("Paginate")
+		getNetworkSmDevicePerformanceHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmDevicePerformanceHistoryPaginate, networkID, deviceID, getNetworkSmDevicePerformanceHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmDevicePerformanceHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{deviceId}", fmt.Sprintf("%v", deviceID), -1)
 
@@ -1017,6 +1198,11 @@ func (s *SmService) GetNetworkSmDevicePerformanceHistory(networkID string, devic
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmDevicePerformanceHistoryPaginate(networkID string, deviceID string, getNetworkSmDevicePerformanceHistoryQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmDevicePerformanceHistoryQueryParamsConverted := getNetworkSmDevicePerformanceHistoryQueryParams.(*GetNetworkSmDevicePerformanceHistoryQueryParams)
+
+	return s.GetNetworkSmDevicePerformanceHistory(networkID, deviceID, getNetworkSmDevicePerformanceHistoryQueryParamsConverted)
+}
 
 //GetNetworkSmDeviceRestrictions List the restrictions on a device
 /* List the restrictions on a device
@@ -1026,6 +1212,7 @@ func (s *SmService) GetNetworkSmDevicePerformanceHistory(networkID string, devic
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceRestrictions(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceRestrictions, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/restrictions"
 	s.rateLimiterBucket.Wait(1)
@@ -1061,6 +1248,7 @@ func (s *SmService) GetNetworkSmDeviceRestrictions(networkID string, deviceID st
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceSecurityCenters(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceSecurityCenters, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/securityCenters"
 	s.rateLimiterBucket.Wait(1)
@@ -1096,6 +1284,7 @@ func (s *SmService) GetNetworkSmDeviceSecurityCenters(networkID string, deviceID
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceSoftwares(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceSoftwares, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/softwares"
 	s.rateLimiterBucket.Wait(1)
@@ -1131,6 +1320,7 @@ func (s *SmService) GetNetworkSmDeviceSoftwares(networkID string, deviceID strin
 
 
 */
+
 func (s *SmService) GetNetworkSmDeviceWLANLists(networkID string, deviceID string) (*ResponseSmGetNetworkSmDeviceWLANLists, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/devices/{deviceId}/wlanLists"
 	s.rateLimiterBucket.Wait(1)
@@ -1166,6 +1356,7 @@ func (s *SmService) GetNetworkSmDeviceWLANLists(networkID string, deviceID strin
 
 
 */
+
 func (s *SmService) GetNetworkSmProfiles(networkID string, getNetworkSmProfilesQueryParams *GetNetworkSmProfilesQueryParams) (*ResponseSmGetNetworkSmProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/profiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1202,6 +1393,7 @@ func (s *SmService) GetNetworkSmProfiles(networkID string, getNetworkSmProfilesQ
 
 
 */
+
 func (s *SmService) GetNetworkSmTargetGroups(networkID string, getNetworkSmTargetGroupsQueryParams *GetNetworkSmTargetGroupsQueryParams) (*ResponseSmGetNetworkSmTargetGroups, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/targetGroups"
 	s.rateLimiterBucket.Wait(1)
@@ -1239,6 +1431,7 @@ func (s *SmService) GetNetworkSmTargetGroups(networkID string, getNetworkSmTarge
 
 
 */
+
 func (s *SmService) GetNetworkSmTargetGroup(networkID string, targetGroupID string, getNetworkSmTargetGroupQueryParams *GetNetworkSmTargetGroupQueryParams) (*ResponseSmGetNetworkSmTargetGroup, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/targetGroups/{targetGroupId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1276,9 +1469,40 @@ func (s *SmService) GetNetworkSmTargetGroup(networkID string, targetGroupID stri
 
 
 */
+
 func (s *SmService) GetNetworkSmTrustedAccessConfigs(networkID string, getNetworkSmTrustedAccessConfigsQueryParams *GetNetworkSmTrustedAccessConfigsQueryParams) (*ResponseSmGetNetworkSmTrustedAccessConfigs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/trustedAccessConfigs"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmTrustedAccessConfigsQueryParams != nil && getNetworkSmTrustedAccessConfigsQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmTrustedAccessConfigs
+		println("Paginate")
+		getNetworkSmTrustedAccessConfigsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmTrustedAccessConfigsPaginate, networkID, "", getNetworkSmTrustedAccessConfigsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmTrustedAccessConfigs
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSmTrustedAccessConfigsQueryParams)
@@ -1303,6 +1527,11 @@ func (s *SmService) GetNetworkSmTrustedAccessConfigs(networkID string, getNetwor
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmTrustedAccessConfigsPaginate(networkID string, getNetworkSmTrustedAccessConfigsQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmTrustedAccessConfigsQueryParamsConverted := getNetworkSmTrustedAccessConfigsQueryParams.(*GetNetworkSmTrustedAccessConfigsQueryParams)
+
+	return s.GetNetworkSmTrustedAccessConfigs(networkID, getNetworkSmTrustedAccessConfigsQueryParamsConverted)
+}
 
 //GetNetworkSmUserAccessDevices List User Access Devices and its Trusted Access Connections
 /* List User Access Devices and its Trusted Access Connections
@@ -1312,9 +1541,40 @@ func (s *SmService) GetNetworkSmTrustedAccessConfigs(networkID string, getNetwor
 
 
 */
+
 func (s *SmService) GetNetworkSmUserAccessDevices(networkID string, getNetworkSmUserAccessDevicesQueryParams *GetNetworkSmUserAccessDevicesQueryParams) (*ResponseSmGetNetworkSmUserAccessDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/userAccessDevices"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSmUserAccessDevicesQueryParams != nil && getNetworkSmUserAccessDevicesQueryParams.PerPage == -1 {
+		var result *ResponseSmGetNetworkSmUserAccessDevices
+		println("Paginate")
+		getNetworkSmUserAccessDevicesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSmUserAccessDevicesPaginate, networkID, "", getNetworkSmUserAccessDevicesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetNetworkSmUserAccessDevices
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSmUserAccessDevicesQueryParams)
@@ -1339,6 +1599,11 @@ func (s *SmService) GetNetworkSmUserAccessDevices(networkID string, getNetworkSm
 	return result, response, err
 
 }
+func (s *SmService) GetNetworkSmUserAccessDevicesPaginate(networkID string, getNetworkSmUserAccessDevicesQueryParams any) (any, *resty.Response, error) {
+	getNetworkSmUserAccessDevicesQueryParamsConverted := getNetworkSmUserAccessDevicesQueryParams.(*GetNetworkSmUserAccessDevicesQueryParams)
+
+	return s.GetNetworkSmUserAccessDevices(networkID, getNetworkSmUserAccessDevicesQueryParamsConverted)
+}
 
 //GetNetworkSmUsers List the owners in an SM network with various specified fields and filters
 /* List the owners in an SM network with various specified fields and filters
@@ -1348,6 +1613,7 @@ func (s *SmService) GetNetworkSmUserAccessDevices(networkID string, getNetworkSm
 
 
 */
+
 func (s *SmService) GetNetworkSmUsers(networkID string, getNetworkSmUsersQueryParams *GetNetworkSmUsersQueryParams) (*ResponseSmGetNetworkSmUsers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/users"
 	s.rateLimiterBucket.Wait(1)
@@ -1384,6 +1650,7 @@ func (s *SmService) GetNetworkSmUsers(networkID string, getNetworkSmUsersQueryPa
 
 
 */
+
 func (s *SmService) GetNetworkSmUserDeviceProfiles(networkID string, userID string) (*ResponseSmGetNetworkSmUserDeviceProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/users/{userId}/deviceProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -1419,6 +1686,7 @@ func (s *SmService) GetNetworkSmUserDeviceProfiles(networkID string, userID stri
 
 
 */
+
 func (s *SmService) GetNetworkSmUserSoftwares(networkID string, userID string) (*ResponseSmGetNetworkSmUserSoftwares, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/sm/users/{userId}/softwares"
 	s.rateLimiterBucket.Wait(1)
@@ -1454,9 +1722,40 @@ func (s *SmService) GetNetworkSmUserSoftwares(networkID string, userID string) (
 
 
 */
+
 func (s *SmService) GetOrganizationSmAdminsRoles(organizationID string, getOrganizationSmAdminsRolesQueryParams *GetOrganizationSmAdminsRolesQueryParams) (*ResponseSmGetOrganizationSmAdminsRoles, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/admins/roles"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSmAdminsRolesQueryParams != nil && getOrganizationSmAdminsRolesQueryParams.PerPage == -1 {
+		var result *ResponseSmGetOrganizationSmAdminsRoles
+		println("Paginate")
+		getOrganizationSmAdminsRolesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSmAdminsRolesPaginate, organizationID, "", getOrganizationSmAdminsRolesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetOrganizationSmAdminsRoles
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSmAdminsRolesQueryParams)
@@ -1481,6 +1780,11 @@ func (s *SmService) GetOrganizationSmAdminsRoles(organizationID string, getOrgan
 	return result, response, err
 
 }
+func (s *SmService) GetOrganizationSmAdminsRolesPaginate(organizationID string, getOrganizationSmAdminsRolesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSmAdminsRolesQueryParamsConverted := getOrganizationSmAdminsRolesQueryParams.(*GetOrganizationSmAdminsRolesQueryParams)
+
+	return s.GetOrganizationSmAdminsRoles(organizationID, getOrganizationSmAdminsRolesQueryParamsConverted)
+}
 
 //GetOrganizationSmAdminsRole Return a Limited Access Role
 /* Return a Limited Access Role
@@ -1490,6 +1794,7 @@ func (s *SmService) GetOrganizationSmAdminsRoles(organizationID string, getOrgan
 
 
 */
+
 func (s *SmService) GetOrganizationSmAdminsRole(organizationID string, roleID string) (*ResponseSmGetOrganizationSmAdminsRole, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/admins/roles/{roleId}"
 	s.rateLimiterBucket.Wait(1)
@@ -1524,6 +1829,7 @@ func (s *SmService) GetOrganizationSmAdminsRole(organizationID string, roleID st
 
 
 */
+
 func (s *SmService) GetOrganizationSmApnsCert(organizationID string) (*ResponseSmGetOrganizationSmApnsCert, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/apnsCert"
 	s.rateLimiterBucket.Wait(1)
@@ -1558,9 +1864,40 @@ func (s *SmService) GetOrganizationSmApnsCert(organizationID string) (*ResponseS
 
 
 */
+
 func (s *SmService) GetOrganizationSmSentryPoliciesAssignmentsByNetwork(organizationID string, getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams *GetOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams) (*ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/sentry/policies/assignments/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams != nil && getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork
+		println("Paginate")
+		getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSmSentryPoliciesAssignmentsByNetworkPaginate, organizationID, "", getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSmGetOrganizationSmSentryPoliciesAssignmentsByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams)
@@ -1585,6 +1922,11 @@ func (s *SmService) GetOrganizationSmSentryPoliciesAssignmentsByNetwork(organiza
 	return result, response, err
 
 }
+func (s *SmService) GetOrganizationSmSentryPoliciesAssignmentsByNetworkPaginate(organizationID string, getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParamsConverted := getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams.(*GetOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParams)
+
+	return s.GetOrganizationSmSentryPoliciesAssignmentsByNetwork(organizationID, getOrganizationSmSentryPoliciesAssignmentsByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationSmVppAccounts List the VPP accounts in the organization
 /* List the VPP accounts in the organization
@@ -1593,6 +1935,7 @@ func (s *SmService) GetOrganizationSmSentryPoliciesAssignmentsByNetwork(organiza
 
 
 */
+
 func (s *SmService) GetOrganizationSmVppAccounts(organizationID string) (*ResponseSmGetOrganizationSmVppAccounts, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/vppAccounts"
 	s.rateLimiterBucket.Wait(1)
@@ -1627,6 +1970,7 @@ func (s *SmService) GetOrganizationSmVppAccounts(organizationID string) (*Respon
 
 
 */
+
 func (s *SmService) GetOrganizationSmVppAccount(organizationID string, vppAccountID string) (*ResponseSmGetOrganizationSmVppAccount, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/sm/vppAccounts/{vppAccountId}"
 	s.rateLimiterBucket.Wait(1)

--- a/sdk/switch.go
+++ b/sdk/switch.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -2837,6 +2838,7 @@ type RequestSwitchCloneOrganizationSwitchDevices struct {
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchPorts(serial string) (*ResponseSwitchGetDeviceSwitchPorts, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/ports"
 	s.rateLimiterBucket.Wait(1)
@@ -2871,6 +2873,7 @@ func (s *SwitchService) GetDeviceSwitchPorts(serial string) (*ResponseSwitchGetD
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchPortsStatuses(serial string, getDeviceSwitchPortsStatusesQueryParams *GetDeviceSwitchPortsStatusesQueryParams) (*ResponseSwitchGetDeviceSwitchPortsStatuses, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/ports/statuses"
 	s.rateLimiterBucket.Wait(1)
@@ -2907,6 +2910,7 @@ func (s *SwitchService) GetDeviceSwitchPortsStatuses(serial string, getDeviceSwi
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchPortsStatusesPackets(serial string, getDeviceSwitchPortsStatusesPacketsQueryParams *GetDeviceSwitchPortsStatusesPacketsQueryParams) (*ResponseSwitchGetDeviceSwitchPortsStatusesPackets, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/ports/statuses/packets"
 	s.rateLimiterBucket.Wait(1)
@@ -2943,6 +2947,7 @@ func (s *SwitchService) GetDeviceSwitchPortsStatusesPackets(serial string, getDe
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchPort(serial string, portID string) (*ResponseSwitchGetDeviceSwitchPort, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/ports/{portId}"
 	s.rateLimiterBucket.Wait(1)
@@ -2977,6 +2982,7 @@ func (s *SwitchService) GetDeviceSwitchPort(serial string, portID string) (*Resp
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchRoutingInterfaces(serial string) (*ResponseSwitchGetDeviceSwitchRoutingInterfaces, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/interfaces"
 	s.rateLimiterBucket.Wait(1)
@@ -3011,6 +3017,7 @@ func (s *SwitchService) GetDeviceSwitchRoutingInterfaces(serial string) (*Respon
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchRoutingInterface(serial string, interfaceID string) (*ResponseSwitchGetDeviceSwitchRoutingInterface, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/interfaces/{interfaceId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3046,6 +3053,7 @@ func (s *SwitchService) GetDeviceSwitchRoutingInterface(serial string, interface
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchRoutingInterfaceDhcp(serial string, interfaceID string) (*ResponseSwitchGetDeviceSwitchRoutingInterfaceDhcp, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/interfaces/{interfaceId}/dhcp"
 	s.rateLimiterBucket.Wait(1)
@@ -3080,6 +3088,7 @@ func (s *SwitchService) GetDeviceSwitchRoutingInterfaceDhcp(serial string, inter
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchRoutingStaticRoutes(serial string) (*ResponseSwitchGetDeviceSwitchRoutingStaticRoutes, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
@@ -3114,6 +3123,7 @@ func (s *SwitchService) GetDeviceSwitchRoutingStaticRoutes(serial string) (*Resp
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchRoutingStaticRoute(serial string, staticRouteID string) (*ResponseSwitchGetDeviceSwitchRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/routing/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3148,6 +3158,7 @@ func (s *SwitchService) GetDeviceSwitchRoutingStaticRoute(serial string, staticR
 
 
 */
+
 func (s *SwitchService) GetDeviceSwitchWarmSpare(serial string) (*ResponseSwitchGetDeviceSwitchWarmSpare, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/switch/warmSpare"
 	s.rateLimiterBucket.Wait(1)
@@ -3181,6 +3192,7 @@ func (s *SwitchService) GetDeviceSwitchWarmSpare(serial string) (*ResponseSwitch
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchAccessControlLists(networkID string) (*ResponseSwitchGetNetworkSwitchAccessControlLists, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/accessControlLists"
 	s.rateLimiterBucket.Wait(1)
@@ -3214,6 +3226,7 @@ func (s *SwitchService) GetNetworkSwitchAccessControlLists(networkID string) (*R
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchAccessPolicies(networkID string) (*ResponseSwitchGetNetworkSwitchAccessPolicies, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/accessPolicies"
 	s.rateLimiterBucket.Wait(1)
@@ -3248,6 +3261,7 @@ func (s *SwitchService) GetNetworkSwitchAccessPolicies(networkID string) (*Respo
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchAccessPolicy(networkID string, accessPolicyNumber string) (*ResponseSwitchGetNetworkSwitchAccessPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/accessPolicies/{accessPolicyNumber}"
 	s.rateLimiterBucket.Wait(1)
@@ -3282,6 +3296,7 @@ func (s *SwitchService) GetNetworkSwitchAccessPolicy(networkID string, accessPol
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchAlternateManagementInterface(networkID string) (*ResponseSwitchGetNetworkSwitchAlternateManagementInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/alternateManagementInterface"
 	s.rateLimiterBucket.Wait(1)
@@ -3316,9 +3331,40 @@ func (s *SwitchService) GetNetworkSwitchAlternateManagementInterface(networkID s
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchDhcpV4ServersSeen(networkID string, getNetworkSwitchDhcpV4ServersSeenQueryParams *GetNetworkSwitchDhcpV4ServersSeenQueryParams) (*ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dhcp/v4/servers/seen"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSwitchDhcpV4ServersSeenQueryParams != nil && getNetworkSwitchDhcpV4ServersSeenQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen
+		println("Paginate")
+		getNetworkSwitchDhcpV4ServersSeenQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSwitchDhcpV4ServersSeenPaginate, networkID, "", getNetworkSwitchDhcpV4ServersSeenQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetNetworkSwitchDhcpV4ServersSeen
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSwitchDhcpV4ServersSeenQueryParams)
@@ -3343,6 +3389,11 @@ func (s *SwitchService) GetNetworkSwitchDhcpV4ServersSeen(networkID string, getN
 	return result, response, err
 
 }
+func (s *SwitchService) GetNetworkSwitchDhcpV4ServersSeenPaginate(networkID string, getNetworkSwitchDhcpV4ServersSeenQueryParams any) (any, *resty.Response, error) {
+	getNetworkSwitchDhcpV4ServersSeenQueryParamsConverted := getNetworkSwitchDhcpV4ServersSeenQueryParams.(*GetNetworkSwitchDhcpV4ServersSeenQueryParams)
+
+	return s.GetNetworkSwitchDhcpV4ServersSeen(networkID, getNetworkSwitchDhcpV4ServersSeenQueryParamsConverted)
+}
 
 //GetNetworkSwitchDhcpServerPolicy Return the DHCP server settings
 /* Return the DHCP server settings. Blocked/allowed servers are only applied when default policy is allow/block, respectively
@@ -3351,6 +3402,7 @@ func (s *SwitchService) GetNetworkSwitchDhcpV4ServersSeen(networkID string, getN
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchDhcpServerPolicy(networkID string) (*ResponseSwitchGetNetworkSwitchDhcpServerPolicy, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dhcpServerPolicy"
 	s.rateLimiterBucket.Wait(1)
@@ -3385,9 +3437,40 @@ func (s *SwitchService) GetNetworkSwitchDhcpServerPolicy(networkID string) (*Res
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers(networkID string, getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams *GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams) (*ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/trustedServers"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams != nil && getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers
+		println("Paginate")
+		getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersPaginate, networkID, "", getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams)
@@ -3412,6 +3495,11 @@ func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServ
 	return result, response, err
 
 }
+func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersPaginate(networkID string, getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams any) (any, *resty.Response, error) {
+	getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParamsConverted := getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams.(*GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParams)
+
+	return s.GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServers(networkID, getNetworkSwitchDhcpServerPolicyArpInspectionTrustedServersQueryParamsConverted)
+}
 
 //GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice Return the devices that have a Dynamic ARP Inspection warning and their warnings
 /* Return the devices that have a Dynamic ARP Inspection warning and their warnings
@@ -3421,9 +3509,40 @@ func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionTrustedServ
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice(networkID string, getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams *GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams) (*ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dhcpServerPolicy/arpInspection/warnings/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams != nil && getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice
+		println("Paginate")
+		getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevicePaginate, networkID, "", getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams)
@@ -3448,6 +3567,11 @@ func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByD
 	return result, response, err
 
 }
+func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevicePaginate(networkID string, getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams any) (any, *resty.Response, error) {
+	getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParamsConverted := getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams.(*GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParams)
+
+	return s.GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDevice(networkID, getNetworkSwitchDhcpServerPolicyArpInspectionWarningsByDeviceQueryParamsConverted)
+}
 
 //GetNetworkSwitchDscpToCosMappings Return the DSCP to CoS mappings
 /* Return the DSCP to CoS mappings
@@ -3456,6 +3580,7 @@ func (s *SwitchService) GetNetworkSwitchDhcpServerPolicyArpInspectionWarningsByD
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchDscpToCosMappings(networkID string) (*ResponseSwitchGetNetworkSwitchDscpToCosMappings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/dscpToCosMappings"
 	s.rateLimiterBucket.Wait(1)
@@ -3489,6 +3614,7 @@ func (s *SwitchService) GetNetworkSwitchDscpToCosMappings(networkID string) (*Re
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchLinkAggregations(networkID string) (*ResponseSwitchGetNetworkSwitchLinkAggregations, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/linkAggregations"
 	s.rateLimiterBucket.Wait(1)
@@ -3522,6 +3648,7 @@ func (s *SwitchService) GetNetworkSwitchLinkAggregations(networkID string) (*Res
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchMtu(networkID string) (*ResponseSwitchGetNetworkSwitchMtu, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/mtu"
 	s.rateLimiterBucket.Wait(1)
@@ -3555,6 +3682,7 @@ func (s *SwitchService) GetNetworkSwitchMtu(networkID string) (*ResponseSwitchGe
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchPortSchedules(networkID string) (*ResponseSwitchGetNetworkSwitchPortSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/portSchedules"
 	s.rateLimiterBucket.Wait(1)
@@ -3588,6 +3716,7 @@ func (s *SwitchService) GetNetworkSwitchPortSchedules(networkID string) (*Respon
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchQosRules(networkID string) (*ResponseSwitchGetNetworkSwitchQosRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/qosRules"
 	s.rateLimiterBucket.Wait(1)
@@ -3621,6 +3750,7 @@ func (s *SwitchService) GetNetworkSwitchQosRules(networkID string) (*ResponseSwi
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchQosRulesOrder(networkID string) (*ResponseSwitchGetNetworkSwitchQosRulesOrder, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/qosRules/order"
 	s.rateLimiterBucket.Wait(1)
@@ -3655,6 +3785,7 @@ func (s *SwitchService) GetNetworkSwitchQosRulesOrder(networkID string) (*Respon
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchQosRule(networkID string, qosRuleID string) (*ResponseSwitchGetNetworkSwitchQosRule, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/qosRules/{qosRuleId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3689,6 +3820,7 @@ func (s *SwitchService) GetNetworkSwitchQosRule(networkID string, qosRuleID stri
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchRoutingMulticast(networkID string) (*ResponseSwitchGetNetworkSwitchRoutingMulticast, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/multicast"
 	s.rateLimiterBucket.Wait(1)
@@ -3722,6 +3854,7 @@ func (s *SwitchService) GetNetworkSwitchRoutingMulticast(networkID string) (*Res
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchRoutingMulticastRendezvousPoints(networkID string) (*ResponseSwitchGetNetworkSwitchRoutingMulticastRendezvousPoints, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/multicast/rendezvousPoints"
 	s.rateLimiterBucket.Wait(1)
@@ -3756,6 +3889,7 @@ func (s *SwitchService) GetNetworkSwitchRoutingMulticastRendezvousPoints(network
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchRoutingMulticastRendezvousPoint(networkID string, rendezvousPointID string) (*ResponseSwitchGetNetworkSwitchRoutingMulticastRendezvousPoint, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/multicast/rendezvousPoints/{rendezvousPointId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3790,6 +3924,7 @@ func (s *SwitchService) GetNetworkSwitchRoutingMulticastRendezvousPoint(networkI
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchRoutingOspf(networkID string) (*ResponseSwitchGetNetworkSwitchRoutingOspf, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/routing/ospf"
 	s.rateLimiterBucket.Wait(1)
@@ -3823,6 +3958,7 @@ func (s *SwitchService) GetNetworkSwitchRoutingOspf(networkID string) (*Response
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchSettings(networkID string) (*ResponseSwitchGetNetworkSwitchSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3856,6 +3992,7 @@ func (s *SwitchService) GetNetworkSwitchSettings(networkID string) (*ResponseSwi
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStacks(networkID string) (*ResponseSwitchGetNetworkSwitchStacks, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks"
 	s.rateLimiterBucket.Wait(1)
@@ -3890,6 +4027,7 @@ func (s *SwitchService) GetNetworkSwitchStacks(networkID string) (*ResponseSwitc
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStack(networkID string, switchStackID string) (*ResponseSwitchGetNetworkSwitchStack, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3925,6 +4063,7 @@ func (s *SwitchService) GetNetworkSwitchStack(networkID string, switchStackID st
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStackRoutingInterfaces(networkID string, switchStackID string) (*ResponseSwitchGetNetworkSwitchStackRoutingInterfaces, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces"
 	s.rateLimiterBucket.Wait(1)
@@ -3961,6 +4100,7 @@ func (s *SwitchService) GetNetworkSwitchStackRoutingInterfaces(networkID string,
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStackRoutingInterface(networkID string, switchStackID string, interfaceID string) (*ResponseSwitchGetNetworkSwitchStackRoutingInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}"
 	s.rateLimiterBucket.Wait(1)
@@ -3998,6 +4138,7 @@ func (s *SwitchService) GetNetworkSwitchStackRoutingInterface(networkID string, 
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStackRoutingInterfaceDhcp(networkID string, switchStackID string, interfaceID string) (*ResponseSwitchGetNetworkSwitchStackRoutingInterfaceDhcp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/interfaces/{interfaceId}/dhcp"
 	s.rateLimiterBucket.Wait(1)
@@ -4034,6 +4175,7 @@ func (s *SwitchService) GetNetworkSwitchStackRoutingInterfaceDhcp(networkID stri
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStackRoutingStaticRoutes(networkID string, switchStackID string) (*ResponseSwitchGetNetworkSwitchStackRoutingStaticRoutes, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes"
 	s.rateLimiterBucket.Wait(1)
@@ -4070,6 +4212,7 @@ func (s *SwitchService) GetNetworkSwitchStackRoutingStaticRoutes(networkID strin
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStackRoutingStaticRoute(networkID string, switchStackID string, staticRouteID string) (*ResponseSwitchGetNetworkSwitchStackRoutingStaticRoute, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stacks/{switchStackId}/routing/staticRoutes/{staticRouteId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4105,6 +4248,7 @@ func (s *SwitchService) GetNetworkSwitchStackRoutingStaticRoute(networkID string
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStormControl(networkID string) (*ResponseSwitchGetNetworkSwitchStormControl, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stormControl"
 	s.rateLimiterBucket.Wait(1)
@@ -4138,6 +4282,7 @@ func (s *SwitchService) GetNetworkSwitchStormControl(networkID string) (*Respons
 
 
 */
+
 func (s *SwitchService) GetNetworkSwitchStp(networkID string) (*ResponseSwitchGetNetworkSwitchStp, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/switch/stp"
 	s.rateLimiterBucket.Wait(1)
@@ -4172,6 +4317,7 @@ func (s *SwitchService) GetNetworkSwitchStp(networkID string) (*ResponseSwitchGe
 
 
 */
+
 func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfiles(organizationID string, configTemplateID string) (*ResponseSwitchGetOrganizationConfigTemplateSwitchProfiles, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles"
 	s.rateLimiterBucket.Wait(1)
@@ -4208,6 +4354,7 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfiles(organization
 
 
 */
+
 func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePorts(organizationID string, configTemplateID string, profileID string) (*ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePorts, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles/{profileId}/ports"
 	s.rateLimiterBucket.Wait(1)
@@ -4246,6 +4393,7 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePorts(organiza
 
 
 */
+
 func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePort(organizationID string, configTemplateID string, profileID string, portID string) (*ResponseSwitchGetOrganizationConfigTemplateSwitchProfilePort, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/configTemplates/{configTemplateId}/switch/profiles/{profileId}/ports/{portId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4283,6 +4431,7 @@ func (s *SwitchService) GetOrganizationConfigTemplateSwitchProfilePort(organizat
 
 
 */
+
 func (s *SwitchService) GetOrganizationSummarySwitchPowerHistory(organizationID string, getOrganizationSummarySwitchPowerHistoryQueryParams *GetOrganizationSummarySwitchPowerHistoryQueryParams) (*ResponseSwitchGetOrganizationSummarySwitchPowerHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/summary/switch/power/history"
 	s.rateLimiterBucket.Wait(1)
@@ -4319,9 +4468,40 @@ func (s *SwitchService) GetOrganizationSummarySwitchPowerHistory(organizationID 
 
 
 */
+
 func (s *SwitchService) GetOrganizationSwitchPortsBySwitch(organizationID string, getOrganizationSwitchPortsBySwitchQueryParams *GetOrganizationSwitchPortsBySwitchQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsBySwitch, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/ports/bySwitch"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSwitchPortsBySwitchQueryParams != nil && getOrganizationSwitchPortsBySwitchQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetOrganizationSwitchPortsBySwitch
+		println("Paginate")
+		getOrganizationSwitchPortsBySwitchQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSwitchPortsBySwitchPaginate, organizationID, "", getOrganizationSwitchPortsBySwitchQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetOrganizationSwitchPortsBySwitch
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Ports = append(*result.Ports, *resultTmp.Ports...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSwitchPortsBySwitchQueryParams)
@@ -4346,6 +4526,11 @@ func (s *SwitchService) GetOrganizationSwitchPortsBySwitch(organizationID string
 	return result, response, err
 
 }
+func (s *SwitchService) GetOrganizationSwitchPortsBySwitchPaginate(organizationID string, getOrganizationSwitchPortsBySwitchQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSwitchPortsBySwitchQueryParamsConverted := getOrganizationSwitchPortsBySwitchQueryParams.(*GetOrganizationSwitchPortsBySwitchQueryParams)
+
+	return s.GetOrganizationSwitchPortsBySwitch(organizationID, getOrganizationSwitchPortsBySwitchQueryParamsConverted)
+}
 
 //GetOrganizationSwitchPortsClientsOverviewByDevice List the number of clients for all switchports with at least one online client in an organization.
 /* List the number of clients for all switchports with at least one online client in an organization.
@@ -4355,9 +4540,40 @@ func (s *SwitchService) GetOrganizationSwitchPortsBySwitch(organizationID string
 
 
 */
+
 func (s *SwitchService) GetOrganizationSwitchPortsClientsOverviewByDevice(organizationID string, getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams *GetOrganizationSwitchPortsClientsOverviewByDeviceQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/ports/clients/overview/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams != nil && getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice
+		println("Paginate")
+		getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSwitchPortsClientsOverviewByDevicePaginate, organizationID, "", getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetOrganizationSwitchPortsClientsOverviewByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams)
@@ -4382,6 +4598,11 @@ func (s *SwitchService) GetOrganizationSwitchPortsClientsOverviewByDevice(organi
 	return result, response, err
 
 }
+func (s *SwitchService) GetOrganizationSwitchPortsClientsOverviewByDevicePaginate(organizationID string, getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSwitchPortsClientsOverviewByDeviceQueryParamsConverted := getOrganizationSwitchPortsClientsOverviewByDeviceQueryParams.(*GetOrganizationSwitchPortsClientsOverviewByDeviceQueryParams)
+
+	return s.GetOrganizationSwitchPortsClientsOverviewByDevice(organizationID, getOrganizationSwitchPortsClientsOverviewByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationSwitchPortsOverview Returns the counts of all active ports for the requested timespan, grouped by speed
 /* Returns the counts of all active ports for the requested timespan, grouped by speed. An active port is a port that at any point during the timeframe is observed to be connected to a responsive device and isn't configured to be disabled. For a port that is observed at multiple speeds during the timeframe, it will be counted at the highest speed observed. The number of inactive ports, and the total number of ports are also provided. Only ports on switches online during the timeframe will be represented and a port is only guaranteed to be present if its switch was online for at least 6 hours of the timeframe.
@@ -4391,6 +4612,7 @@ func (s *SwitchService) GetOrganizationSwitchPortsClientsOverviewByDevice(organi
 
 
 */
+
 func (s *SwitchService) GetOrganizationSwitchPortsOverview(organizationID string, getOrganizationSwitchPortsOverviewQueryParams *GetOrganizationSwitchPortsOverviewQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsOverview, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/ports/overview"
 	s.rateLimiterBucket.Wait(1)
@@ -4427,9 +4649,40 @@ func (s *SwitchService) GetOrganizationSwitchPortsOverview(organizationID string
 
 
 */
+
 func (s *SwitchService) GetOrganizationSwitchPortsStatusesBySwitch(organizationID string, getOrganizationSwitchPortsStatusesBySwitchQueryParams *GetOrganizationSwitchPortsStatusesBySwitchQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/ports/statuses/bySwitch"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSwitchPortsStatusesBySwitchQueryParams != nil && getOrganizationSwitchPortsStatusesBySwitchQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch
+		println("Paginate")
+		getOrganizationSwitchPortsStatusesBySwitchQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSwitchPortsStatusesBySwitchPaginate, organizationID, "", getOrganizationSwitchPortsStatusesBySwitchQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetOrganizationSwitchPortsStatusesBySwitch
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSwitchPortsStatusesBySwitchQueryParams)
@@ -4454,6 +4707,11 @@ func (s *SwitchService) GetOrganizationSwitchPortsStatusesBySwitch(organizationI
 	return result, response, err
 
 }
+func (s *SwitchService) GetOrganizationSwitchPortsStatusesBySwitchPaginate(organizationID string, getOrganizationSwitchPortsStatusesBySwitchQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSwitchPortsStatusesBySwitchQueryParamsConverted := getOrganizationSwitchPortsStatusesBySwitchQueryParams.(*GetOrganizationSwitchPortsStatusesBySwitchQueryParams)
+
+	return s.GetOrganizationSwitchPortsStatusesBySwitch(organizationID, getOrganizationSwitchPortsStatusesBySwitchQueryParamsConverted)
+}
 
 //GetOrganizationSwitchPortsTopologyDiscoveryByDevice List most recently seen LLDP/CDP discovery and topology information per switch port in an organization.
 /* List most recently seen LLDP/CDP discovery and topology information per switch port in an organization.
@@ -4463,9 +4721,40 @@ func (s *SwitchService) GetOrganizationSwitchPortsStatusesBySwitch(organizationI
 
 
 */
+
 func (s *SwitchService) GetOrganizationSwitchPortsTopologyDiscoveryByDevice(organizationID string, getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams *GetOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams) (*ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/switch/ports/topology/discovery/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams != nil && getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice
+		println("Paginate")
+		getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationSwitchPortsTopologyDiscoveryByDevicePaginate, organizationID, "", getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams)
@@ -4489,6 +4778,11 @@ func (s *SwitchService) GetOrganizationSwitchPortsTopologyDiscoveryByDevice(orga
 	result := response.Result().(*ResponseSwitchGetOrganizationSwitchPortsTopologyDiscoveryByDevice)
 	return result, response, err
 
+}
+func (s *SwitchService) GetOrganizationSwitchPortsTopologyDiscoveryByDevicePaginate(organizationID string, getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParamsConverted := getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams.(*GetOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParams)
+
+	return s.GetOrganizationSwitchPortsTopologyDiscoveryByDevice(organizationID, getOrganizationSwitchPortsTopologyDiscoveryByDeviceQueryParamsConverted)
 }
 
 //CycleDeviceSwitchPorts Cycle a set of switch ports

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -241,11 +241,91 @@ type GetOrganizationWirelessClientsOverviewByDeviceQueryParams struct {
 	StartingAfter           string   `url:"startingAfter,omitempty"`             //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore            string   `url:"endingBefore,omitempty"`              //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 }
+type GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 90 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
+type GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 31 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 31 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be less than or equal to 31 days. The default is 7 days.
+	Interval      int      `url:"interval,omitempty"`      //The time interval in seconds for returned data. The valid intervals are: 300, 600, 3600, 7200, 14400, 21600. The default is 3600.
+}
 type GetOrganizationWirelessDevicesEthernetStatusesQueryParams struct {
 	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 100.
 	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
 	NetworkIDs    []string `url:"networkIds[],omitempty"`  //A list of Meraki network IDs to filter results to contain only specified networks. E.g.: networkIds[]=N_12345678&networkIds[]=L_3456
+}
+type GetOrganizationWirelessDevicesPacketLossByClientQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	Macs          []string `url:"macs[],omitempty"`        //Filter results by client mac address(es).
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
+}
+type GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
+}
+type GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams struct {
+	NetworkIDs    []string `url:"networkIds[],omitempty"`  //Filter results by network.
+	Serials       []string `url:"serials[],omitempty"`     //Filter results by device.
+	SSIDs         []string `url:"ssids[],omitempty"`       //Filter results by SSID number.
+	Bands         []string `url:"bands[],omitempty"`       //Filter results by band. Valid bands are: 2.4, 5, and 6.
+	PerPage       int      `url:"perPage,omitempty"`       //The number of entries per page returned. Acceptable range is 3 - 1000. Default is 1000.
+	StartingAfter string   `url:"startingAfter,omitempty"` //A token used by the server to indicate the start of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	EndingBefore  string   `url:"endingBefore,omitempty"`  //A token used by the server to indicate the end of the page. Often this is a timestamp or an ID but it is not limited to those. This parameter should not be defined by client applications. The link for the first, last, prev, or next page in the HTTP Link header should define it.
+	T0            string   `url:"t0,omitempty"`            //The beginning of the timespan for the data. The maximum lookback period is 90 days from today.
+	T1            string   `url:"t1,omitempty"`            //The end of the timespan for the data. t1 can be a maximum of 90 days after t0.
+	Timespan      float64  `url:"timespan,omitempty"`      //The timespan for which the information will be fetched. If specifying timespan, do not specify parameters t0 and t1. The value must be in seconds and be greater than or equal to 5 minutes and be less than or equal to 90 days. The default is 7 days.
 }
 type GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams struct {
 	NetworkIDs        []string `url:"networkIds[],omitempty"`        //Optional parameter to filter access points by network ID. This filter uses multiple exact matches.
@@ -898,10 +978,7 @@ type ResponseItemWirelessGetNetworkWirelessMeshStatusesLatestMeshPerformance str
 	Metric          *int   `json:"metric,omitempty"`          // Represents the quality of the entire route from the repeater access point to its gateway access point.
 	UsagePercentage string `json:"usagePercentage,omitempty"` // Mesh utilization as a percentage.
 }
-
-type ResponseWirelessGetNetworkWirelessRfProfiles []ResponseItemWirelessGetNetworkWirelessRfProfiles
-
-type ResponseItemWirelessGetNetworkWirelessRfProfiles struct {
+type ResponseWirelessGetNetworkWirelessRfProfiles struct {
 	ApBandSettings         *ResponseWirelessGetNetworkWirelessRfProfilesApBandSettings     `json:"apBandSettings,omitempty"`         // Settings that will be enabled if selectionType is set to 'ap'.
 	BandSelectionType      string                                                          `json:"bandSelectionType,omitempty"`      // Band selection can be set to either 'ssid' or 'ap'. This param is required on creation.
 	ClientBalancingEnabled *bool                                                           `json:"clientBalancingEnabled,omitempty"` // Steers client to best available access point. Can be either true or false. Defaults to true.
@@ -2031,7 +2108,6 @@ type ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRulesRules struct {
 	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
 	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
 	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
-	IpVer    string `json:"ipVer,omitempty"`    //
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRules struct {
 	AllowLanAccess *bool                                                                    `json:"allowLanAccess,omitempty"` // Allows wireless client access to local LAN (boolean value - true allows access and false denies access)
@@ -2048,86 +2124,18 @@ type ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRules struct {
 	Rules *[]ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules struct {
-	Policy    string                                                                    `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
-	Type      string                                                                    `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
-	Value     *string                                                                   //
-	ValueObj  *ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesRulesValueObj //
-	ValueList *[]string                                                                 //
+	Policy string `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
+	Type   string `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
+	Value  string `json:"value,omitempty"`  // The value of what needs to get blocked. Format of the value varies depending on type of the firewall rule selected.
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules struct {
 	Rules *[]ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An ordered array of the firewall rules for this SSID (not including the local LAN access rule or the default rule).
 }
 type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules struct {
-	Policy    string                                                                    `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
-	Type      string                                                                    `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
-	Value     *string                                                                   //
-	ValueObj  *ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesRulesValueObj //
-	ValueList *[]string                                                                 //
+	Policy string `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
+	Type   string `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
+	Value  string `json:"value,omitempty"`  // The value of what needs to get blocked. Format of the value varies depending on type of the firewall rule selected.
 }
-type ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRulesValueObj struct {
-	ID   string `json:"id,omitempty"`   //
-	Name string `json:"name,omitempty"` //
-}
-
-func (r *ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules) UnmarshalJSON(data []byte) error {
-	type Alias ResponseWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules
-	aux := &struct {
-		Value interface{} `json:"value"`
-		*Alias
-	}{
-		Alias: (*Alias)(r),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	switch v := aux.Value.(type) {
-	case string:
-		r.Value = &v
-	case []interface{}:
-		strList := make([]string, len(v))
-		for i, item := range v {
-			strList[i] = item.(string)
-		}
-		r.ValueList = &strList
-	case map[string]interface{}:
-		valueObj := &ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesRulesValueObj{
-			ID:   v["id"].(string),
-			Name: v["name"].(string),
-		}
-		r.ValueObj = valueObj
-	}
-	return nil
-}
-func (r *ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules) UnmarshalJSON(data []byte) error {
-	type Alias ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRulesRules
-	aux := &struct {
-		Value interface{} `json:"value"`
-		*Alias
-	}{
-		Alias: (*Alias)(r),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	switch v := aux.Value.(type) {
-	case string:
-		r.Value = &v
-	case []interface{}:
-		strList := make([]string, len(v))
-		for i, item := range v {
-			strList[i] = item.(string)
-		}
-		r.ValueList = &strList
-	case map[string]interface{}:
-		valueObj := &ResponseApplianceGetNetworkApplianceFirewallL7FirewallRulesRulesValueObj{
-			ID:   v["id"].(string),
-			Name: v["name"].(string),
-		}
-		r.ValueObj = valueObj
-	}
-	return nil
-}
-
 type ResponseWirelessGetNetworkWirelessSSIDHotspot20 struct {
 	Domains           []string                                                    `json:"domains,omitempty"`           //
 	Enabled           *bool                                                       `json:"enabled,omitempty"`           //
@@ -3615,20 +3623,14 @@ type RequestWirelessUpdateNetworkWirelessSSIDFirewallL3FirewallRulesRules struct
 	DestPort string `json:"destPort,omitempty"` // Comma-separated list of destination port(s) (integer in the range 1-65535), or 'any'
 	Policy   string `json:"policy,omitempty"`   // 'allow' or 'deny' traffic specified by this rule
 	Protocol string `json:"protocol,omitempty"` // The type of protocol (must be 'tcp', 'udp', 'icmp', 'icmp6' or 'any')
-	IpVer    string `json:"ipVer,omitempty"`    //
 }
 type RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRules struct {
 	Rules *[]RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules `json:"rules,omitempty"` // An array of L7 firewall rules for this SSID. Rules will get applied in the same order user has specified in request. Empty array will clear the L7 firewall rule configuration.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRules struct {
-	Policy string      `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
-	Type   string      `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
-	Value  interface{} `json:"value,omitempty"`  // The 'value' of what you want to block. Format of 'value' varies depending on type of the rule. The application categories and application ids can be retrieved from the the 'MX L7 application categories' endpoint. The countries follow the two-letter ISO 3166-1 alpha-2 format.
-}
-
-type RequestWirelessUpdateNetworkWirelessSSIDFirewallL7FirewallRulesRulesValue struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Policy string `json:"policy,omitempty"` // 'Deny' traffic specified by this rule
+	Type   string `json:"type,omitempty"`   // Type of the L7 firewall rule. One of: 'application', 'applicationCategory', 'host', 'port', 'ipRange'
+	Value  string `json:"value,omitempty"`  // The value of what needs to get blocked. Format of the value varies depending on type of the firewall rule selected.
 }
 type RequestWirelessUpdateNetworkWirelessSSIDHotspot20 struct {
 	Domains           []string                                                      `json:"domains,omitempty"`           // An array of domain names
@@ -3813,6 +3815,7 @@ type RequestWirelessRecalculateOrganizationWirelessRadioAutoRfChannels struct {
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*ResponseWirelessGetDeviceWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/bluetooth/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3847,6 +3850,7 @@ func (s *WirelessService) GetDeviceWirelessBluetoothSettings(serial string) (*Re
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDeviceWirelessConnectionStatsQueryParams *GetDeviceWirelessConnectionStatsQueryParams) (*ResponseWirelessGetDeviceWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/connectionStats"
 	s.rateLimiterBucket.Wait(1)
@@ -3882,6 +3886,7 @@ func (s *WirelessService) GetDeviceWirelessConnectionStats(serial string, getDev
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessElectronicShelfLabel(serial string) (*ResponseWirelessGetDeviceWirelessElectronicShelfLabel, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/electronicShelfLabel"
 	s.rateLimiterBucket.Wait(1)
@@ -3916,6 +3921,7 @@ func (s *WirelessService) GetDeviceWirelessElectronicShelfLabel(serial string) (
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDeviceWirelessLatencyStatsQueryParams *GetDeviceWirelessLatencyStatsQueryParams) (*ResponseWirelessGetDeviceWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/latencyStats"
 	s.rateLimiterBucket.Wait(1)
@@ -3951,6 +3957,7 @@ func (s *WirelessService) GetDeviceWirelessLatencyStats(serial string, getDevice
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*ResponseWirelessGetDeviceWirelessRadioSettings, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/radio/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -3984,6 +3991,7 @@ func (s *WirelessService) GetDeviceWirelessRadioSettings(serial string) (*Respon
 
 
 */
+
 func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirelessGetDeviceWirelessStatus, *resty.Response, error) {
 	path := "/api/v1/devices/{serial}/wireless/status"
 	s.rateLimiterBucket.Wait(1)
@@ -4018,6 +4026,7 @@ func (s *WirelessService) GetDeviceWirelessStatus(serial string) (*ResponseWirel
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetworkWirelessAirMarshalQueryParams *GetNetworkWirelessAirMarshalQueryParams) (*ResponseWirelessGetNetworkWirelessAirMarshal, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/airMarshal"
 	s.rateLimiterBucket.Wait(1)
@@ -4053,6 +4062,7 @@ func (s *WirelessService) GetNetworkWirelessAirMarshal(networkID string, getNetw
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(networkID string) (*ResponseWirelessGetNetworkWirelessAlternateManagementInterface, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/alternateManagementInterface"
 	s.rateLimiterBucket.Wait(1)
@@ -4086,6 +4096,7 @@ func (s *WirelessService) GetNetworkWirelessAlternateManagementInterface(network
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessBilling(networkID string) (*ResponseWirelessGetNetworkWirelessBilling, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/billing"
 	s.rateLimiterBucket.Wait(1)
@@ -4121,6 +4132,7 @@ Bluetooth settings
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) (*ResponseWirelessGetNetworkWirelessBluetoothSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/bluetooth/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -4155,6 +4167,7 @@ func (s *WirelessService) GetNetworkWirelessBluetoothSettings(networkID string) 
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID string, getNetworkWirelessChannelUtilizationHistoryQueryParams *GetNetworkWirelessChannelUtilizationHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessChannelUtilizationHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/channelUtilizationHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4191,6 +4204,7 @@ func (s *WirelessService) GetNetworkWirelessChannelUtilizationHistory(networkID 
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string, getNetworkWirelessClientCountHistoryQueryParams *GetNetworkWirelessClientCountHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientCountHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clientCountHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4227,6 +4241,7 @@ func (s *WirelessService) GetNetworkWirelessClientCountHistory(networkID string,
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID string, getNetworkWirelessClientsConnectionStatsQueryParams *GetNetworkWirelessClientsConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/connectionStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4263,6 +4278,7 @@ func (s *WirelessService) GetNetworkWirelessClientsConnectionStats(networkID str
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string, getNetworkWirelessClientsLatencyStatsQueryParams *GetNetworkWirelessClientsLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientsLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/latencyStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4300,6 +4316,7 @@ func (s *WirelessService) GetNetworkWirelessClientsLatencyStats(networkID string
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID string, clientID string, getNetworkWirelessClientConnectionStatsQueryParams *GetNetworkWirelessClientConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectionStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4338,9 +4355,40 @@ func (s *WirelessService) GetNetworkWirelessClientConnectionStats(networkID stri
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID string, clientID string, getNetworkWirelessClientConnectivityEventsQueryParams *GetNetworkWirelessClientConnectivityEventsQueryParams) (*ResponseWirelessGetNetworkWirelessClientConnectivityEvents, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/connectivityEvents"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkWirelessClientConnectivityEventsQueryParams != nil && getNetworkWirelessClientConnectivityEventsQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetNetworkWirelessClientConnectivityEvents
+		println("Paginate")
+		getNetworkWirelessClientConnectivityEventsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkWirelessClientConnectivityEventsPaginate, networkID, clientID, getNetworkWirelessClientConnectivityEventsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetNetworkWirelessClientConnectivityEvents
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 	path = strings.Replace(path, "{clientId}", fmt.Sprintf("%v", clientID), -1)
 
@@ -4366,6 +4414,11 @@ func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID s
 	return result, response, err
 
 }
+func (s *WirelessService) GetNetworkWirelessClientConnectivityEventsPaginate(networkID string, clientID string, getNetworkWirelessClientConnectivityEventsQueryParams any) (any, *resty.Response, error) {
+	getNetworkWirelessClientConnectivityEventsQueryParamsConverted := getNetworkWirelessClientConnectivityEventsQueryParams.(*GetNetworkWirelessClientConnectivityEventsQueryParams)
+
+	return s.GetNetworkWirelessClientConnectivityEvents(networkID, clientID, getNetworkWirelessClientConnectivityEventsQueryParamsConverted)
+}
 
 //GetNetworkWirelessClientLatencyHistory Return the latency history for a client
 /* Return the latency history for a client. Clients can be identified by a client key or either the MAC or IP depending on whether the network uses Track-by-IP. The latency data is from a sample of 2% of packets and is grouped into 4 traffic categories: background, best effort, video, voice. Within these categories the sampled packet counters are bucketed by latency in milliseconds.
@@ -4376,6 +4429,7 @@ func (s *WirelessService) GetNetworkWirelessClientConnectivityEvents(networkID s
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID string, clientID string, getNetworkWirelessClientLatencyHistoryQueryParams *GetNetworkWirelessClientLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4414,6 +4468,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyHistory(networkID strin
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string, clientID string, getNetworkWirelessClientLatencyStatsQueryParams *GetNetworkWirelessClientLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessClientLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/clients/{clientId}/latencyStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4451,6 +4506,7 @@ func (s *WirelessService) GetNetworkWirelessClientLatencyStats(networkID string,
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, getNetworkWirelessConnectionStatsQueryParams *GetNetworkWirelessConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/connectionStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4487,6 +4543,7 @@ func (s *WirelessService) GetNetworkWirelessConnectionStats(networkID string, ge
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, getNetworkWirelessDataRateHistoryQueryParams *GetNetworkWirelessDataRateHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessDataRateHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/dataRateHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4523,6 +4580,7 @@ func (s *WirelessService) GetNetworkWirelessDataRateHistory(networkID string, ge
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID string, getNetworkWirelessDevicesConnectionStatsQueryParams *GetNetworkWirelessDevicesConnectionStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesConnectionStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/connectionStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4559,6 +4617,7 @@ func (s *WirelessService) GetNetworkWirelessDevicesConnectionStats(networkID str
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string, getNetworkWirelessDevicesLatencyStatsQueryParams *GetNetworkWirelessDevicesLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessDevicesLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/devices/latencyStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4594,6 +4653,7 @@ func (s *WirelessService) GetNetworkWirelessDevicesLatencyStats(networkID string
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessElectronicShelfLabel(networkID string) (*ResponseWirelessGetNetworkWirelessElectronicShelfLabel, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/electronicShelfLabel"
 	s.rateLimiterBucket.Wait(1)
@@ -4627,6 +4687,7 @@ func (s *WirelessService) GetNetworkWirelessElectronicShelfLabel(networkID strin
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessElectronicShelfLabelConfiguredDevices(networkID string) (*ResponseWirelessGetNetworkWirelessElectronicShelfLabelConfiguredDevices, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/electronicShelfLabel/configuredDevices"
 	s.rateLimiterBucket.Wait(1)
@@ -4660,6 +4721,7 @@ func (s *WirelessService) GetNetworkWirelessElectronicShelfLabelConfiguredDevice
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessEthernetPortsProfiles(networkID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles"
 	s.rateLimiterBucket.Wait(1)
@@ -4694,6 +4756,7 @@ func (s *WirelessService) GetNetworkWirelessEthernetPortsProfiles(networkID stri
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessEthernetPortsProfile(networkID string, profileID string) (*ResponseWirelessGetNetworkWirelessEthernetPortsProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ethernet/ports/profiles/{profileId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4729,6 +4792,7 @@ func (s *WirelessService) GetNetworkWirelessEthernetPortsProfile(networkID strin
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, getNetworkWirelessFailedConnectionsQueryParams *GetNetworkWirelessFailedConnectionsQueryParams) (*ResponseWirelessGetNetworkWirelessFailedConnections, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/failedConnections"
 	s.rateLimiterBucket.Wait(1)
@@ -4765,6 +4829,7 @@ func (s *WirelessService) GetNetworkWirelessFailedConnections(networkID string, 
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, getNetworkWirelessLatencyHistoryQueryParams *GetNetworkWirelessLatencyHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -4801,6 +4866,7 @@ func (s *WirelessService) GetNetworkWirelessLatencyHistory(networkID string, get
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNetworkWirelessLatencyStatsQueryParams *GetNetworkWirelessLatencyStatsQueryParams) (*ResponseWirelessGetNetworkWirelessLatencyStats, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/latencyStats"
 	s.rateLimiterBucket.Wait(1)
@@ -4837,9 +4903,40 @@ func (s *WirelessService) GetNetworkWirelessLatencyStats(networkID string, getNe
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNetworkWirelessMeshStatusesQueryParams *GetNetworkWirelessMeshStatusesQueryParams) (*ResponseWirelessGetNetworkWirelessMeshStatuses, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/meshStatuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getNetworkWirelessMeshStatusesQueryParams != nil && getNetworkWirelessMeshStatusesQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetNetworkWirelessMeshStatuses
+		println("Paginate")
+		getNetworkWirelessMeshStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetNetworkWirelessMeshStatusesPaginate, networkID, "", getNetworkWirelessMeshStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetNetworkWirelessMeshStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{networkId}", fmt.Sprintf("%v", networkID), -1)
 
 	queryString, _ := query.Values(getNetworkWirelessMeshStatusesQueryParams)
@@ -4864,6 +4961,11 @@ func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNe
 	return result, response, err
 
 }
+func (s *WirelessService) GetNetworkWirelessMeshStatusesPaginate(networkID string, getNetworkWirelessMeshStatusesQueryParams any) (any, *resty.Response, error) {
+	getNetworkWirelessMeshStatusesQueryParamsConverted := getNetworkWirelessMeshStatusesQueryParams.(*GetNetworkWirelessMeshStatusesQueryParams)
+
+	return s.GetNetworkWirelessMeshStatuses(networkID, getNetworkWirelessMeshStatusesQueryParamsConverted)
+}
 
 //GetNetworkWirelessRfProfiles List RF profiles for this network
 /* List RF profiles for this network
@@ -4873,6 +4975,7 @@ func (s *WirelessService) GetNetworkWirelessMeshStatuses(networkID string, getNe
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetworkWirelessRfProfilesQueryParams *GetNetworkWirelessRfProfilesQueryParams) (*ResponseWirelessGetNetworkWirelessRfProfiles, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles"
 	s.rateLimiterBucket.Wait(1)
@@ -4909,6 +5012,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfiles(networkID string, getNetw
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfileID string) (*ResponseWirelessGetNetworkWirelessRfProfile, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/rfProfiles/{rfProfileId}"
 	s.rateLimiterBucket.Wait(1)
@@ -4943,6 +5047,7 @@ func (s *WirelessService) GetNetworkWirelessRfProfile(networkID string, rfProfil
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*ResponseWirelessGetNetworkWirelessSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -4977,6 +5082,7 @@ func (s *WirelessService) GetNetworkWirelessSettings(networkID string) (*Respons
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID string, getNetworkWirelessSignalQualityHistoryQueryParams *GetNetworkWirelessSignalQualityHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessSignalQualityHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/signalQualityHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -5012,6 +5118,7 @@ func (s *WirelessService) GetNetworkWirelessSignalQualityHistory(networkID strin
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWirelessGetNetworkWirelessSSIDs, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids"
 	s.rateLimiterBucket.Wait(1)
@@ -5046,6 +5153,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDs(networkID string) (*ResponseWi
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSID, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}"
 	s.rateLimiterBucket.Wait(1)
@@ -5081,6 +5189,7 @@ func (s *WirelessService) GetNetworkWirelessSSID(networkID string, number string
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDBonjourForwarding, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/bonjourForwarding"
 	s.rateLimiterBucket.Wait(1)
@@ -5116,6 +5225,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDBonjourForwarding(networkID stri
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDDeviceTypeGroupPolicies, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/deviceTypeGroupPolicies"
 	s.rateLimiterBucket.Wait(1)
@@ -5151,6 +5261,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDDeviceTypeGroupPolicies(networkI
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDEapOverride, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/eapOverride"
 	s.rateLimiterBucket.Wait(1)
@@ -5186,6 +5297,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDEapOverride(networkID string, nu
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL3FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l3FirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -5221,6 +5333,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL3FirewallRules(networkI
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDFirewallL7FirewallRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/firewall/l7FirewallRules"
 	s.rateLimiterBucket.Wait(1)
@@ -5256,6 +5369,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDFirewallL7FirewallRules(networkI
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDHotspot20, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/hotspot20"
 	s.rateLimiterBucket.Wait(1)
@@ -5291,6 +5405,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDHotspot20(networkID string, numb
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsks, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks"
 	s.rateLimiterBucket.Wait(1)
@@ -5327,6 +5442,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsks(networkID string, n
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, number string, identityPskID string) (*ResponseWirelessGetNetworkWirelessSSIDIDentityPsk, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/identityPsks/{identityPskId}"
 	s.rateLimiterBucket.Wait(1)
@@ -5363,6 +5479,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDIDentityPsk(networkID string, nu
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSchedules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/schedules"
 	s.rateLimiterBucket.Wait(1)
@@ -5398,6 +5515,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSchedules(networkID string, numb
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDSplashSettings, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/splash/settings"
 	s.rateLimiterBucket.Wait(1)
@@ -5433,6 +5551,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDSplashSettings(networkID string,
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDTrafficShapingRules, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/trafficShaping/rules"
 	s.rateLimiterBucket.Wait(1)
@@ -5468,6 +5587,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDTrafficShapingRules(networkID st
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number string) (*ResponseWirelessGetNetworkWirelessSSIDVpn, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/ssids/{number}/vpn"
 	s.rateLimiterBucket.Wait(1)
@@ -5503,6 +5623,7 @@ func (s *WirelessService) GetNetworkWirelessSSIDVpn(networkID string, number str
 
 
 */
+
 func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNetworkWirelessUsageHistoryQueryParams *GetNetworkWirelessUsageHistoryQueryParams) (*ResponseWirelessGetNetworkWirelessUsageHistory, *resty.Response, error) {
 	path := "/api/v1/networks/{networkId}/wireless/usageHistory"
 	s.rateLimiterBucket.Wait(1)
@@ -5539,9 +5660,40 @@ func (s *WirelessService) GetNetworkWirelessUsageHistory(networkID string, getNe
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessAirMarshalRules(organizationID string, getOrganizationWirelessAirMarshalRulesQueryParams *GetOrganizationWirelessAirMarshalRulesQueryParams) (*ResponseWirelessGetOrganizationWirelessAirMarshalRules, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/airMarshal/rules"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessAirMarshalRulesQueryParams != nil && getOrganizationWirelessAirMarshalRulesQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessAirMarshalRules
+		println("Paginate")
+		getOrganizationWirelessAirMarshalRulesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessAirMarshalRulesPaginate, organizationID, "", getOrganizationWirelessAirMarshalRulesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessAirMarshalRules
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessAirMarshalRulesQueryParams)
@@ -5566,6 +5718,11 @@ func (s *WirelessService) GetOrganizationWirelessAirMarshalRules(organizationID 
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessAirMarshalRulesPaginate(organizationID string, getOrganizationWirelessAirMarshalRulesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessAirMarshalRulesQueryParamsConverted := getOrganizationWirelessAirMarshalRulesQueryParams.(*GetOrganizationWirelessAirMarshalRulesQueryParams)
+
+	return s.GetOrganizationWirelessAirMarshalRules(organizationID, getOrganizationWirelessAirMarshalRulesQueryParamsConverted)
+}
 
 //GetOrganizationWirelessAirMarshalSettingsByNetwork Returns the current Air Marshal settings for this network
 /* Returns the current Air Marshal settings for this network
@@ -5575,9 +5732,40 @@ func (s *WirelessService) GetOrganizationWirelessAirMarshalRules(organizationID 
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessAirMarshalSettingsByNetwork(organizationID string, getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams *GetOrganizationWirelessAirMarshalSettingsByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/airMarshal/settings/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams != nil && getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork
+		println("Paginate")
+		getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessAirMarshalSettingsByNetworkPaginate, organizationID, "", getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessAirMarshalSettingsByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams)
@@ -5602,6 +5790,11 @@ func (s *WirelessService) GetOrganizationWirelessAirMarshalSettingsByNetwork(org
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessAirMarshalSettingsByNetworkPaginate(organizationID string, getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessAirMarshalSettingsByNetworkQueryParamsConverted := getOrganizationWirelessAirMarshalSettingsByNetworkQueryParams.(*GetOrganizationWirelessAirMarshalSettingsByNetworkQueryParams)
+
+	return s.GetOrganizationWirelessAirMarshalSettingsByNetwork(organizationID, getOrganizationWirelessAirMarshalSettingsByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationWirelessClientsOverviewByDevice List access point client count at the moment in an organization
 /* List access point client count at the moment in an organization
@@ -5611,9 +5804,40 @@ func (s *WirelessService) GetOrganizationWirelessAirMarshalSettingsByNetwork(org
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessClientsOverviewByDevice(organizationID string, getOrganizationWirelessClientsOverviewByDeviceQueryParams *GetOrganizationWirelessClientsOverviewByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/clients/overview/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessClientsOverviewByDeviceQueryParams != nil && getOrganizationWirelessClientsOverviewByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice
+		println("Paginate")
+		getOrganizationWirelessClientsOverviewByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessClientsOverviewByDevicePaginate, organizationID, "", getOrganizationWirelessClientsOverviewByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessClientsOverviewByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessClientsOverviewByDeviceQueryParams)
@@ -5638,6 +5862,11 @@ func (s *WirelessService) GetOrganizationWirelessClientsOverviewByDevice(organiz
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessClientsOverviewByDevicePaginate(organizationID string, getOrganizationWirelessClientsOverviewByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessClientsOverviewByDeviceQueryParamsConverted := getOrganizationWirelessClientsOverviewByDeviceQueryParams.(*GetOrganizationWirelessClientsOverviewByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessClientsOverviewByDevice(organizationID, getOrganizationWirelessClientsOverviewByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesChannelUtilizationByDevice Get average channel utilization for all bands in a network, split by AP
 /* Get average channel utilization for all bands in a network, split by AP
@@ -5647,9 +5876,40 @@ func (s *WirelessService) GetOrganizationWirelessClientsOverviewByDevice(organiz
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
@@ -5674,6 +5934,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevi
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevicePaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationByDevice(organizationID, getOrganizationWirelessDevicesChannelUtilizationByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesChannelUtilizationByNetwork Get average channel utilization across all bands for all networks in the organization
 /* Get average channel utilization across all bands for all networks in the organization
@@ -5683,9 +5948,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByDevi
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams *GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationByNetworkPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
@@ -5710,6 +6006,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetw
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetworkPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationByNetwork(organizationID, getOrganizationWirelessDevicesChannelUtilizationByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval Get a time-series of average channel utilization for all bands, segmented by device.
 /* Get a time-series of average channel utilization for all bands, segmented by device.
@@ -5719,9 +6020,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationByNetw
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byDevice/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
@@ -5746,6 +6078,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByInterval(organizationID, getOrganizationWirelessDevicesChannelUtilizationHistoryByDeviceByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval Get a time-series of average channel utilization for all bands
 /* Get a time-series of average channel utilization for all bands
@@ -5755,9 +6092,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams *GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/channelUtilization/history/byNetwork/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams != nil && getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+		println("Paginate")
+		getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalPaginate, organizationID, "", getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
@@ -5782,6 +6150,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalPaginate(organizationID string, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParamsConverted := getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams.(*GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByInterval(organizationID, getOrganizationWirelessDevicesChannelUtilizationHistoryByNetworkByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesEthernetStatuses List the most recent Ethernet link speed, duplex, aggregation and power mode and status information for wireless devices.
 /* List the most recent Ethernet link speed, duplex, aggregation and power mode and status information for wireless devices.
@@ -5791,9 +6164,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesChannelUtilizationHistor
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organizationID string, getOrganizationWirelessDevicesEthernetStatusesQueryParams *GetOrganizationWirelessDevicesEthernetStatusesQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/ethernet/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesEthernetStatusesQueryParams != nil && getOrganizationWirelessDevicesEthernetStatusesQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses
+		println("Paginate")
+		getOrganizationWirelessDevicesEthernetStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesEthernetStatusesPaginate, organizationID, "", getOrganizationWirelessDevicesEthernetStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesEthernetStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesEthernetStatusesQueryParams)
@@ -5818,6 +6222,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organiz
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatusesPaginate(organizationID string, getOrganizationWirelessDevicesEthernetStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesEthernetStatusesQueryParamsConverted := getOrganizationWirelessDevicesEthernetStatusesQueryParams.(*GetOrganizationWirelessDevicesEthernetStatusesQueryParams)
+
+	return s.GetOrganizationWirelessDevicesEthernetStatuses(organizationID, getOrganizationWirelessDevicesEthernetStatusesQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesPacketLossByClient Get average packet loss for the given timespan for all clients in the organization.
 /* Get average packet loss for the given timespan for all clients in the organization.
@@ -5827,9 +6236,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesEthernetStatuses(organiz
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams *GetOrganizationWirelessDevicesPacketLossByClientQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byClient"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByClientQueryParams != nil && getOrganizationWirelessDevicesPacketLossByClientQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByClientQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByClientPaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByClientQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByClient
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByClientQueryParams)
@@ -5854,6 +6294,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organ
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClientPaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByClientQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByClientQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByClientQueryParams.(*GetOrganizationWirelessDevicesPacketLossByClientQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByClient(organizationID, getOrganizationWirelessDevicesPacketLossByClientQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesPacketLossByDevice Get average packet loss for the given timespan for all devices in the organization
 /* Get average packet loss for the given timespan for all devices in the organization. Does not include device's own traffic.
@@ -5863,9 +6308,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByClient(organ
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams *GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByDeviceQueryParams != nil && getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
@@ -5890,6 +6366,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organ
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevicePaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByDeviceQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByDeviceQueryParams.(*GetOrganizationWirelessDevicesPacketLossByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByDevice(organizationID, getOrganizationWirelessDevicesPacketLossByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesPacketLossByNetwork Get average packet loss for the given timespan for all networks in the organization.
 /* Get average packet loss for the given timespan for all networks in the organization.
@@ -5899,9 +6380,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByDevice(organ
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams *GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/packetLoss/byNetwork"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesPacketLossByNetworkQueryParams != nil && getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork
+		println("Paginate")
+		getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesPacketLossByNetworkPaginate, organizationID, "", getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesPacketLossByNetwork
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
@@ -5926,6 +6438,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(orga
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetworkPaginate(organizationID string, getOrganizationWirelessDevicesPacketLossByNetworkQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesPacketLossByNetworkQueryParamsConverted := getOrganizationWirelessDevicesPacketLossByNetworkQueryParams.(*GetOrganizationWirelessDevicesPacketLossByNetworkQueryParams)
+
+	return s.GetOrganizationWirelessDevicesPacketLossByNetwork(organizationID, getOrganizationWirelessDevicesPacketLossByNetworkQueryParamsConverted)
+}
 
 //GetOrganizationWirelessDevicesWirelessControllersByDevice List of Catalyst access points information
 /* List of Catalyst access points information
@@ -5935,9 +6452,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesPacketLossByNetwork(orga
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams *GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/devices/wirelessControllers/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams != nil && getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice
+		println("Paginate")
+		getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessDevicesWirelessControllersByDevicePaginate, organizationID, "", getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessDevicesWirelessControllersByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
@@ -5962,6 +6510,11 @@ func (s *WirelessService) GetOrganizationWirelessDevicesWirelessControllersByDev
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessDevicesWirelessControllersByDevicePaginate(organizationID string, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParamsConverted := getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams.(*GetOrganizationWirelessDevicesWirelessControllersByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessDevicesWirelessControllersByDevice(organizationID, getOrganizationWirelessDevicesWirelessControllersByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessRfProfilesAssignmentsByDevice List the RF profiles of an organization by device
 /* List the RF profiles of an organization by device
@@ -5971,9 +6524,40 @@ func (s *WirelessService) GetOrganizationWirelessDevicesWirelessControllersByDev
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessRfProfilesAssignmentsByDevice(organizationID string, getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams *GetOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/rfProfiles/assignments/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams != nil && getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice
+		println("Paginate")
+		getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessRfProfilesAssignmentsByDevicePaginate, organizationID, "", getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessRfProfilesAssignmentsByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams)
@@ -5998,6 +6582,11 @@ func (s *WirelessService) GetOrganizationWirelessRfProfilesAssignmentsByDevice(o
 	return result, response, err
 
 }
+func (s *WirelessService) GetOrganizationWirelessRfProfilesAssignmentsByDevicePaginate(organizationID string, getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParamsConverted := getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams.(*GetOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessRfProfilesAssignmentsByDevice(organizationID, getOrganizationWirelessRfProfilesAssignmentsByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessSSIDsStatusesByDevice List status information of all BSSIDs in your organization
 /* List status information of all BSSIDs in your organization
@@ -6007,9 +6596,40 @@ func (s *WirelessService) GetOrganizationWirelessRfProfilesAssignmentsByDevice(o
 
 
 */
+
 func (s *WirelessService) GetOrganizationWirelessSSIDsStatusesByDevice(organizationID string, getOrganizationWirelessSsidsStatusesByDeviceQueryParams *GetOrganizationWirelessSSIDsStatusesByDeviceQueryParams) (*ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wireless/ssids/statuses/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessSsidsStatusesByDeviceQueryParams != nil && getOrganizationWirelessSsidsStatusesByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice
+		println("Paginate")
+		getOrganizationWirelessSsidsStatusesByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessSSIDsStatusesByDevicePaginate, organizationID, "", getOrganizationWirelessSsidsStatusesByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessSsidsStatusesByDeviceQueryParams)
@@ -6033,6 +6653,11 @@ func (s *WirelessService) GetOrganizationWirelessSSIDsStatusesByDevice(organizat
 	result := response.Result().(*ResponseWirelessGetOrganizationWirelessSSIDsStatusesByDevice)
 	return result, response, err
 
+}
+func (s *WirelessService) GetOrganizationWirelessSSIDsStatusesByDevicePaginate(organizationID string, getOrganizationWirelessSsidsStatusesByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessSsidsStatusesByDeviceQueryParamsConverted := getOrganizationWirelessSsidsStatusesByDeviceQueryParams.(*GetOrganizationWirelessSSIDsStatusesByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessSSIDsStatusesByDevice(organizationID, getOrganizationWirelessSsidsStatusesByDeviceQueryParamsConverted)
 }
 
 //CreateNetworkWirelessAirMarshalRule Creates a new rule

--- a/sdk/wireless_controller.go
+++ b/sdk/wireless_controller.go
@@ -1,6 +1,7 @@
 package meraki
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -671,7 +672,38 @@ type ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice
 
 func (s *WirelessControllerService) GetOrganizationWirelessControllerAvailabilitiesChangeHistory(organizationID string, getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams *GetOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/availabilities/changeHistory"
+	fmt.Print("HOLA", path)
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams != nil && getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory
+		println("Paginate")
+		getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerAvailabilitiesChangeHistoryPaginate, organizationID, "", getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerAvailabilitiesChangeHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams)
@@ -696,6 +728,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerAvailabilit
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerAvailabilitiesChangeHistoryPaginate(organizationID string, getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParamsConverted := getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams.(*GetOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParams)
+
+	return s.GetOrganizationWirelessControllerAvailabilitiesChangeHistory(organizationID, getOrganizationWirelessControllerAvailabilitiesChangeHistoryQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval List wireless client counts of wireless LAN controllers over time in an organization
 /* List wireless client counts of wireless LAN controllers over time in an organization
@@ -709,6 +746,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerAvailabilit
 func (s *WirelessControllerService) GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval(organizationID string, getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams *GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/clients/overview/history/byDevice/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams != nil && getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams)
@@ -733,6 +800,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerClientsOver
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalPaginate(organizationID string, getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParamsConverted := getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams.(*GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerClientsOverviewHistoryByDeviceByInterval(organizationID, getOrganizationWirelessControllerClientsOverviewHistoryByDeviceByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerConnections List all access points associated with wireless LAN controllers in an organization
 /* List all access points associated with wireless LAN controllers in an organization
@@ -746,6 +818,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerClientsOver
 func (s *WirelessControllerService) GetOrganizationWirelessControllerConnections(organizationID string, getOrganizationWirelessControllerConnectionsQueryParams *GetOrganizationWirelessControllerConnectionsQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerConnections, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/connections"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerConnectionsQueryParams != nil && getOrganizationWirelessControllerConnectionsQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerConnections
+		println("Paginate")
+		getOrganizationWirelessControllerConnectionsQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerConnectionsPaginate, organizationID, "", getOrganizationWirelessControllerConnectionsQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerConnections
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerConnectionsQueryParams)
@@ -770,6 +872,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerConnections
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerConnectionsPaginate(organizationID string, getOrganizationWirelessControllerConnectionsQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerConnectionsQueryParamsConverted := getOrganizationWirelessControllerConnectionsQueryParams.(*GetOrganizationWirelessControllerConnectionsQueryParams)
+
+	return s.GetOrganizationWirelessControllerConnections(organizationID, getOrganizationWirelessControllerConnectionsQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice List wireless LAN controller layer 2 interfaces in an organization
 /* List wireless LAN controller layer 2 interfaces in an organization
@@ -783,6 +890,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerConnections
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2ByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2ByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
@@ -807,6 +944,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2ByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2ByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2ByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice List wireless LAN controller layer 2 interfaces history status in an organization
 /* List wireless LAN controller layer 2 interfaces history status in an organization
@@ -820,6 +962,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/statuses/changeHistory/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
@@ -844,6 +1016,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2StatusesChangeHistoryByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval List wireless LAN controller layer 2 interfaces history usage in an organization
 /* List wireless LAN controller layer 2 interfaces history usage in an organization
@@ -857,6 +1034,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l2/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
@@ -881,6 +1088,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesL2UsageHistoryByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice List wireless LAN controller layer 3 interfaces in an organization
 /* List wireless LAN controller layer 3 interfaces in an organization
@@ -894,6 +1106,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3ByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3ByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
@@ -918,6 +1160,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3ByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3ByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3ByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice List wireless LAN controller layer 3 interfaces history status in an organization
 /* List wireless LAN controller layer 3 interfaces history status in an organization
@@ -931,6 +1178,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/statuses/changeHistory/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
@@ -955,6 +1232,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3StatusesChangeHistoryByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval List wireless LAN controller layer 3 interfaces history usage in an organization
 /* List wireless LAN controller layer 3 interfaces history usage in an organization
@@ -968,6 +1250,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/l3/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
@@ -992,6 +1304,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesL3UsageHistoryByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice Retrieve the packet counters for the interfaces of a Wireless LAN controller
 /* Retrieve the packet counters for the interfaces of a Wireless LAN controller
@@ -1005,6 +1322,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams *GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/packets/overview/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevicePaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
@@ -1029,6 +1376,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevicePaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDevice(organizationID, getOrganizationWirelessControllerDevicesInterfacesPacketsOverviewByDeviceQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval Retrieve the traffic for the interfaces of a Wireless LAN controller
 /* Retrieve the traffic for the interfaces of a Wireless LAN controller
@@ -1042,6 +1394,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/interfaces/usage/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
@@ -1066,6 +1448,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesInterfacesUsageHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesInterfacesUsageHistoryByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory List the failover events of wireless LAN controllers in an organization
 /* List the failover events of wireless LAN controllers in an organization
@@ -1079,6 +1466,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesInte
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams *GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/failover/history"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams != nil && getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryPaginate, organizationID, "", getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyFailoverHistory
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result = append(*result, *resultTmp...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
@@ -1103,6 +1520,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedu
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryPaginate(organizationID string, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParamsConverted := getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams.(*GetOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesRedundancyFailoverHistory(organizationID, getOrganizationWirelessControllerDevicesRedundancyFailoverHistoryQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesRedundancyStatuses List redundancy details of wireless LAN controllers in an organization
 /* List redundancy details of wireless LAN controllers in an organization. The failover count refers to the total failovers system happens from the moment of this device onboarding to Dashboard
@@ -1116,6 +1538,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedu
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams *GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/redundancy/statuses"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams != nil && getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesRedundancyStatusesPaginate, organizationID, "", getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesRedundancyStatuses
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
@@ -1140,6 +1592,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedu
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedundancyStatusesPaginate(organizationID string, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParamsConverted := getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams.(*GetOrganizationWirelessControllerDevicesRedundancyStatusesQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesRedundancyStatuses(organizationID, getOrganizationWirelessControllerDevicesRedundancyStatusesQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval List cpu utilization data of wireless LAN controllers in an organization
 /* List cpu utilization data of wireless LAN controllers in an organization
@@ -1153,6 +1610,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesRedu
 func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams *GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/devices/system/utilization/history/byInterval"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams != nil && getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval
+		println("Paginate")
+		getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalPaginate, organizationID, "", getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
@@ -1177,6 +1664,11 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesSyst
 	return result, response, err
 
 }
+func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalPaginate(organizationID string, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParamsConverted := getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams.(*GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParams)
+
+	return s.GetOrganizationWirelessControllerDevicesSystemUtilizationHistoryByInterval(organizationID, getOrganizationWirelessControllerDevicesSystemUtilizationHistoryByIntervalQueryParamsConverted)
+}
 
 //GetOrganizationWirelessControllerOverviewByDevice List the overview information of wireless LAN controllers in an organization and it is updated every minute.
 /* List the overview information of wireless LAN controllers in an organization and it is updated every minute.
@@ -1190,6 +1682,36 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerDevicesSyst
 func (s *WirelessControllerService) GetOrganizationWirelessControllerOverviewByDevice(organizationID string, getOrganizationWirelessControllerOverviewByDeviceQueryParams *GetOrganizationWirelessControllerOverviewByDeviceQueryParams) (*ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice, *resty.Response, error) {
 	path := "/api/v1/organizations/{organizationId}/wirelessController/overview/byDevice"
 	s.rateLimiterBucket.Wait(1)
+
+	if getOrganizationWirelessControllerOverviewByDeviceQueryParams != nil && getOrganizationWirelessControllerOverviewByDeviceQueryParams.PerPage == -1 {
+		var result *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice
+		println("Paginate")
+		getOrganizationWirelessControllerOverviewByDeviceQueryParams.PerPage = PAGINATION_PER_PAGE
+		result2, response, err := Paginate(s.GetOrganizationWirelessControllerOverviewByDevicePaginate, organizationID, "", getOrganizationWirelessControllerOverviewByDeviceQueryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		jsonResult, err := json.Marshal(result2)
+		// Verficar el error
+		if err != nil {
+			return nil, nil, err
+		}
+		var paginatedResponse []any
+		err = json.Unmarshal(jsonResult, &paginatedResponse)
+		// for para recorrer "paginatedResponse"
+		for i := 0; i < len(paginatedResponse); i++ {
+			var resultTmp *ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice
+			jsonResult2, _ := json.Marshal(paginatedResponse[i])
+			err = json.Unmarshal(jsonResult2, &resultTmp)
+			// Verificar si result es nil, si lo es inicialiarlo
+			if result == nil {
+				result = resultTmp
+			} else {
+				*result.Items = append(*result.Items, *resultTmp.Items...)
+			}
+		}
+		return result, response, err
+	}
 	path = strings.Replace(path, "{organizationId}", fmt.Sprintf("%v", organizationID), -1)
 
 	queryString, _ := query.Values(getOrganizationWirelessControllerOverviewByDeviceQueryParams)
@@ -1213,4 +1735,9 @@ func (s *WirelessControllerService) GetOrganizationWirelessControllerOverviewByD
 	result := response.Result().(*ResponseWirelessControllerGetOrganizationWirelessControllerOverviewByDevice)
 	return result, response, err
 
+}
+func (s *WirelessControllerService) GetOrganizationWirelessControllerOverviewByDevicePaginate(organizationID string, getOrganizationWirelessControllerOverviewByDeviceQueryParams any) (any, *resty.Response, error) {
+	getOrganizationWirelessControllerOverviewByDeviceQueryParamsConverted := getOrganizationWirelessControllerOverviewByDeviceQueryParams.(*GetOrganizationWirelessControllerOverviewByDeviceQueryParams)
+
+	return s.GetOrganizationWirelessControllerOverviewByDevice(organizationID, getOrganizationWirelessControllerOverviewByDeviceQueryParamsConverted)
 }


### PR DESCRIPTION
### Added
- **Support for fetching all items with `perpage=-1`** A new feature has been added to the endpoint where if the `perpage` parameter is set to `-1`, it will return all available items for that endpoint. This eliminates the need for multiple paginated requests when retrieving the full set of data.

**Behavior:**
- When `perpage` is set to `-1`, all items will be returned.
- For positive values of `perpage`, the traditional pagination logic will be applied.

**Benefits:**
- Simplifies fetching all data in a single request.
- Reduces the need for multiple API calls to retrieve the full dataset.