### PR TITLE
## [4.0.6] - 2025-03-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.6] - 2025-03-10
+### Fixed
+- Include `ID` to `ResponseCameraGetOrganizationCameraRole` and `ResponseItemCameraGetOrganizationCameraRoles`.
+
 ## [4.0.5] - 2025-03-05
 ### Fixed
 - Organization.CreateOrganizationSamlIDp fails unmarshalling, `object`, not `array`.
@@ -1449,4 +1453,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [4.0.3]: https://github.com/meraki/dashboard-api-go/compare/v4.0.2...4.0.3
 [4.0.4]: https://github.com/meraki/dashboard-api-go/compare/v4.0.3...4.0.4
 [4.0.5]: https://github.com/meraki/dashboard-api-go/compare/v4.0.4...4.0.5
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v4.0.5...main
+[4.0.6]: https://github.com/meraki/dashboard-api-go/compare/v4.0.5...4.0.6
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v4.0.6...main

--- a/sdk/camera.go
+++ b/sdk/camera.go
@@ -421,6 +421,7 @@ type ResponseCameraGetOrganizationCameraPermission struct {
 }
 type ResponseCameraGetOrganizationCameraRoles []ResponseItemCameraGetOrganizationCameraRoles // Array of ResponseCameraGetOrganizationCameraRoles
 type ResponseItemCameraGetOrganizationCameraRoles struct {
+	ID                string                                                           `json:"id,omitempty"`                //
 	AppliedOnDevices  *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOnDevices  `json:"appliedOnDevices,omitempty"`  //
 	AppliedOnNetworks *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` //
 	AppliedOrgWide    *[]ResponseItemCameraGetOrganizationCameraRolesAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    //
@@ -452,6 +453,7 @@ type ResponseCameraGetOrganizationCameraRole struct {
 	AppliedOnNetworks *[]ResponseCameraGetOrganizationCameraRoleAppliedOnNetworks `json:"appliedOnNetworks,omitempty"` //
 	AppliedOrgWide    *[]ResponseCameraGetOrganizationCameraRoleAppliedOrgWide    `json:"appliedOrgWide,omitempty"`    //
 	Name              string                                                      `json:"name,omitempty"`              //
+	ID                string                                                      `json:"id,omitempty"`                //
 }
 type ResponseCameraGetOrganizationCameraRoleAppliedOnDevices struct {
 	ID                string `json:"id,omitempty"`                //


### PR DESCRIPTION
### Fixed
- Include `ID` to `ResponseCameraGetOrganizationCameraRole` and `ResponseItemCameraGetOrganizationCameraRoles`.