### PR TITLE
v5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.0.5] - 2025-07-21
+- Change IMEI field type from float64 to string in ResponseItemOrganizationsGetOrganizationDevices struct for better compatibility with device identifiers.
+
 ## [5.0.4] - 2025-07-09
 ### Fixed
 - Added retry and backoff logic for handling rate limit (429) responses.
@@ -1479,4 +1483,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [4.0.6]: https://github.com/meraki/dashboard-api-go/compare/v4.0.5...4.0.6
 [5.0.0]: https://github.com/meraki/dashboard-api-go/compare/v4.0.6...5.0.0
 [5.0.1]: https://github.com/meraki/dashboard-api-go/compare/v5.0.0...5.0.1
-[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v5.0.1...main
+[5.0.2]: https://github.com/meraki/dashboard-api-go/compare/v5.0.1...5.0.2
+[5.0.3]: https://github.com/meraki/dashboard-api-go/compare/v5.0.2...5.0.3
+[5.0.4]: https://github.com/meraki/dashboard-api-go/compare/v5.0.3...5.0.4
+[5.0.5]: https://github.com/meraki/dashboard-api-go/compare/v5.0.4...5.0.5
+[Unreleased]: https://github.com/meraki/dashboard-api-go/compare/v5.0.5...main

--- a/sdk/organizations.go
+++ b/sdk/organizations.go
@@ -1671,7 +1671,7 @@ type ResponseItemOrganizationsGetOrganizationDevices struct {
 	Address     string                                                    `json:"address,omitempty"`     // Physical address of the device
 	Details     *[]ResponseItemOrganizationsGetOrganizationDevicesDetails `json:"details,omitempty"`     // Additional device information
 	Firmware    string                                                    `json:"firmware,omitempty"`    // Firmware version of the device
-	Imei        *float64                                                  `json:"imei,omitempty"`        // IMEI of the device, if applicable
+	Imei        string                                                    `json:"imei,omitempty"`        // IMEI of the device, if applicable
 	LanIP       string                                                    `json:"lanIp,omitempty"`       // LAN IP address of the device
 	Lat         *float64                                                  `json:"lat,omitempty"`         // Latitude of the device
 	Lng         *float64                                                  `json:"lng,omitempty"`         // Longitude of the device


### PR DESCRIPTION
Change IMEI field type from float64 to string in ResponseItemOrganizationsGetOrganizationDevices struct for better compatibility with device identifiers.