### PR TITLE
Swap order of User-Agent components

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ client, err = meraki.NewClientWithOptions("https://api.meraki.com/",
 
 The client allows you to configure automatic retry (backoff) behavior for rate-limited (HTTP 429) responses using the `SetBackoff` method. This is useful to control how and how many times the SDK retries requests when the API responds with rate limits.
 
-#### Using SetBackoff
+#### Using SetBackoff example
 
 ```go
 // Example of custom backoff configuration

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -164,7 +164,7 @@ func (c *Client) SetAuthToken(accessToken string) {
 
 // SetUserAgent sets the User-Agent header in the request
 func (c *Client) SetUserAgent() {
-	userAgent := fmt.Sprintf("%s %s", DEFAULT_USER_AGENT, os.Getenv("MERAKI_USER_AGENT"))
+	userAgent := fmt.Sprintf("%s %s", os.Getenv("MERAKI_USER_AGENT"), DEFAULT_USER_AGENT)
 	c.common.client.SetHeader("User-Agent", userAgent)
 }
 


### PR DESCRIPTION
User-Agent format is `<Application> <Vendor> <Client>`, DEFAULT_USER_AGENT is clearly a Client part of the User-Agent.