### PR TITLE
fix: guard debug prints in doWithRetriesAndResult with client.Debug

### DIFF
--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -509,7 +509,6 @@ func changeParams(params interface{}, newValue string) interface{} {
 	}
 	//
 
-	fmt.Println("New Params: ", newParams)
 	// Devolver el nuevo objeto como interface{}
 	return newParams.Addr().Interface()
 }
@@ -581,18 +580,21 @@ func doWithRetriesAndResult[T any](
 	maxRetries, maxRetryDelay, maxRetryJitter, useRetryHeader := getBackoffValues(backoff)
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		fmt.Println("MAX_RETRIES: ", maxRetries+1)
+		if client.Debug {
+			log.Printf("[debug] max retries: %d", maxRetries+1)
+		}
 		resp, err = operation()
 
 		if err != nil && resp.StatusCode() != http.StatusTooManyRequests {
-
-			log.Printf("Error 1: %v", err)
-			log.Printf("Response: %v", resp.StatusCode())
+			if client.Debug {
+				log.Printf("[debug] request error: %v, response status: %d", err, resp.StatusCode())
+			}
 			return nil, resp, err
 		}
 		if resp.IsError() && resp.StatusCode() != http.StatusTooManyRequests {
-			log.Printf("Error 2: %v", resp)
-			log.Printf("Status code: %v", resp.StatusCode())
+			if client.Debug {
+				log.Printf("[debug] response error: %v, status: %d", resp, resp.StatusCode())
+			}
 			return nil, resp, fmt.Errorf("error with operation: %s Error:\n %s", resp.Request.URL, resp)
 		}
 		if resp != nil && resp.StatusCode() != http.StatusTooManyRequests {
@@ -622,7 +624,9 @@ func doWithRetriesAndResult[T any](
 							break
 						}
 						if resp.IsError() {
-							log.Printf("Error 3: %v", resp)
+							if client.Debug {
+								log.Printf("[debug] pagination error: %v", resp)
+							}
 							if resp.StatusCode() != http.StatusTooManyRequests {
 								return result, resp, fmt.Errorf("error with get operation: %s", link)
 							}
@@ -630,7 +634,9 @@ func doWithRetriesAndResult[T any](
 						delay := maxRetryDelay * time.Duration(1<<attempt)
 						jitter := time.Duration(rand.Int63n(int64(maxRetryJitter)))
 						wait := delay + jitter
-						log.Printf("[retry] attempt %d: received 429, waiting %v", attempt, wait)
+						if client.Debug {
+							log.Printf("[retry] attempt %d: received 429, waiting %v", attempt, wait)
+						}
 						time.Sleep(wait)
 					}
 					json.Unmarshal(resp.Body(), &result2)
@@ -664,12 +670,16 @@ func doWithRetriesAndResult[T any](
 			}
 		}
 
-		log.Printf("[retry] attempt %d: received 429, waiting %v", attempt+1, wait)
+		if client.Debug {
+			log.Printf("[retry] attempt %d: received 429, waiting %v", attempt+1, wait)
+		}
 		time.Sleep(wait)
 	}
 
 	// If result is nil, return zero value
-	log.Printf("error 4: %v", err)
+	if client.Debug {
+		log.Printf("[debug] retry error: %v", err)
+	}
 	if result != nil {
 
 		return result, resp, fmt.Errorf("failed after %d retries", maxRetries+1)


### PR DESCRIPTION

## Summary

This PR converts unconditional debug print statements in the `doWithRetriesAndResult` function (`sdk/api_client.go`) to use the SDK's existing debug
configuration system (`client.Debug`). All `fmt.Println` calls are converted to `log.Printf` for consistent `CustomLogger` integration, and all diagnostic
output is guarded behind `if client.Debug`. This is a follow-up to PR #72, which fixed similar issues in `doWithRetriesAndNotResult` but missed the generic
typed version of the function.

## Problem

The SDK currently contains hardcoded debug statements that:
- Pollute console output in production environments
- Cannot be disabled via `MERAKI_DEBUG` environment variable
- Break terminal UI applications that rely on clean stdout/stderr
- Add noise to production logging systems

### Affected Lines (v5.0.8)
- Line 512: `fmt.Println("New Params: ", newParams)`
- Line 584: `fmt.Println("MAX_RETRIES: ", maxRetries+1)`
- Lines 589-590, 594-595, 625, 672: Unconditional `log.Printf` error messages

## Solution

This PR:
1. **Removes `fmt.Println` in `changeParams()`** - No `client` access for debug guard; low-value diagnostic
2. **Converts `fmt.Println` in `doWithRetriesAndResult` to debug-guarded `log.Printf`** - Retains diagnostic value when debug mode is enabled; uses
`log.Printf` for consistent `CustomLogger` integration
3. **Guards all unconditional `log.Printf` with `client.Debug`** - Intermediate retry errors and response diagnostics are preserved for debugging but silenced
in production
4. **Replaces developer-oriented labels with descriptive names** - "Error 1/2/3/4" replaced with "request error", "response error", "pagination error", "retry
error"
5. **Aligns with PR #72 behavior** - Ensures consistency across both retry functions

## Testing

- [x] All existing unit tests pass
- [x] Manual testing confirms no output in normal operation (`MERAKI_DEBUG=false`)
- [x] Debug mode still provides useful output when enabled (`MERAKI_DEBUG=true`)
- [x] No performance regression (removing prints slightly improves performance)
- [x] Integration testing with real API key shows clean output

## Backward Compatibility

This is a non-breaking change:
- No public API changes
- Eliminates unwanted output in production (all guarded by `client.Debug`)
- Preserves all functionality
- Retains full diagnostic output when debug mode is explicitly enabled
- Improves diagnostic quality with descriptive error labels

## Related Issues

- Completes fix started in PR #72 / Issue #72
- Addresses console pollution issues reported by users
- Related to historical Issue #6 about retry client logging

## Checklist

- [x] Code follows Go formatting conventions (`gofmt`)
- [x] All tests pass
- [x] No new dependencies added
- [x] Commit message follows conventional commits format
- [x] Changes are focused and minimal